### PR TITLE
Fix: length function characters counting

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2537,7 +2537,7 @@ fn exec_lower(reg: &OwnedValue) -> Option<OwnedValue> {
 fn exec_length(reg: &OwnedValue) -> OwnedValue {
     match reg {
         OwnedValue::Text(_) | OwnedValue::Integer(_) | OwnedValue::Float(_) => {
-            OwnedValue::Integer(reg.to_string().len() as i64)
+            OwnedValue::Integer(reg.to_string().chars().count() as i64)
         }
         OwnedValue::Blob(blob) => OwnedValue::Integer(blob.len() as i64),
         OwnedValue::Agg(aggctx) => exec_length(aggctx.final_value()),

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -343,6 +343,10 @@ do_execsql_test length-text {
   SELECT length('limbo');
 } {5}
 
+do_execsql_test lenght-text-utf8-chars {
+  SELECT length('ąłóżźć');
+} {6}
+
 do_execsql_test length-integer {
   SELECT length(12345);
 } {5}


### PR DESCRIPTION
`String::len()` function returns number of bytes. Here we need to use `chars().count()` to count real characters as specified in https://www.sqlite.org/lang_corefunc.html#length