### PR TITLE
feat(optimizer): eliminate between statement

### DIFF
--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -881,6 +881,9 @@ fn convert_between_expr(expr: ast::Expr) -> ast::Expr {
                 )
             }
         }
+        ast::Expr::Parenthesized(mut exprs) => {
+            ast::Expr::Parenthesized(exprs.drain(..).map(convert_between_expr).collect())
+        }
         // Process other expressions recursively
         ast::Expr::Binary(lhs, op, rhs) => ast::Expr::Binary(
             Box::new(convert_between_expr(*lhs)),

--- a/testing/where.test
+++ b/testing/where.test
@@ -317,3 +317,20 @@ do_execsql_test where-age-index-seek-regression-test {
 do_execsql_test where-age-index-seek-regression-test-2 {
     select count(1) from users where age > 0;
 } {10000}
+
+do_execsql_test where-simple-between {
+    SELECT * FROM products WHERE price BETWEEN 70 AND 100;
+} {1|hat|79.0
+2|cap|82.0
+5|sweatshirt|74.0
+6|shorts|70.0
+7|jeans|78.0
+8|sneakers|82.0
+11|accessories|81.0}
+
+do_execsql_test between-price-range-with-names {
+    SELECT * FROM products 
+    WHERE (price BETWEEN 70 AND 100) 
+    AND (name = 'sweatshirt' OR name = 'sneakers');
+} {5|sweatshirt|74.0
+8|sneakers|82.0}


### PR DESCRIPTION
Rewrite `Y BETWEEN X AND Z` as `X <= Y AND Y <= Z`. And due to the support of this optimization rule, limbo should now be able to execute the `BETWEEN AND` statement.