### PR TITLE
Fix limbo_sqlite3 static library build

### DIFF
--- a/sqlite3/Cargo.toml
+++ b/sqlite3/Cargo.toml
@@ -17,6 +17,7 @@ dist = true
 
 [lib]
 doc = false
+crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 env_logger = { version = "0.11.3", default-features = false }


### PR DESCRIPTION
Static lib was built successfully  on MacOS 15.0.1 (24A348) and Linux fedora 6.12.4-orbstack-00286-g339578031cbf