### PR TITLE
Add two arguments version of `unhex(x, y)` function

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -154,7 +154,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | trim(X,Y)                    | Yes    |         |
 | typeof(X)                    | Yes    |         |
 | unhex(X)                     | Yes    |         |
-| unhex(X,Y)                   | No     |         |
+| unhex(X,Y)                   | Yes    |         |
 | unicode(X)                   | Yes    |         |
 | unlikely(X)                  | No     |         |
 | upper(X)                     | Yes    |         |

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -215,6 +215,46 @@ do_execsql_test unhex-null {
   SELECT unhex(NULL);
 } {}
 
+do_execsql_test unhex-x-y-prefix {
+  SELECT unhex('x2E', 'x');
+} {.}
+
+do_execsql_test unhex-x-y-suffix {
+  SELECT unhex('2Ex', 'x');
+} {.}
+
+do_execsql_test unhex-x-y-prefix-suffix {
+  SELECT unhex('x2Ex', 'x');
+} {.}
+
+do_execsql_test unhex-x-y-incorrect-suffix {
+  SELECT unhex('x2Ey', 'x');
+} {}
+
+do_execsql_test unhex-x-y-long-prefix {
+  SELECT unhex('xyz2E', 'xyz');
+} {.}
+
+do_execsql_test unhex-x-y-shorter-suffix {
+  SELECT unhex('xyz2Exy', 'xyz');
+} {.}
+
+do_execsql_test unhex-x-y-shorter-prefix {
+  SELECT unhex('xy2Exyz', 'xyz');
+} {.};
+
+do_execsql_test unhex-x-y-random-order {
+  SELECT unhex('yx2Ezyx', 'xyz');
+} {.};
+
+do_execsql_test unhex-x-y-char-in-the-middle {
+  SELECT unhex('yx2xEzyx', 'xyz');
+} {};
+
+do_execsql_test unhex-x-y-character-outside-set {
+  SELECT unhex('yxn2Ezyx', 'xyz');
+} {};
+
 do_execsql_test trim {
   SELECT trim('   Limbo    ');
 } {Limbo}


### PR DESCRIPTION
Part of solution for #144 