### PR TITLE
Add support for soundex() function

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -5,6 +5,7 @@ This document describes the SQLite compatibility status of Limbo:
 - [SQLite Compatibility](#sqlite-compatibility)
   - [Limitations](#limitations)
   - [SQL statements](#sql-statements)
+    - [SELECT Expressions](#select-expressions)
   - [SQL functions](#sql-functions)
     - [Scalar functions](#scalar-functions)
     - [Aggregate functions](#aggregate-functions)
@@ -138,7 +139,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | rtrim(X)                     | Yes    |         |
 | rtrim(X,Y)                   | Yes    |         |
 | sign(X)                      | Yes    |         |
-| soundex(X)                   | No     |         |
+| soundex(X)                   | Yes    |         |
 | sqlite_compileoption_get(N)  | No     |         |
 | sqlite_compileoption_used(X) | No     |         |
 | sqlite_offset(X)             | No     |         |

--- a/core/function.rs
+++ b/core/function.rs
@@ -76,6 +76,7 @@ pub enum ScalarFunc {
     Sign,
     Substr,
     Substring,
+    Soundex,
     Date,
     Time,
     Typeof,
@@ -119,6 +120,7 @@ impl Display for ScalarFunc {
             ScalarFunc::Sign => "sign".to_string(),
             ScalarFunc::Substr => "substr".to_string(),
             ScalarFunc::Substring => "substring".to_string(),
+            ScalarFunc::Soundex => "soundex".to_string(),
             ScalarFunc::Date => "date".to_string(),
             ScalarFunc::Time => "time".to_string(),
             ScalarFunc::Typeof => "typeof".to_string(),
@@ -210,6 +212,7 @@ impl Func {
             "hex" => Ok(Func::Scalar(ScalarFunc::Hex)),
             "unhex" => Ok(Func::Scalar(ScalarFunc::Unhex)),
             "zeroblob" => Ok(Func::Scalar(ScalarFunc::ZeroBlob)),
+            "soundex" => Ok(Func::Scalar(ScalarFunc::Soundex)),
             _ => Err(()),
         }
     }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1169,6 +1169,7 @@ pub fn translate_expr(
                         | ScalarFunc::Quote
                         | ScalarFunc::RandomBlob
                         | ScalarFunc::Sign
+                        | ScalarFunc::Soundex
                         | ScalarFunc::ZeroBlob => {
                             let args = if let Some(args) = args {
                                 if args.len() != 1 {

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -767,3 +767,7 @@ do_execsql_test cast-in-where {
   select age from users where age = cast('45' as integer) limit 1;
 } {45}
 
+# TODO: sqlite seems not enable soundex() by default unless build it with SQLITE_SOUNDEX enabled.
+# do_execsql_test soundex-text {
+#  select soundex('Pfister'), soundex('husobee'), soundex('Tymczak'), soundex('Ashcraft'), soundex('Robert'), soundex('Rupert'), soundex('Rubin'), soundex('Kant'), soundex('Knuth'), soundex('x'), soundex('');
+# } {P236|H210|T522|A261|R163|R163|R150|K530|K530|X000|0000}


### PR DESCRIPTION
add [soundex](https://www.sqlite.org/lang_corefunc.html#soundex) scalar function.

it seems that sqlite did not enable `soundex()` function by default unless build it with `SQLITE_SOUNDEX`, while the sqlite in the ci workflow did not enable it. this pr skipped the test over `soundex()` temporarily in the `scalar-function.test` file.