### PR TITLE
Add last_insert_rowid() function

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -78,7 +78,7 @@ This document describes the SQLite compatibility status of Limbo:
 | ifnull(X,Y)                  | Yes    |         |
 | iif(X,Y,Z)                   | No     |         |
 | instr(X,Y)                   | Yes    |         |
-| last_insert_rowid()          | No     |         |
+| last_insert_rowid()          | Yes    |         |
 | length(X)                    | Yes    |         |
 | like(X,Y)                    | No     |         |
 | like(X,Y,Z)                  | No     |         |

--- a/core/function.rs
+++ b/core/function.rs
@@ -84,6 +84,7 @@ pub enum ScalarFunc {
     Hex,
     Unhex,
     ZeroBlob,
+    LastInsertRowid,
 }
 
 impl Display for ScalarFunc {
@@ -124,6 +125,7 @@ impl Display for ScalarFunc {
             ScalarFunc::Hex => "hex".to_string(),
             ScalarFunc::Unhex => "unhex".to_string(),
             ScalarFunc::ZeroBlob => "zeroblob".to_string(),
+            ScalarFunc::LastInsertRowid => "last_insert_rowid".to_string(),
         };
         write!(f, "{}", str)
     }
@@ -192,6 +194,7 @@ impl Func {
             "date" => Ok(Func::Scalar(ScalarFunc::Date)),
             "time" => Ok(Func::Scalar(ScalarFunc::Time)),
             "typeof" => Ok(Func::Scalar(ScalarFunc::Typeof)),
+            "last_insert_rowid" => Ok(Func::Scalar(ScalarFunc::LastInsertRowid)),
             "unicode" => Ok(Func::Scalar(ScalarFunc::Unicode)),
             "quote" => Ok(Func::Scalar(ScalarFunc::Quote)),
             "sqlite_version" => Ok(Func::Scalar(ScalarFunc::SqliteVersion)),

--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -23,6 +23,10 @@ impl Cursor for PseudoCursor {
         self.current.borrow().is_none()
     }
 
+    fn root_page(&self) -> usize {
+        unreachable!()
+    }
+
     fn rewind(&mut self) -> Result<CursorResult<()>> {
         *self.current.borrow_mut() = None;
         Ok(CursorResult::Ok(()))

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1703,6 +1703,10 @@ impl Cursor for BTreeCursor {
         self.record.borrow().is_none()
     }
 
+    fn root_page(&self) -> usize {
+        self.root_page
+    }
+
     fn rewind(&mut self) -> Result<CursorResult<()>> {
         self.move_to_root();
 
@@ -1772,6 +1776,7 @@ impl Cursor for BTreeCursor {
         }
 
         return_if_io!(self.insert_into_page(key, _record));
+        self.rowid.replace(Some(*int_key as u64));
         Ok(CursorResult::Ok(()))
     }
 

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -867,7 +867,7 @@ pub fn translate_expr(
                                 func: func_ctx,
                             });
                             Ok(target_register)
-                        }                    
+                        }
                         ScalarFunc::Concat => {
                             let args = if let Some(args) = args {
                                 args

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -858,6 +858,16 @@ pub fn translate_expr(
 
                             Ok(target_register)
                         }
+                        ScalarFunc::LastInsertRowid => {
+                            let regs = program.alloc_register();
+                            program.emit_insn(Insn::Function {
+                                constant_mask: 0,
+                                start_reg: regs,
+                                dest: target_register,
+                                func: func_ctx,
+                            });
+                            Ok(target_register)
+                        }                    
                         ScalarFunc::Concat => {
                             let args = if let Some(args) = args {
                                 args

--- a/core/types.rs
+++ b/core/types.rs
@@ -425,6 +425,7 @@ pub enum SeekKey<'a> {
 
 pub trait Cursor {
     fn is_empty(&self) -> bool;
+    fn root_page(&self) -> usize;
     fn rewind(&mut self) -> Result<CursorResult<()>>;
     fn last(&mut self) -> Result<CursorResult<()>>;
     fn next(&mut self) -> Result<CursorResult<()>>;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2107,11 +2107,12 @@ impl Program {
                             ScalarFunc::IfNull => {}
                             ScalarFunc::LastInsertRowid => {
                                 if let Some(conn) = self.connection.upgrade() {
-                                    state.registers[*dest] = OwnedValue::Integer(conn.last_insert_rowid() as i64);
+                                    state.registers[*dest] =
+                                        OwnedValue::Integer(conn.last_insert_rowid() as i64);
                                 } else {
                                     state.registers[*dest] = OwnedValue::Null;
                                 }
-                            }                        
+                            }
                             ScalarFunc::Instr => {
                                 let reg_value = &state.registers[*start_reg];
                                 let pattern_value = &state.registers[*start_reg + 1];

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -26,6 +26,10 @@ impl Cursor for Sorter {
         self.current.borrow().is_none()
     }
 
+    fn root_page(&self) -> usize {
+        unreachable!()
+    }
+
     // We do the sorting here since this is what is called by the SorterSort instruction
     fn rewind(&mut self) -> Result<CursorResult<()>> {
         self.records.sort_by(|a, b| {

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -414,11 +414,13 @@ mod tests {
     #[test]
     fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
         let _ = env_logger::try_init();
-        let tmp_db = TempDatabase::new("CREATE TABLE test_rowid (id INTEGER PRIMARY KEY, val TEXT);");
+        let tmp_db =
+            TempDatabase::new("CREATE TABLE test_rowid (id INTEGER PRIMARY KEY, val TEXT);");
         let conn = tmp_db.connect_limbo();
 
         // Simple insert
-        let mut insert_query = conn.query("INSERT INTO test_rowid (id, val) VALUES (NULL, 'test1')")?;
+        let mut insert_query =
+            conn.query("INSERT INTO test_rowid (id, val) VALUES (NULL, 'test1')")?;
         if let Some(ref mut rows) = insert_query {
             loop {
                 match rows.next_row()? {
@@ -449,7 +451,7 @@ mod tests {
             }
         }
 
-            // Test explicit rowid
+        // Test explicit rowid
         match conn.query("INSERT INTO test_rowid (id, val) VALUES (5, 'test2')") {
             Ok(Some(ref mut rows)) => loop {
                 match rows.next_row()? {
@@ -486,5 +488,5 @@ mod tests {
         assert_eq!(last_id, 5, "Explicit insert should have rowid 5");
         do_flush(&conn, &tmp_db)?;
         Ok(())
-    }    
+    }
 }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -410,4 +410,81 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_db = TempDatabase::new("CREATE TABLE test_rowid (id INTEGER PRIMARY KEY, val TEXT);");
+        let conn = tmp_db.connect_limbo();
+
+        // Simple insert
+        let mut insert_query = conn.query("INSERT INTO test_rowid (id, val) VALUES (NULL, 'test1')")?;
+        if let Some(ref mut rows) = insert_query {
+            loop {
+                match rows.next_row()? {
+                    RowResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    RowResult::Done => break,
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        // Check last_insert_rowid separately
+        let mut select_query = conn.query("SELECT last_insert_rowid()")?;
+        if let Some(ref mut rows) = select_query {
+            loop {
+                match rows.next_row()? {
+                    RowResult::Row(row) => {
+                        if let Value::Integer(id) = row.values[0] {
+                            assert_eq!(id, 1, "First insert should have rowid 1");
+                        }
+                    }
+                    RowResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    RowResult::Done => break,
+                }
+            }
+        }
+
+            // Test explicit rowid
+        match conn.query("INSERT INTO test_rowid (id, val) VALUES (5, 'test2')") {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    RowResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    RowResult::Done => break,
+                    _ => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => eprintln!("{}", err),
+        };
+
+        // Check last_insert_rowid after explicit id
+        let mut last_id = 0;
+        match conn.query("SELECT last_insert_rowid()") {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    RowResult::Row(row) => {
+                        if let Value::Integer(id) = row.values[0] {
+                            last_id = id;
+                        }
+                    }
+                    RowResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    RowResult::Done => break,
+                }
+            },
+            Ok(None) => {}
+            Err(err) => eprintln!("{}", err),
+        };
+        assert_eq!(last_id, 5, "Explicit insert should have rowid 5");
+        do_flush(&conn, &tmp_db)?;
+        Ok(())
+    }    
 }

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -1,4 +1,3 @@
 #!/usr/bin/env tclsh
-
 set testdir [file dirname $argv0]
 source $testdir/tester.tcl


### PR DESCRIPTION
- Changed `Cursor` trait to be able to get access to `root_page` 

- SQLite only updates last_insert_rowid for non-schema inserts. So we check if the `InsertAwait` is not for `root_page` before   updating rowid

In SQLite it looks like this:

```
sqlite> EXPLAIN SELECT last_insert_rowid();
addr  opcode         p1    p2    p3    p4             p5  comment      
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     4     0                    0   
1     Function       0     0     1     last_insert_rowid(0) 0   
2     ResultRow      1     1     0                    0   
3     Halt           0     0     0                    0   
4     Goto           0     1     0                    0   
```

In limbo it will look like this:

```
limbo> EXPLAIN SELECT last_insert_rowid();
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     4     0                    0   Start at 4
1     Function           0     2     1     last_insert_rowid  0   r[1]=func()
2     ResultRow          1     1     0                    0   output=r[1]
3     Halt               0     0     0                    0   
4     Transaction        0     0     0                    0   
5     Goto               0     1     0                    0   
```