### PR TITLE
Start multithread support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,7 @@ dependencies = [
 name = "limbo_core"
 version = "0.0.9"
 dependencies = [
+ "bumpalo",
  "cfg_block",
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ codegen-units = 1
 panic = "abort"
 lto = true
 
+[profile.bench-profile]
+inherits = "release"
+debug = true
+
 [profile.dist]
 inherits = "release"
 lto = "thin"

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub struct Database {
-    db: Rc<limbo_core::Database>,
+    db: Arc<limbo_core::Database>,
     conn: Rc<limbo_core::Connection>,
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,6 +52,7 @@ serde = { version = "1.0", features = ["derive"] }
 pest = { version = "2.0", optional = true }
 pest_derive = { version = "2.0", optional = true }
 rand = "0.8.5"
+bumpalo = { version = "3.16.0", features = ["collections", "boxed"] }
 
 [target.'cfg(not(target_family = "windows"))'.dev-dependencies]
 pprof = { version = "0.14.0", features = ["criterion", "flamegraph"] }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -28,7 +28,7 @@ use storage::btree::btree_init_page;
 #[cfg(feature = "fs")]
 use storage::database::FileStorage;
 use storage::pager::{allocate_page, DumbLruPageCache};
-use storage::sqlite3_ondisk::{DatabaseHeader, WalHeader, DATABASE_HEADER_SIZE};
+use storage::sqlite3_ondisk::{DatabaseHeader, DATABASE_HEADER_SIZE};
 pub use storage::wal::WalFile;
 pub use storage::wal::WalFileShared;
 use util::parse_schema_rows;
@@ -167,8 +167,7 @@ pub fn maybe_init_database_file(file: &Rc<dyn File>, io: &Arc<dyn IO>) -> Result
                 DATABASE_HEADER_SIZE,
             );
 
-            let mut page = page1.borrow_mut();
-            let contents = page.contents.as_mut().unwrap();
+            let contents = page1.get().contents.as_mut().unwrap();
             contents.write_database_header(&db_header);
             // write the first page to disk synchronously
             let flag_complete = Rc::new(RefCell::new(false));

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -8,8 +8,8 @@ use crate::io::{File, SyncCompletion, IO};
 use crate::storage::sqlite3_ondisk::{
     begin_read_wal_frame, begin_write_wal_frame, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
 };
+use crate::Completion;
 use crate::{storage::pager::Page, Result};
-use crate::{Completion, OpenFlags};
 
 use self::sqlite3_ondisk::{checksum_wal, WAL_MAGIC_BE, WAL_MAGIC_LE};
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -277,8 +277,6 @@ impl WalFile {
                         self.io.run_once()?;
                         self.wal_header.replace(Some(wal_header));
                     } else {
-                        // magic is a single number represented as WAL_MAGIC_LE but the big endian
-                        // counterpart is just the same number with LSB set to 1.
                         let magic = if cfg!(target_endian = "big") {
                             WAL_MAGIC_BE
                         } else {

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -13,7 +13,7 @@ struct SimulatorEnv {
     tables: Vec<Table>,
     connections: Vec<SimConnection>,
     io: Arc<SimulatorIO>,
-    db: Rc<Database>,
+    db: Arc<Database>,
     rng: ChaCha8Rng,
 }
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -33,7 +33,7 @@ pub mod util;
 use util::sqlite3_safety_check_sick_or_ok;
 
 pub struct sqlite3 {
-    pub(crate) _db: Rc<limbo_core::Database>,
+    pub(crate) _db: Arc<limbo_core::Database>,
     pub(crate) conn: Rc<limbo_core::Connection>,
     pub(crate) err_code: ffi::c_int,
     pub(crate) err_mask: ffi::c_int,
@@ -43,7 +43,7 @@ pub struct sqlite3 {
 }
 
 impl sqlite3 {
-    pub fn new(db: Rc<limbo_core::Database>, conn: Rc<limbo_core::Connection>) -> Self {
+    pub fn new(db: Arc<limbo_core::Database>, conn: Rc<limbo_core::Connection>) -> Self {
         Self {
             _db: db,
             conn,

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -885,7 +885,7 @@ fn sqlite3_errstr_impl(rc: i32) -> *const std::ffi::c_char {
         "datatype mismatch",                    // SQLITE_MISMATCH
         "bad parameter or other API misuse",    // SQLITE_MISUSE
         #[cfg(feature = "lfs")]
-        "",     // SQLITE_NOLFS
+        "",      // SQLITE_NOLFS
         #[cfg(not(feature = "lfs"))]
         "large file support is disabled", // SQLITE_NOLFS
         "authorization denied",                 // SQLITE_AUTH

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -885,7 +885,7 @@ fn sqlite3_errstr_impl(rc: i32) -> *const std::ffi::c_char {
         "datatype mismatch",                    // SQLITE_MISMATCH
         "bad parameter or other API misuse",    // SQLITE_MISUSE
         #[cfg(feature = "lfs")]
-        "",      // SQLITE_NOLFS
+        "",     // SQLITE_NOLFS
         #[cfg(not(feature = "lfs"))]
         "large file support is disabled", // SQLITE_NOLFS
         "authorization denied",                 // SQLITE_AUTH


### PR DESCRIPTION
Since we expect to ensure thread safety between multiple threads in the
future, we extract what is important to be shared between multiple
connections with regards to WAL/Pager.

This is WIP so I just put whatever feels like important behind a RwLock
but expect this to change to Atomics in the future as needed. Maybe even
these locks might disappear because they will be better served with
transaction locks.

This also includes addition of unsafe Sync/Send + UnsafeCell in Pages.
