### PR TITLE
Fix Python binding packaging

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -30,7 +30,14 @@ dependencies = ['typing-extensions >=4.6.0,!=4.7.0']
 dynamic = ['readme', 'version']
 
 [project.optional-dependencies]
-dev = ["mypy==1.11.0", "pytest==8.3.1", "pytest-cov==5.0.0", "ruff==0.5.4", "coverage==7.6.1"]
+dev = [
+    "mypy==1.11.0",
+    "pytest==8.3.1",
+    "pytest-cov==5.0.0",
+    "ruff==0.5.4",
+    "coverage==7.6.1",
+    "maturin==1.7.8",
+]
 
 [project.urls]
 Homepage = "https://github.com/penberg/limbo"

--- a/bindings/python/requirements-dev.txt
+++ b/bindings/python/requirements-dev.txt
@@ -1,11 +1,11 @@
 coverage==7.6.1
     # via
-    #   limbo (pyproject.toml)
+    #   pylimbo (pyproject.toml)
     #   pytest-cov
 iniconfig==2.0.0
     # via pytest
 mypy==1.11.0
-    # via limbo (pyproject.toml)
+    # via pylimbo (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
 packaging==24.2
@@ -14,13 +14,13 @@ pluggy==1.5.0
     # via pytest
 pytest==8.3.1
     # via
-    #   limbo (pyproject.toml)
+    #   pylimbo (pyproject.toml)
     #   pytest-cov
 pytest-cov==5.0.0
-    # via limbo (pyproject.toml)
+    # via pylimbo (pyproject.toml)
 ruff==0.5.4
-    # via limbo (pyproject.toml)
+    # via pylimbo (pyproject.toml)
 typing-extensions==4.12.2
     # via
-    #   limbo (pyproject.toml)
     #   mypy
+    #   pylimbo (pyproject.toml)

--- a/bindings/python/requirements-dev.txt
+++ b/bindings/python/requirements-dev.txt
@@ -4,6 +4,8 @@ coverage==7.6.1
     #   pytest-cov
 iniconfig==2.0.0
     # via pytest
+maturin==1.7.8
+    # via pylimbo (pyproject.toml)
 mypy==1.11.0
     # via pylimbo (pyproject.toml)
 mypy-extensions==1.0.0

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -1,2 +1,2 @@
 typing-extensions==4.12.2
-    # via limbo (pyproject.toml)
+    # via pylimbo (pyproject.toml)


### PR DESCRIPTION
Somehow the `make` command does not work because of the name mismatching. This PR will fix only this issue.

For reproducing the issue:

```
$ make

Checking requirements files...
mkdir -p .tmp
pip-compile pyproject.toml --quiet             --output-file=.tmp/requirements.txt
pip-compile pyproject.toml --quiet --extra=dev --output-file=.tmp/requirements-dev.txt
diff -u requirements.txt     .tmp/requirements.txt     || (echo "requirements.txt doesn't match pyproject.toml"     && exit 1)
--- requirements.txt    2024-12-17 02:19:29.887227723 +0000
+++ .tmp/requirements.txt       2024-12-17 02:19:38.046065295 +0000
@@ -1,2 +1,2 @@
 typing-extensions==4.12.2
-    # via limbo (pyproject.toml)
+    # via pylimbo (pyproject.toml)
requirements.txt doesn't match pyproject.toml
make: *** [Makefile:28: check-requirements] Error 1
```

## Another issue...

`maturin` is still not in requirements dev list. Shall we continue to install it manually or add it to dev list?