### PR TITLE
pragma: inital approach to handle pragma statements

### DIFF
--- a/testing/pragma.test
+++ b/testing/pragma.test
@@ -6,3 +6,7 @@ source $testdir/tester.tcl
 do_execsql_test pragma-cache-size {
   PRAGMA cache_size
 } {-2000}
+
+do_execsql_test pragma-update-journal-mode-wal {
+  PRAGMA journal_mode=WAL
+} {wal}

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1572,10 +1572,31 @@ pub enum PragmaBody {
     /// function call
     Call(PragmaValue),
 }
-
 /// `PRAGMA` value
 // https://sqlite.org/syntax/pragma-value.html
 pub type PragmaValue = Expr; // TODO
+
+/// `PRAGMA` value
+// https://sqlite.org/pragma.html
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PragmaName {
+    /// `cache_size` pragma
+    CacheSize,
+    /// `journal_mode` pragma
+    JournalMode,
+}
+
+impl FromStr for PragmaName {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "cache_size" => Ok(PragmaName::CacheSize),
+            "journal_mode" => Ok(PragmaName::JournalMode),
+            _ => Err(()),
+        }
+    }
+}
 
 /// `CREATE TRIGGER` time
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
This change refactors how PRAGMA statements are handled, introducing a more organized and extensible structure to simplify adding new PRAGMA properties in the future.

Previously, only the `cache_size` PRAGMA was supported. With this update, support for the `journal_mode` PRAGMA has been added.