### PR TITLE
In-memory mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ test: limbo test-compat test-sqlite3
 
 test-compat:
 	SQLITE_EXEC=$(SQLITE_EXEC) ./testing/all.test
-	SQLITE_EXEC=$(SQLITE_EXEC) ./testing/memory-repl.tcl
 .PHONY: test-compat
 
 test-sqlite3:

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ test: limbo test-compat test-sqlite3
 
 test-compat:
 	SQLITE_EXEC=$(SQLITE_EXEC) ./testing/all.test
+	SQLITE_EXEC=$(SQLITE_EXEC) ./testing/memory-repl.tcl
 .PHONY: test-compat
 
 test-sqlite3:

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -3,12 +3,9 @@ mod opcodes_dictionary;
 
 use clap::Parser;
 use rustyline::{error::ReadlineError, DefaultEditor};
-use std::{
-    io::IsTerminal,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
 };
 
 #[allow(clippy::arc_with_non_send_sync)]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -3,8 +3,13 @@ mod opcodes_dictionary;
 
 use clap::Parser;
 use rustyline::{error::ReadlineError, DefaultEditor};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::{
+    io::IsTerminal,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 #[allow(clippy::arc_with_non_send_sync)]
 fn main() -> anyhow::Result<()> {
@@ -29,8 +34,6 @@ fn main() -> anyhow::Result<()> {
         }
         return Ok(());
     }
-    println!("Limbo v{}", env!("CARGO_PKG_VERSION"));
-    println!("Enter \".help\" for usage hints.");
     let mut rl = DefaultEditor::new()?;
     let home = dirs::home_dir().expect("Could not determine home directory");
     let history_file = home.join(".limbo_history");
@@ -50,7 +53,7 @@ fn main() -> anyhow::Result<()> {
                 // At prompt, increment interrupt count
                 if interrupt_count.fetch_add(1, Ordering::SeqCst) >= 1 {
                     eprintln!("Interrupted. Exiting...");
-                    app.close_conn();
+                    let _ = app.close_conn();
                     break;
                 }
                 println!("Use .quit to exit or press Ctrl-C again to force quit.");
@@ -58,11 +61,11 @@ fn main() -> anyhow::Result<()> {
                 continue;
             }
             Err(ReadlineError::Eof) => {
-                app.close_conn();
+                let _ = app.close_conn();
                 break;
             }
             Err(err) => {
-                app.close_conn();
+                let _ = app.close_conn();
                 anyhow::bail!(err)
             }
         }

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -1,0 +1,182 @@
+use super::{Buffer, Completion, File, OpenFlags, IO};
+use crate::Result;
+
+use std::{
+    cell::{RefCell, RefMut},
+    collections::BTreeMap,
+    rc::Rc,
+    sync::Arc,
+};
+
+const PAGE_SIZE: usize = 4 * 1024;
+
+pub struct MemoryIO {
+    pages: RefCell<BTreeMap<usize, Vec<u8>>>,
+    size: RefCell<usize>,
+}
+
+impl MemoryIO {
+    #[allow(clippy::arc_with_non_send_sync)]
+    pub fn new() -> Result<Arc<Self>> {
+        Ok(Arc::new(Self {
+            pages: RefCell::new(BTreeMap::new()),
+            size: RefCell::new(0),
+        }))
+    }
+
+    fn get_or_allocate_page(&self, page_no: usize) -> RefMut<Vec<u8>> {
+        let mut pages = self.pages.borrow_mut();
+        pages.entry(page_no).or_insert_with(|| vec![0; PAGE_SIZE]);
+
+        RefMut::map(pages, |p| p.get_mut(&page_no).unwrap())
+    }
+
+    fn get_page(&self, page_no: usize) -> Option<RefMut<Vec<u8>>> {
+        let pages = self.pages.borrow_mut();
+        if pages.contains_key(&page_no) {
+            Some(RefMut::map(pages, |p| p.get_mut(&page_no).unwrap()))
+        } else {
+            None
+        }
+    }
+}
+
+impl IO for Arc<MemoryIO> {
+    fn open_file(&self, _path: &str, _flags: OpenFlags, _direct: bool) -> Result<Rc<dyn File>> {
+        Ok(Rc::new(MemoryFile {
+            io: Arc::clone(self),
+        }))
+    }
+
+    fn run_once(&self) -> Result<()> {
+        // nop
+        Ok(())
+    }
+
+    fn generate_random_number(&self) -> i64 {
+        let mut buf = [0u8; 8];
+        getrandom::getrandom(&mut buf).unwrap();
+        i64::from_ne_bytes(buf)
+    }
+
+    fn get_current_time(&self) -> String {
+        chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
+    }
+}
+
+pub struct MemoryFile {
+    io: Arc<MemoryIO>,
+}
+
+impl File for MemoryFile {
+    // no-ops
+    fn lock_file(&self, _exclusive: bool) -> Result<()> {
+        Ok(())
+    }
+    fn unlock_file(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn pread(&self, pos: usize, c: Rc<Completion>) -> Result<()> {
+        let r = match &*c {
+            Completion::Read(r) => r,
+            _ => unreachable!(),
+        };
+        let buf_len = r.buf().len();
+        if buf_len == 0 {
+            c.complete(0);
+            return Ok(());
+        }
+
+        let file_size = *self.io.size.borrow();
+        if pos >= file_size {
+            c.complete(0);
+            return Ok(());
+        }
+
+        let read_len = buf_len.min(file_size - pos);
+        let mut read_buf = r.buf_mut();
+
+        let mut offset = pos;
+        let mut remaining = read_len;
+        let mut buf_offset = 0;
+
+        while remaining > 0 {
+            let page_no = offset / PAGE_SIZE;
+            let page_offset = offset % PAGE_SIZE;
+            let bytes_to_read = remaining.min(PAGE_SIZE - page_offset);
+            if let Some(page) = self.io.get_page(page_no) {
+                {
+                    let page_data = &*page;
+                    read_buf.as_mut_slice()[buf_offset..buf_offset + bytes_to_read]
+                        .copy_from_slice(&page_data[page_offset..page_offset + bytes_to_read]);
+                }
+            } else {
+                for b in &mut read_buf.as_mut_slice()[buf_offset..buf_offset + bytes_to_read] {
+                    *b = 0;
+                }
+            }
+
+            offset += bytes_to_read;
+            buf_offset += bytes_to_read;
+            remaining -= bytes_to_read;
+        }
+        drop(read_buf);
+        c.complete(read_len as i32);
+        Ok(())
+    }
+
+    fn pwrite(&self, pos: usize, buffer: Rc<RefCell<Buffer>>, c: Rc<Completion>) -> Result<()> {
+        let buf = buffer.borrow();
+        let buf_len = buf.len();
+        if buf_len == 0 {
+            c.complete(0);
+            return Ok(());
+        }
+
+        let mut offset = pos;
+        let mut remaining = buf_len;
+        let mut buf_offset = 0;
+        let data = &buf.as_slice();
+
+        while remaining > 0 {
+            let page_no = offset / PAGE_SIZE;
+            let page_offset = offset % PAGE_SIZE;
+            let bytes_to_write = remaining.min(PAGE_SIZE - page_offset);
+
+            {
+                let mut page = self.io.get_or_allocate_page(page_no);
+                page[page_offset..page_offset + bytes_to_write]
+                    .copy_from_slice(&data[buf_offset..buf_offset + bytes_to_write]);
+            }
+
+            offset += bytes_to_write;
+            buf_offset += bytes_to_write;
+            remaining -= bytes_to_write;
+        }
+
+        {
+            let mut size = self.io.size.borrow_mut();
+            *size = (*size).max(pos + buf_len);
+        }
+
+        c.complete(buf_len as i32);
+        Ok(())
+    }
+
+    fn sync(&self, c: Rc<Completion>) -> Result<()> {
+        // no-op
+        c.complete(0);
+        Ok(())
+    }
+
+    fn size(&self) -> Result<u64> {
+        Ok(*self.io.size.borrow() as u64)
+    }
+}
+
+impl Drop for MemoryFile {
+    fn drop(&mut self) {
+        // no-op
+    }
+}

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -25,10 +25,10 @@ impl MemoryIO {
     }
 
     fn get_or_allocate_page(&self, page_no: usize) -> RefMut<Vec<u8>> {
-        let mut pages = self.pages.borrow_mut();
-        pages.entry(page_no).or_insert_with(|| vec![0; PAGE_SIZE]);
-
-        RefMut::map(pages, |p| p.get_mut(&page_no).unwrap())
+        let pages = self.pages.borrow_mut();
+        RefMut::map(pages, |p| {
+            p.entry(page_no).or_insert_with(|| vec![0; PAGE_SIZE])
+        })
     }
 
     fn get_page(&self, page_no: usize) -> Option<RefMut<Vec<u8>>> {

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -185,4 +185,6 @@ cfg_block! {
     }
 }
 
+mod memory;
+pub use memory::MemoryIO;
 mod common;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -42,7 +42,7 @@ pub type Result<T> = std::result::Result<T, error::LimboError>;
 pub use io::OpenFlags;
 #[cfg(feature = "fs")]
 pub use io::PlatformIO;
-pub use io::{Buffer, Completion, File, WriteCompletion, IO};
+pub use io::{Buffer, Completion, File, MemoryIO, WriteCompletion, IO};
 pub use storage::buffer_pool::BufferPool;
 pub use storage::database::DatabaseStorage;
 pub use storage::pager::Page;

--- a/testing/memory-repl.tcl
+++ b/testing/memory-repl.tcl
@@ -1,0 +1,114 @@
+#!/usr/bin/env tclsh
+
+set sqlite_exec [expr {[info exists env(SQLITE_EXEC)] ? $env(SQLITE_EXEC) : "sqlite3"}]
+
+proc start_sqlite_repl {sqlite_exec init_commands} {
+    set command [list $sqlite_exec ":memory:"]
+    set pipe [open "|[join $command]" RDWR]
+    puts $pipe $init_commands
+    flush $pipe
+    return $pipe
+}
+
+proc execute_sql {pipe sql} {
+    puts $pipe $sql
+    flush $pipe
+    puts $pipe "SELECT 'END_OF_RESULT';"
+    flush $pipe
+    set output ""
+    while {[gets $pipe line] >= 0} {
+        if {$line eq "END_OF_RESULT"} {
+            break
+        }
+        append output "$line\n"
+    }
+    return [string trim $output]
+}
+
+proc run_test {pipe sql expected_output} {
+    set actual_output [execute_sql $pipe $sql]
+    if {$actual_output ne $expected_output} {
+        puts "Test FAILED: '$sql'"
+        puts "returned '$actual_output'"
+        puts "expected '$expected_output'"
+        exit 1
+    }
+}
+
+proc do_execsql_test {pipe test_name sql expected_output} {
+    puts "Running test: $test_name"
+    run_test $pipe $sql $expected_output
+}
+
+set init_commands {
+CREATE TABLE users (
+        id INTEGER PRIMARY KEY,
+		first_name TEXT,
+		last_name TEXT,
+		age INTEGER
+	);
+    CREATE TABLE products (
+	id INTEGER PRIMARY KEY,
+	name TEXT,
+	price INTEGER
+	);
+    INSERT INTO users (id, first_name, last_name, age) VALUES
+	(1, 'Alice', 'Smith', 30), (2, 'Bob', 'Johnson', 25), (3, 'Charlie', 'Brown', 66), (4, 'David', 'Nichols', 70); INSERT INTO products (id, name, price) VALUES (1, 'Hat', 19.99), (2, 'Shirt', 29.99), (3, 'Shorts', 39.99), (4, 'Dress', 49.99);
+    CREATE TABLE t(x1, x2, x3, x4);
+    INSERT INTO t VALUES (zeroblob(1024 * 1024 - 1), zeroblob(1024 * 1024 - 2), zeroblob(1024 * 1024 - 3), zeroblob(1024 * 1024 - 4));
+}
+
+set pipe [start_sqlite_repl $sqlite_exec $init_commands]
+
+do_execsql_test $pipe schema {
+  .schema 
+} {CREATE TABLE users (id INTEGER PRIMARY KEY, first_name TEXT, last_name TEXT, age INTEGER);
+CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
+CREATE TABLE t (x1, x2, x3, x4);}
+
+do_execsql_test $pipe "select-avg" {
+  SELECT avg(age) FROM users;
+} {47.75}
+
+do_execsql_test $pipe select-avg-text {
+  SELECT avg(first_name) FROM users;
+} {0.0}
+
+do_execsql_test $pipe select-sum {
+  SELECT sum(age) FROM users;
+} {191}
+
+do_execsql_test $pipe select-sum-text {
+  SELECT sum(first_name) FROM users;
+} {0.0}
+
+do_execsql_test $pipe select-total {
+  SELECT total(age) FROM users;
+} {191.0}
+
+do_execsql_test $pipe select-total-text {
+  SELECT total(first_name) FROM users WHERE id < 3;
+} {0.0}
+
+do_execsql_test $pipe select-limit {
+  SELECT typeof(id) FROM users LIMIT 1;
+} {integer}
+
+do_execsql_test $pipe select-count {
+  SELECT count(id) FROM users;
+} {4}
+
+do_execsql_test $pipe select-count {
+  SELECT count(*) FROM users;
+} {4}
+
+do_execsql_test $pipe select-count-constant-true {
+  SELECT count(*) FROM users WHERE true;
+} {4}
+
+do_execsql_test $pipe select-count-constant-false {
+  SELECT count(*) FROM users WHERE false;
+} {0}
+
+puts "All tests passed successfully."
+close $pipe


### PR DESCRIPTION
https://github.com/tursodatabase/limbo/issues/53

This PR implements a (naive) in-memory option and makes it the default connection when no DB file argument is passed to the CLI. If a `:memory:` parameter is passed in place of a path to a database file, to replicate sqlite's behavior.

It's slightly more difficult to test for obvious reasons, so I added some dumb and probably temporary ones until I can craft a better solution. Let it be noted that I had never touched `tcl` previously if that wasn't obvious ;)

also cleaned up a bit of previous pr, replacing`format!` calls to writeln with `write_fmt` to prevent double allocations.

EDIT: I originally had these additional tests running with the `test-compat`, but they would hang whenever running on github actions for whatever reason.