### PR TITLE
Pin toolchain to Rust version 1.83

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.83.0"


### PR DESCRIPTION
It's annoying for the CI to trip over formatting because you happen to have a different version of Rust locally.