### PR TITLE
Handle all SQLite quoting syntax

### DIFF
--- a/testing/join.test
+++ b/testing/join.test
@@ -240,6 +240,12 @@ do_execsql_test join-using-multiple {
 Cindy|Salazar|cap
 Tommy|Perry|shirt"}
 
+do_execsql_test join-using-multiple-with-quoting {
+    select u.first_name, u.last_name, p.name from users u join users u2 using(id) join [products] p using(`id`) limit 3;
+} {"Jamie|Foster|hat
+Cindy|Salazar|cap
+Tommy|Perry|shirt"}
+
 # NATURAL JOIN desugars to JOIN USING (common_column1, common_column2...)
 do_execsql_test join-using {
     select * from users natural join products limit 3;

--- a/testing/select.test
+++ b/testing/select.test
@@ -51,6 +51,14 @@ do_execsql_test table-star-2 {
     select p.*, u.first_name from users u join products p on u.id = p.id limit 1;
 } {1|hat|79.0|Jamie}
 
+do_execsql_test select_with_quoting {
+  select `users`.id from [users] where users.[id] = 5;
+} {5}
+
+do_execsql_test select_with_quoting_2 {
+  select "users".`id` from users where `users`.[id] = 5;
+} {5}
+
 do_execsql_test seekrowid {
     select * from users u where u.id = 5;
 } {"5|Edward|Miller|christiankramer@example.com|725-281-1033|08522 English Plain|Lake Keith|ID|23283|15"}


### PR DESCRIPTION
This PR adds missing SQLite quoting syntax: https://sqlite.org/lang_keywords.html

Closes #483 
Closes #497 

```bash
➜  limbo git:(missing-quoting) ✗ cargo run --package limbo --bin limbo home.db
Limbo v0.0.9
Enter ".help" for usage hints.
limbo> select * from home limit 1;
Documents|dir|280|2024-10-13 06:26:05.605048960+02:00
limbo> select * from [home] limit 1;
Documents|dir|280|2024-10-13 06:26:05.605048960+02:00
limbo> select * from `home` limit 1;
Documents|dir|280|2024-10-13 06:26:05.605048960+02:00
limbo> select * from "home" limit 1;
Documents|dir|280|2024-10-13 06:26:05.605048960+02:00
```