### PR TITLE
Use strum crate to minimize boiler plate code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,8 @@ dependencies = [
  "serde",
  "sieve-cache",
  "sqlite3-parser",
+ "strum",
+ "strum_macros",
  "tempfile",
  "thiserror 1.0.69",
 ]
@@ -1929,6 +1931,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
 name = "rustyline"
 version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,6 +2112,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "symbolic-common"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,6 +53,8 @@ pest = { version = "2.0", optional = true }
 pest_derive = { version = "2.0", optional = true }
 rand = "0.8.5"
 bumpalo = { version = "3.16.0", features = ["collections", "boxed"] }
+strum = { version = "0.26.3", features = ["derive"] }
+strum_macros = "0.26.3"
 
 [target.'cfg(not(target_family = "windows"))'.dev-dependencies]
 pprof = { version = "0.14.0", features = ["criterion", "flamegraph"] }

--- a/core/function.rs
+++ b/core/function.rs
@@ -32,7 +32,7 @@ pub enum ScalarFunc {
     Ifnull,
     Iif,
     Instr,
-    #[strum(to_string="like(2)", serialize = "like")]
+    #[strum(to_string = "like(2)", serialize = "like")]
     Like,
     Abs,
     Upper,
@@ -115,7 +115,7 @@ impl Func {
             return Ok(Func::Json(json_func));
         }
 
-        //return Err if the string is not handled in any of the above if let blocks 
+        //return Err if the string is not handled in any of the above if let blocks
 
         Err(())
     }

--- a/core/function.rs
+++ b/core/function.rs
@@ -1,26 +1,14 @@
-use std::fmt;
-use std::fmt::Display;
+use strum::Display;
 
 #[cfg(feature = "json")]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Display)]
 pub enum JsonFunc {
+    #[strum(to_string = "json")]
     Json,
 }
 
