### PR TITLE
cleanup: replace &(*x) with x.as_ref() for smart pointer derefs

### DIFF
--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -267,7 +267,7 @@ impl DatabaseStorage {
 
 impl limbo_core::DatabaseStorage for DatabaseStorage {
     fn read_page(&self, page_idx: usize, c: Rc<limbo_core::Completion>) -> Result<()> {
-        let r = match &(*c) {
+        let r = match c.as_ref() {
             limbo_core::Completion::Read(r) => r,
             _ => unreachable!(),
         };

--- a/core/io/darwin.rs
+++ b/core/io/darwin.rs
@@ -190,7 +190,7 @@ impl File for DarwinFile {
     fn pread(&self, pos: usize, c: Rc<Completion>) -> Result<()> {
         let file = self.file.borrow();
         let result = {
-            let r = match &(*c) {
+            let r = match c.as_ref() {
                 Completion::Read(r) => r,
                 _ => unreachable!(),
             };

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -55,7 +55,7 @@ impl File for GenericFile {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         {
-            let r = match &(*c) {
+            let r = match c.as_ref() {
                 Completion::Read(r) => r,
                 _ => unreachable!(),
             };

--- a/core/io/linux.rs
+++ b/core/io/linux.rs
@@ -241,7 +241,7 @@ impl File for LinuxFile {
     }
 
     fn pread(&self, pos: usize, c: Rc<Completion>) -> Result<()> {
-        let r = match &(*c) {
+        let r = match c.as_ref() {
             Completion::Read(r) => r,
             _ => unreachable!(),
         };

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -57,7 +57,7 @@ impl File for WindowsFile {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         {
-            let r = match &(*c) {
+            let r = match c.as_ref() {
                 Completion::Read(r) => r,
                 _ => unreachable!(),
             };

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -25,7 +25,7 @@ pub struct FileStorage {
 #[cfg(feature = "fs")]
 impl DatabaseStorage for FileStorage {
     fn read_page(&self, page_idx: usize, c: Rc<Completion>) -> Result<()> {
-        let r = match &(*c) {
+        let r = match c.as_ref() {
             Completion::Read(r) => r,
             _ => unreachable!(),
         };


### PR DESCRIPTION
The only instances of the &(*x) dereferencing pattern in the codebase, is used with Completion smart pointers. Changed it to use as_ref(). No functional changes.