-#[cfg(feature = "json")]
-impl Display for JsonFunc {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                JsonFunc::Json => "json".to_string(),
-            }
-        )
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Display)]
+#[strum(serialize_all="snake_case")]
 pub enum AggFunc {
     Avg,
     Count,
@@ -32,22 +20,10 @@ pub enum AggFunc {
     Total,
 }
 
-impl AggFunc {
-    pub fn to_string(&self) -> &str {
-        match self {
-            AggFunc::Avg => "avg",
-            AggFunc::Count => "count",
-            AggFunc::GroupConcat => "group_concat",
-            AggFunc::Max => "max",
-            AggFunc::Min => "min",
-            AggFunc::StringAgg => "string_agg",
-            AggFunc::Sum => "sum",
-            AggFunc::Total => "total",
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq)]
+#[derive(strum_macros::Display)]
+#[strum(serialize_all="snake_case")]
 pub enum ScalarFunc {
     Cast,
     Char,
@@ -91,72 +67,17 @@ pub enum ScalarFunc {
     Replace,
 }
 
-impl Display for ScalarFunc {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let str = match self {
-            ScalarFunc::Cast => "cast".to_string(),
-            ScalarFunc::Char => "char".to_string(),
-            ScalarFunc::Coalesce => "coalesce".to_string(),
-            ScalarFunc::Concat => "concat".to_string(),
-            ScalarFunc::ConcatWs => "concat_ws".to_string(),
-            ScalarFunc::Glob => "glob".to_string(),
-            ScalarFunc::IfNull => "ifnull".to_string(),
-            ScalarFunc::Iif => "iif".to_string(),
-            ScalarFunc::Instr => "instr".to_string(),
-            ScalarFunc::Like => "like(2)".to_string(),
-            ScalarFunc::Abs => "abs".to_string(),
-            ScalarFunc::Upper => "upper".to_string(),
-            ScalarFunc::Lower => "lower".to_string(),
-            ScalarFunc::Random => "random".to_string(),
-            ScalarFunc::RandomBlob => "randomblob".to_string(),
-            ScalarFunc::Trim => "trim".to_string(),
-            ScalarFunc::LTrim => "ltrim".to_string(),
-            ScalarFunc::RTrim => "rtrim".to_string(),
-            ScalarFunc::Round => "round".to_string(),
-            ScalarFunc::Length => "length".to_string(),
-            ScalarFunc::OctetLength => "octet_length".to_string(),
-            ScalarFunc::Min => "min".to_string(),
-            ScalarFunc::Max => "max".to_string(),
-            ScalarFunc::Nullif => "nullif".to_string(),
-            ScalarFunc::Sign => "sign".to_string(),
-            ScalarFunc::Substr => "substr".to_string(),
-            ScalarFunc::Substring => "substring".to_string(),
-            ScalarFunc::Soundex => "soundex".to_string(),
-            ScalarFunc::Date => "date".to_string(),
-            ScalarFunc::Time => "time".to_string(),
-            ScalarFunc::Typeof => "typeof".to_string(),
-            ScalarFunc::Unicode => "unicode".to_string(),
-            ScalarFunc::Quote => "quote".to_string(),
-            ScalarFunc::SqliteVersion => "sqlite_version".to_string(),
-            ScalarFunc::UnixEpoch => "unixepoch".to_string(),
-            ScalarFunc::Hex => "hex".to_string(),
-            ScalarFunc::Unhex => "unhex".to_string(),
-            ScalarFunc::ZeroBlob => "zeroblob".to_string(),
-            ScalarFunc::LastInsertRowid => "last_insert_rowid".to_string(),
-            ScalarFunc::Replace => "replace".to_string(),
-        };
-        write!(f, "{}", str)
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Display)]
 pub enum Func {
+    #[strum(to_string="{0}")]
     Agg(AggFunc),
+    #[strum(to_string="{0}")]
     Scalar(ScalarFunc),
     #[cfg(feature = "json")]
+    #[strum(to_string="{0}")]
     Json(JsonFunc),
 }
 
-impl Display for Func {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Func::Agg(agg_func) => write!(f, "{}", agg_func.to_string()),
-            Func::Scalar(scalar_func) => write!(f, "{}", scalar_func),
-            #[cfg(feature = "json")]
-            Func::Json(json_func) => write!(f, "{}", json_func),
-        }
-    }
-}
 
 #[derive(Debug)]
 pub struct FuncCtx {

--- a/core/function.rs
+++ b/core/function.rs
@@ -8,7 +8,7 @@ pub enum JsonFunc {
 }
 
 #[derive(Debug, Clone, PartialEq, Display)]
-#[strum(serialize_all="snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum AggFunc {
     Avg,
     Count,
@@ -20,10 +20,8 @@ pub enum AggFunc {
     Total,
 }
 
-
-#[derive(Debug, Clone, PartialEq)]
-#[derive(strum_macros::Display)]
-#[strum(serialize_all="snake_case")]
+#[derive(Debug, Clone, PartialEq, strum_macros::Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum ScalarFunc {
     Cast,
     Char,
@@ -69,15 +67,14 @@ pub enum ScalarFunc {
 
 #[derive(Debug, Display)]
 pub enum Func {
-    #[strum(to_string="{0}")]
+    #[strum(to_string = "{0}")]
     Agg(AggFunc),
-    #[strum(to_string="{0}")]
+    #[strum(to_string = "{0}")]
     Scalar(ScalarFunc),
     #[cfg(feature = "json")]
-    #[strum(to_string="{0}")]
+    #[strum(to_string = "{0}")]
     Json(JsonFunc),
 }
-
 
 #[derive(Debug)]
 pub struct FuncCtx {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1044,7 +1044,7 @@ pub fn translate_expr(
                             });
                             Ok(target_register)
                         }
-                        ScalarFunc::IfNull => {
+                        ScalarFunc::Ifnull => {
                             let args = match args {
                                 Some(args) if args.len() == 2 => args,
                                 Some(_) => crate::bail_parse_error!(
@@ -1181,10 +1181,10 @@ pub fn translate_expr(
                         | ScalarFunc::Typeof
                         | ScalarFunc::Unicode
                         | ScalarFunc::Quote
-                        | ScalarFunc::RandomBlob
+                        | ScalarFunc::Randomblob
                         | ScalarFunc::Sign
                         | ScalarFunc::Soundex
-                        | ScalarFunc::ZeroBlob => {
+                        | ScalarFunc::Zeroblob => {
                             let args = if let Some(args) = args {
                                 if args.len() != 1 {
                                     crate::bail_parse_error!(
@@ -1333,7 +1333,7 @@ pub fn translate_expr(
                             });
                             Ok(target_register)
                         }
-                        ScalarFunc::UnixEpoch => {
+                        ScalarFunc::Unixepoch => {
                             let mut start_reg = 0;
                             match args {
                                 Some(args) if args.len() > 1 => {
@@ -1383,8 +1383,8 @@ pub fn translate_expr(
                             Ok(target_register)
                         }
                         ScalarFunc::Trim
-                        | ScalarFunc::LTrim
-                        | ScalarFunc::RTrim
+                        | ScalarFunc::Ltrim
+                        | ScalarFunc::Rtrim
                         | ScalarFunc::Round
                         | ScalarFunc::Unhex => {
                             let args = if let Some(args) = args {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use sqlite3_parser::ast;
+use strum::Display;
 
 use crate::{
     function::AggFunc,
@@ -205,19 +206,12 @@ impl SourceOperator {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Display)]
 pub enum Direction {
+    #[strum(to_string="ASC")]
     Ascending,
+    #[strum(to_string="DESC")]
     Descending,
-}
-
-impl Display for Direction {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Direction::Ascending => write!(f, "ASC"),
-            Direction::Descending => write!(f, "DESC"),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -208,9 +208,9 @@ impl SourceOperator {
 
 #[derive(Clone, Copy, Debug, PartialEq, Display)]
 pub enum Direction {
-    #[strum(to_string="ASC")]
+    #[strum(to_string = "ASC")]
     Ascending,
-    #[strum(to_string="DESC")]
+    #[strum(to_string = "DESC")]
     Descending,
 }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -43,6 +43,7 @@ use datetime::{exec_date, exec_time, exec_unixepoch};
 use rand::distributions::{Distribution, Uniform};
 use rand::{thread_rng, Rng};
 use regex::Regex;
+use strum::Display;
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
@@ -56,23 +57,15 @@ pub type CursorID = usize;
 pub type PageIdx = usize;
 
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Display)]
 pub enum Func {
+    #[strum(to_string="{0}")]
     Scalar(ScalarFunc),
     #[cfg(feature = "json")]
+    #[strum(to_string="{0}")]
     Json(JsonFunc),
 }
 
-impl Display for Func {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let str = match self {
-            Func::Scalar(scalar_func) => scalar_func.to_string(),
-            #[cfg(feature = "json")]
-            Func::Json(json_func) => json_func.to_string(),
-        };
-        write!(f, "{}", str)
-    }
-}
 
 #[derive(Debug)]
 pub enum Insn {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -46,7 +46,6 @@ use regex::Regex;
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::Display;
 use std::rc::{Rc, Weak};
 use strum::Display;
 
@@ -2304,7 +2303,7 @@ impl Program {
                                 };
                                 state.registers[*dest] = result;
                             }
-                            ScalarFunc::IfNull => {}
+                            ScalarFunc::Ifnull => {}
                             ScalarFunc::Iif => {}
                             ScalarFunc::Instr => {
                                 let reg_value = &state.registers[*start_reg];
@@ -2346,10 +2345,10 @@ impl Program {
                             | ScalarFunc::Typeof
                             | ScalarFunc::Unicode
                             | ScalarFunc::Quote
-                            | ScalarFunc::RandomBlob
+                            | ScalarFunc::Randomblob
                             | ScalarFunc::Sign
                             | ScalarFunc::Soundex
-                            | ScalarFunc::ZeroBlob => {
+                            | ScalarFunc::Zeroblob => {
                                 let reg_value = state.registers[*start_reg].borrow_mut();
                                 let result = match scalar_func {
                                     ScalarFunc::Sign => exec_sign(reg_value),
@@ -2361,8 +2360,8 @@ impl Program {
                                     ScalarFunc::Typeof => Some(exec_typeof(reg_value)),
                                     ScalarFunc::Unicode => Some(exec_unicode(reg_value)),
                                     ScalarFunc::Quote => Some(exec_quote(reg_value)),
-                                    ScalarFunc::RandomBlob => Some(exec_randomblob(reg_value)),
-                                    ScalarFunc::ZeroBlob => Some(exec_zeroblob(reg_value)),
+                                    ScalarFunc::Randomblob => Some(exec_randomblob(reg_value)),
+                                    ScalarFunc::Zeroblob => Some(exec_zeroblob(reg_value)),
                                     ScalarFunc::Soundex => Some(exec_soundex(reg_value)),
                                     _ => unreachable!(),
                                 };
@@ -2388,13 +2387,13 @@ impl Program {
                                 let result = exec_trim(&reg_value, pattern_value);
                                 state.registers[*dest] = result;
                             }
-                            ScalarFunc::LTrim => {
+                            ScalarFunc::Ltrim => {
                                 let reg_value = state.registers[*start_reg].clone();
                                 let pattern_value = state.registers.get(*start_reg + 1).cloned();
                                 let result = exec_ltrim(&reg_value, pattern_value);
                                 state.registers[*dest] = result;
                             }
-                            ScalarFunc::RTrim => {
+                            ScalarFunc::Rtrim => {
                                 let reg_value = state.registers[*start_reg].clone();
                                 let pattern_value = state.registers.get(*start_reg + 1).cloned();
                                 let result = exec_rtrim(&reg_value, pattern_value);
@@ -2447,7 +2446,7 @@ impl Program {
                                     exec_time(&state.registers[*start_reg..*start_reg + arg_count]);
                                 state.registers[*dest] = result;
                             }
-                            ScalarFunc::UnixEpoch => {
+                            ScalarFunc::Unixepoch => {
                                 if *start_reg == 0 {
                                     let unixepoch: String = exec_unixepoch(&OwnedValue::Text(
                                         Rc::new("now".to_string()),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -43,12 +43,12 @@ use datetime::{exec_date, exec_time, exec_unixepoch};
 use rand::distributions::{Distribution, Uniform};
 use rand::{thread_rng, Rng};
 use regex::Regex;
-use strum::Display;
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
 use std::rc::{Rc, Weak};
+use strum::Display;
 
 pub type BranchOffset = i64;
 
@@ -59,13 +59,12 @@ pub type PageIdx = usize;
 #[allow(dead_code)]
 #[derive(Debug, Display)]
 pub enum Func {
-    #[strum(to_string="{0}")]
+    #[strum(to_string = "{0}")]
     Scalar(ScalarFunc),
     #[cfg(feature = "json")]
-    #[strum(to_string="{0}")]
+    #[strum(to_string = "{0}")]
     Json(JsonFunc),
 }
-
 
 #[derive(Debug)]
 pub enum Insn {


### PR DESCRIPTION
Adding the strum crate will help us to Display the enums without the need to match each and every enum member and write a string to it