### PR TITLE
UUID support

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -161,15 +161,6 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | zeroblob(N)                  | Yes    |         |
 
 
-|-------------------------------------------------|
-| LibSql / sqlean Scalar       |        |         |
-| ---------------------------- | ------ | ------- |
-| uuid4()                      | Yes    | uuid version 4 **uuid's are `blob` by default** |
-| uuid4_str()                  | Yes    | uuid v4 string alias `gen_random_uuid()` for PG compatibility|
-| uuid7(X?)                    | Yes    | uuid version 7, Optional arg for seconds since epoch|
-| uuid7_timestamp_ms(X)        | Yes    | Convert a uuid v7 to milliseconds since epoch|
-| uuid_str(X)                  | Yes    | Convert a valid uuid to string|
-| uuid_blob(X)                 | Yes    | Convert a valid uuid to blob|
 
 
 
@@ -462,3 +453,16 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | Variable        | No     |
 | VerifyCookie    | No     |
 | Yield           | Yes    |
+
+
+
+
+| LibSql Compatibility / Extensions|    |         |
+| ---------------------------- | ------ | ------- |
+|  **UUID**                    |        | UUID's in limbo are `blobs` by default|
+| uuid4()                      | Yes    | uuid version 4 |
+| uuid4_str()                  | Yes    | uuid v4 string alias `gen_random_uuid()` for PG compatibility|
+| uuid7(X?)                    | Yes    | uuid version 7, Optional arg for seconds since epoch|
+| uuid7_timestamp_ms(X)        | Yes    | Convert a uuid v7 to milliseconds since epoch|
+| uuid_str(X)                  | Yes    | Convert a valid uuid to string|
+| uuid_blob(X)                 | Yes    | Convert a valid uuid to blob|

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -160,6 +160,19 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | upper(X)                     | Yes    |         |
 | zeroblob(N)                  | Yes    |         |
 
+
+|-------------------------------------------------|
+| LibSql / sqlean Scalar       |        |         |
+| ---------------------------- | ------ | ------- |
+| uuid4()                      | Yes    | uuid version 4 **uuid's are `blob` by default** |
+| uuid4_str()                  | Yes    | uuid v4 string alias `gen_random_uuid()` for PG compatibility|
+| uuid7(X?)                    | Yes    | uuid version 7, Optional arg for seconds since epoch|
+| uuid7_timestamp_ms(X)        | Yes    | Convert a uuid v7 to milliseconds since epoch|
+| uuid_str(X)                  | Yes    | Convert a valid uuid to string|
+| uuid_blob(X)                 | Yes    | Convert a valid uuid to blob|
+
+
+
 ### Mathematical functions
 
 | Function   | Status | Comment |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,7 @@ dependencies = [
  "sqlite3-parser",
  "tempfile",
  "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
@@ -2277,6 +2278,9 @@ name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "vcpkg"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,8 +14,9 @@ name = "limbo_core"
 path = "lib.rs"
 
 [features]
-default = ["fs", "json"]
+default = ["fs", "json", "uuid"]
 fs = []
+uuid = ["dep:uuid"]
 json = [
     "dep:jsonb",
     "dep:pest",
@@ -54,6 +55,7 @@ pest_derive = { version = "2.0", optional = true }
 rand = "0.8.5"
 bumpalo = { version = "3.16.0", features = ["collections", "boxed"] }
 macros = { path = "../macros" }
+uuid = { version = "1.11.0", features = ["v4", "v7"], optional = true }
 
 [target.'cfg(not(target_family = "windows"))'.dev-dependencies]
 pprof = { version = "0.14.0", features = ["criterion", "flamegraph"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,7 @@ json = [
     "dep:pest",
     "dep:pest_derive",
 ]
+uuid = ["dep:uuid"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = "0.6.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,6 @@ path = "lib.rs"
 [features]
 default = ["fs", "json", "uuid"]
 fs = []
-uuid = ["dep:uuid"]
 json = [
     "dep:jsonb",
     "dep:pest",

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -1,0 +1,30 @@
+#[cfg(feature = "uuid")]
+mod uuid;
+#[cfg(feature = "uuid")]
+pub use uuid::{exec_ts_from_uuid7, exec_uuid, exec_uuidblob, exec_uuidstr, UuidFunc};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExtFunc {
+    #[cfg(feature = "uuid")]
+    Uuid(UuidFunc),
+}
+
+impl std::fmt::Display for ExtFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "uuid")]
+            ExtFunc::Uuid(uuidfn) => write!(f, "{}", uuidfn),
+            _ => write!(f, "unknown"),
+        }
+    }
+}
+
+impl ExtFunc {
+    pub fn resolve_function(name: &str, num_args: usize) -> Result<ExtFunc, ()> {
+        match name {
+            #[cfg(feature = "uuid")]
+            name => UuidFunc::resolve_function(name, num_args),
+            _ => Err(()),
+        }
+    }
+}

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -20,11 +20,11 @@ impl std::fmt::Display for ExtFunc {
 }
 
 impl ExtFunc {
-    pub fn resolve_function(name: &str, num_args: usize) -> Result<ExtFunc, ()> {
+    pub fn resolve_function(name: &str, num_args: usize) -> Option<ExtFunc> {
         match name {
             #[cfg(feature = "uuid")]
             name => UuidFunc::resolve_function(name, num_args),
-            _ => Err(()),
+            _ => None,
         }
     }
 }

--- a/core/ext/uuid.rs
+++ b/core/ext/uuid.rs
@@ -1,0 +1,334 @@
+use super::ExtFunc;
+use crate::{types::OwnedValue, LimboError};
+use std::rc::Rc;
+use uuid::{ContextV7, Timestamp, Uuid};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum UuidFunc {
+    Uuid4Str,
+    Uuid4,
+    Uuid7,
+    Uuid7TS,
+    UuidStr,
+    UuidBlob,
+}
+
+impl UuidFunc {
+    pub fn resolve_function(name: &str, num_args: usize) -> Result<ExtFunc, ()> {
+        match name {
+            "uuid4_str" => Ok(ExtFunc::Uuid(UuidFunc::Uuid4Str)),
+            "uuid4" => Ok(ExtFunc::Uuid(UuidFunc::Uuid4)),
+            "uuid7" if num_args < 2 => Ok(ExtFunc::Uuid(UuidFunc::Uuid7)),
+            "uuid_str" if num_args == 1 => Ok(ExtFunc::Uuid(UuidFunc::UuidStr)),
+            "uuid_blob" if num_args == 1 => Ok(ExtFunc::Uuid(UuidFunc::UuidBlob)),
+            "uuid7_timestamp_ms" if num_args == 1 => Ok(ExtFunc::Uuid(UuidFunc::Uuid7TS)),
+            // postgres_compatability
+            "gen_random_uuid" => Ok(ExtFunc::Uuid(UuidFunc::Uuid4Str)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl std::fmt::Display for UuidFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UuidFunc::Uuid4Str => write!(f, "uuid4_str"),
+            UuidFunc::Uuid4 => write!(f, "uuid4"),
+            UuidFunc::Uuid7 => write!(f, "uuid7"),
+            UuidFunc::Uuid7TS => write!(f, "uuid7_timestamp_ms"),
+            UuidFunc::UuidStr => write!(f, "uuid_str"),
+            UuidFunc::UuidBlob => write!(f, "uuid_blob"),
+        }
+    }
+}
+
+pub fn exec_uuid(var: &UuidFunc, sec: Option<&OwnedValue>) -> crate::Result<OwnedValue> {
+    match var {
+        UuidFunc::Uuid4 => Ok(OwnedValue::Blob(Rc::new(
+            Uuid::new_v4().into_bytes().to_vec(),
+        ))),
+        UuidFunc::Uuid4Str => Ok(OwnedValue::Text(Rc::new(Uuid::new_v4().to_string()))),
+        UuidFunc::Uuid7 => {
+            let uuid = match sec {
+                Some(OwnedValue::Integer(ref seconds)) => {
+                    let ctx = ContextV7::new();
+                    if *seconds < 0 {
+                        // not valid unix timestamp, error or null?
+                        return Ok(OwnedValue::Null);
+                    }
+                    Uuid::new_v7(Timestamp::from_unix(ctx, *seconds as u64, 0))
+                }
+                _ => Uuid::now_v7(),
+            };
+            Ok(OwnedValue::Blob(Rc::new(uuid.into_bytes().to_vec())))
+        }
+        _ => unreachable!(),
+    }
+}
+
+pub fn exec_uuidstr(reg: &OwnedValue) -> crate::Result<OwnedValue> {
+    match reg {
+        OwnedValue::Blob(blob) => {
+            let uuid = Uuid::from_slice(blob).map_err(|e| LimboError::ParseError(e.to_string()))?;
+            Ok(OwnedValue::Text(Rc::new(uuid.to_string())))
+        }
+        OwnedValue::Text(val) => {
+            let uuid = Uuid::parse_str(val).map_err(|e| LimboError::ParseError(e.to_string()))?;
+            Ok(OwnedValue::Text(Rc::new(uuid.to_string())))
+        }
+        OwnedValue::Null => Ok(OwnedValue::Null),
+        _ => Err(LimboError::ParseError(
+            "Invalid argument type for UUID function".to_string(),
+        )),
+    }
+}
+
+pub fn exec_uuidblob(reg: &OwnedValue) -> crate::Result<OwnedValue> {
+    match reg {
+        OwnedValue::Text(val) => {
+            let uuid = Uuid::parse_str(val).map_err(|e| LimboError::ParseError(e.to_string()))?;
+            Ok(OwnedValue::Blob(Rc::new(uuid.as_bytes().to_vec())))
+        }
+        OwnedValue::Blob(blob) => {
+            let uuid = Uuid::from_slice(blob).map_err(|e| LimboError::ParseError(e.to_string()))?;
+            Ok(OwnedValue::Blob(Rc::new(uuid.as_bytes().to_vec())))
+        }
+        OwnedValue::Null => Ok(OwnedValue::Null),
+        _ => Err(LimboError::ParseError(
+            "Invalid argument type for UUID function".to_string(),
+        )),
+    }
+}
+
+pub fn exec_ts_from_uuid7(reg: &OwnedValue) -> OwnedValue {
+    let uuid = match reg {
+        OwnedValue::Blob(blob) => {
+            Uuid::from_slice(blob).map_err(|e| LimboError::ParseError(e.to_string()))
+        }
+        OwnedValue::Text(val) => {
+            Uuid::parse_str(val).map_err(|e| LimboError::ParseError(e.to_string()))
+        }
+        _ => Err(LimboError::ParseError(
+            "Invalid argument type for UUID function".to_string(),
+        )),
+    };
+    match uuid {
+        Ok(uuid) => OwnedValue::Integer(uuid_to_unix(uuid.as_bytes()) as i64),
+        // display error? sqlean seems to set value to null
+        Err(_) => OwnedValue::Null,
+    }
+}
+
+#[inline(always)]
+fn uuid_to_unix(uuid: &[u8; 16]) -> u64 {
+    ((uuid[0] as u64) << 40)
+        | ((uuid[1] as u64) << 32)
+        | ((uuid[2] as u64) << 24)
+        | ((uuid[3] as u64) << 16)
+        | ((uuid[4] as u64) << 8)
+        | (uuid[5] as u64)
+}
+
+#[cfg(test)]
+#[cfg(feature = "uuid")]
+pub mod test {
+    use super::UuidFunc;
+    use crate::types::OwnedValue;
+    #[test]
+    fn test_exec_uuid_v4blob() {
+        use super::exec_uuid;
+        use uuid::Uuid;
+        let func = UuidFunc::Uuid4;
+        let owned_val = exec_uuid(&func, None);
+        match owned_val {
+            Ok(OwnedValue::Blob(blob)) => {
+                assert_eq!(blob.len(), 16);
+                let uuid = Uuid::from_slice(&blob);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 4);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+    }
+
+    #[test]
+    fn test_exec_uuid_v4str() {
+        use super::{exec_uuid, UuidFunc};
+        use uuid::Uuid;
+        let func = UuidFunc::Uuid4Str;
+        let owned_val = exec_uuid(&func, None);
+        match owned_val {
+            Ok(OwnedValue::Text(v4str)) => {
+                assert_eq!(v4str.len(), 36);
+                let uuid = Uuid::parse_str(&v4str);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 4);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+    }
+
+    #[test]
+    fn test_exec_uuid_v7_now() {
+        use super::{exec_uuid, UuidFunc};
+        use uuid::Uuid;
+        let func = UuidFunc::Uuid7;
+        let owned_val = exec_uuid(&func, None);
+        match owned_val {
+            Ok(OwnedValue::Blob(blob)) => {
+                assert_eq!(blob.len(), 16);
+                let uuid = Uuid::from_slice(&blob);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 7);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+    }
+
+    #[test]
+    fn test_exec_uuid_v7_with_input() {
+        use super::{exec_uuid, UuidFunc};
+        use uuid::Uuid;
+        let func = UuidFunc::Uuid7;
+        let owned_val = exec_uuid(&func, Some(&OwnedValue::Integer(946702800)));
+        match owned_val {
+            Ok(OwnedValue::Blob(blob)) => {
+                assert_eq!(blob.len(), 16);
+                let uuid = Uuid::from_slice(&blob);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 7);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+    }
+
+    #[test]
+    fn test_exec_uuid_v7_now_to_timestamp() {
+        use super::{exec_ts_from_uuid7, exec_uuid, UuidFunc};
+        use uuid::Uuid;
+        let func = UuidFunc::Uuid7;
+        let owned_val = exec_uuid(&func, None);
+        match owned_val {
+            Ok(OwnedValue::Blob(ref blob)) => {
+                assert_eq!(blob.len(), 16);
+                let uuid = Uuid::from_slice(blob);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 7);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+        let result = exec_ts_from_uuid7(&owned_val.expect("uuid7"));
+        if let OwnedValue::Integer(ref ts) = result {
+            let unixnow = (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                * 1000) as i64;
+            assert!(*ts >= unixnow - 1000);
+        }
+    }
+
+    #[test]
+    fn test_exec_uuid_v7_to_timestamp() {
+        use super::{exec_ts_from_uuid7, exec_uuid, UuidFunc};
+        use uuid::Uuid;
+        let func = UuidFunc::Uuid7;
+        let owned_val = exec_uuid(&func, Some(&OwnedValue::Integer(946702800)));
+        match owned_val {
+            Ok(OwnedValue::Blob(ref blob)) => {
+                assert_eq!(blob.len(), 16);
+                let uuid = Uuid::from_slice(blob);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 7);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+        let result = exec_ts_from_uuid7(&owned_val.expect("uuid7"));
+        assert_eq!(result, OwnedValue::Integer(946702800 * 1000));
+        if let OwnedValue::Integer(ts) = result {
+            let time = chrono::DateTime::from_timestamp(ts / 1000, 0);
+            assert_eq!(
+                time.unwrap(),
+                "2000-01-01T05:00:00Z"
+                    .parse::<chrono::DateTime<chrono::Utc>>()
+                    .unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_exec_uuid_v4_str_to_blob() {
+        use super::{exec_uuid, exec_uuidblob, UuidFunc};
+        use uuid::Uuid;
+        let owned_val = exec_uuidblob(
+            &exec_uuid(&UuidFunc::Uuid4Str, None).expect("uuid v4 string to generate"),
+        );
+        match owned_val {
+            Ok(OwnedValue::Blob(blob)) => {
+                assert_eq!(blob.len(), 16);
+                let uuid = Uuid::from_slice(&blob);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 4);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+    }
+
+    #[test]
+    fn test_exec_uuid_v7_str_to_blob() {
+        use super::{exec_uuid, exec_uuidblob, exec_uuidstr, UuidFunc};
+        use uuid::Uuid;
+        // convert a v7 blob to a string then back to a blob
+        let owned_val = exec_uuidblob(
+            &exec_uuidstr(&exec_uuid(&UuidFunc::Uuid7, None).expect("uuid v7 blob to generate"))
+                .expect("uuid v7 string to generate"),
+        );
+        match owned_val {
+            Ok(OwnedValue::Blob(blob)) => {
+                assert_eq!(blob.len(), 16);
+                let uuid = Uuid::from_slice(&blob);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 7);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+    }
+
+    #[test]
+    fn test_exec_uuid_v4_blob_to_str() {
+        use super::{exec_uuid, exec_uuidstr, UuidFunc};
+        use uuid::Uuid;
+        // convert a v4 blob to a string
+        let owned_val =
+            exec_uuidstr(&exec_uuid(&UuidFunc::Uuid4, None).expect("uuid v7 blob to generate"));
+        match owned_val {
+            Ok(OwnedValue::Text(v4str)) => {
+                assert_eq!(v4str.len(), 36);
+                let uuid = Uuid::parse_str(&v4str);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 4);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+    }
+
+    #[test]
+    fn test_exec_uuid_v7_blob_to_str() {
+        use super::{exec_uuid, exec_uuidstr};
+        use uuid::Uuid;
+        // convert a v7 blob to a string
+        let owned_val = exec_uuidstr(
+            &exec_uuid(&UuidFunc::Uuid7, Some(&OwnedValue::Integer(123456789)))
+                .expect("uuid v7 blob to generate"),
+        );
+        match owned_val {
+            Ok(OwnedValue::Text(v7str)) => {
+                assert_eq!(v7str.len(), 36);
+                let uuid = Uuid::parse_str(&v7str);
+                assert!(uuid.is_ok());
+                assert_eq!(uuid.unwrap().get_version_num(), 7);
+            }
+            _ => panic!("exec_uuid did not return a Blob variant"),
+        }
+    }
+}

--- a/core/function.rs
+++ b/core/function.rs
@@ -263,7 +263,7 @@ pub enum Func {
     Math(MathFunc),
     #[cfg(feature = "json")]
     Json(JsonFunc),
-    Extention(ExtFunc),
+    Extension(ExtFunc),
 }
 
 impl Display for Func {
@@ -274,7 +274,7 @@ impl Display for Func {
             Func::Math(math_func) => write!(f, "{}", math_func),
             #[cfg(feature = "json")]
             Func::Json(json_func) => write!(f, "{}", json_func),
-            Func::Extention(ext_func) => write!(f, "{}", ext_func),
+            Func::Extension(ext_func) => write!(f, "{}", ext_func),
         }
     }
 }
@@ -369,8 +369,8 @@ impl Func {
             "tanh" => Ok(Func::Math(MathFunc::Tanh)),
             "trunc" => Ok(Func::Math(MathFunc::Trunc)),
             _ => match ExtFunc::resolve_function(name, arg_count) {
-                Ok(ext_func) => Ok(Func::Extention(ext_func)),
-                Err(_) => Err(()),
+                Some(ext_func) => Ok(Func::Extension(ext_func)),
+                None => Err(()),
             },
         }
     }

--- a/core/function.rs
+++ b/core/function.rs
@@ -96,7 +96,7 @@ pub enum ScalarFunc {
     UuidStr,
     UuidBlob,
     Uuid7,
-    Uuid7Str,
+    Uuid7TS,
 }
 
 impl Display for ScalarFunc {
@@ -146,8 +146,8 @@ impl Display for ScalarFunc {
             ScalarFunc::UuidStr => "uuid_str".to_string(),
             ScalarFunc::UuidBlob => "uuid_blob".to_string(),
             ScalarFunc::Uuid7 => "uuid7".to_string(),
-            ScalarFunc::Uuid7Str => "uuid7_str".to_string(),
             ScalarFunc::Uuid4Str => "uuid4_str".to_string(),
+            ScalarFunc::Uuid7TS => "uuid7_timestamp_ms".to_string(),
         };
         write!(f, "{}", str)
     }
@@ -337,12 +337,14 @@ impl Func {
             "typeof" => Ok(Func::Scalar(ScalarFunc::Typeof)),
             "last_insert_rowid" => Ok(Func::Scalar(ScalarFunc::LastInsertRowid)),
             "unicode" => Ok(Func::Scalar(ScalarFunc::Unicode)),
+            "uuid4_str" => Ok(Func::Scalar(ScalarFunc::Uuid4Str)),
             "uuid4" => Ok(Func::Scalar(ScalarFunc::Uuid4)),
             "uuid7" => Ok(Func::Scalar(ScalarFunc::Uuid7)),
-            "uuid4_str" => Ok(Func::Scalar(ScalarFunc::Uuid4Str)),
-            "uuid7_str" => Ok(Func::Scalar(ScalarFunc::Uuid7Str)),
             "uuid_str" => Ok(Func::Scalar(ScalarFunc::UuidStr)),
             "uuid_blob" => Ok(Func::Scalar(ScalarFunc::UuidBlob)),
+            "uuid7_timestamp_ms" => Ok(Func::Scalar(ScalarFunc::Uuid7TS)),
+            // postgres_compatability
+            "gen_random_uuid" => Ok(Func::Scalar(ScalarFunc::Uuid4Str)),
             "quote" => Ok(Func::Scalar(ScalarFunc::Quote)),
             "sqlite_version" => Ok(Func::Scalar(ScalarFunc::SqliteVersion)),
             "replace" => Ok(Func::Scalar(ScalarFunc::Replace)),

--- a/core/function.rs
+++ b/core/function.rs
@@ -91,6 +91,12 @@ pub enum ScalarFunc {
     ZeroBlob,
     LastInsertRowid,
     Replace,
+    Uuid4,
+    Uuid4Str,
+    UuidStr,
+    UuidBlob,
+    Uuid7,
+    Uuid7Str,
 }
 
 impl Display for ScalarFunc {
@@ -136,6 +142,12 @@ impl Display for ScalarFunc {
             ScalarFunc::ZeroBlob => "zeroblob".to_string(),
             ScalarFunc::LastInsertRowid => "last_insert_rowid".to_string(),
             ScalarFunc::Replace => "replace".to_string(),
+            ScalarFunc::Uuid4 => "uuid4".to_string(),
+            ScalarFunc::UuidStr => "uuid_str".to_string(),
+            ScalarFunc::UuidBlob => "uuid_blob".to_string(),
+            ScalarFunc::Uuid7 => "uuid7".to_string(),
+            ScalarFunc::Uuid7Str => "uuid7_str".to_string(),
+            ScalarFunc::Uuid4Str => "uuid4_str".to_string(),
         };
         write!(f, "{}", str)
     }
@@ -325,6 +337,12 @@ impl Func {
             "typeof" => Ok(Func::Scalar(ScalarFunc::Typeof)),
             "last_insert_rowid" => Ok(Func::Scalar(ScalarFunc::LastInsertRowid)),
             "unicode" => Ok(Func::Scalar(ScalarFunc::Unicode)),
+            "uuid4" => Ok(Func::Scalar(ScalarFunc::Uuid4)),
+            "uuid7" => Ok(Func::Scalar(ScalarFunc::Uuid7)),
+            "uuid4_str" => Ok(Func::Scalar(ScalarFunc::Uuid4Str)),
+            "uuid7_str" => Ok(Func::Scalar(ScalarFunc::Uuid7Str)),
+            "uuid_str" => Ok(Func::Scalar(ScalarFunc::UuidStr)),
+            "uuid_blob" => Ok(Func::Scalar(ScalarFunc::UuidBlob)),
             "quote" => Ok(Func::Scalar(ScalarFunc::Quote)),
             "sqlite_version" => Ok(Func::Scalar(ScalarFunc::SqliteVersion)),
             "replace" => Ok(Func::Scalar(ScalarFunc::Replace)),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+mod ext;
 mod function;
 mod io;
 #[cfg(feature = "json")]

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1615,7 +1615,7 @@ pub fn translate_expr(
                         }
                     }
                 }
-                Func::Extention(ext_func) => match ext_func {
+                Func::Extension(ext_func) => match ext_func {
                     #[cfg(feature = "uuid")]
                     ExtFunc::Uuid(ref uuid_fn) => match uuid_fn {
                         UuidFunc::UuidStr | UuidFunc::UuidBlob | UuidFunc::Uuid7TS => {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -26,7 +26,7 @@ mod datetime;
 use crate::error::{LimboError, SQLITE_CONSTRAINT_PRIMARYKEY};
 #[cfg(feature = "uuid")]
 use crate::ext::{exec_ts_from_uuid7, exec_uuid, exec_uuidblob, exec_uuidstr, ExtFunc, UuidFunc};
-use crate::function::{AggFunc, Func, FuncCtx, MathFunc, MathFuncArity, ScalarFunc};
+use crate::function::{AggFunc, FuncCtx, MathFunc, MathFuncArity, ScalarFunc};
 use crate::pseudo::PseudoCursor;
 use crate::schema::Table;
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
@@ -39,6 +39,7 @@ use crate::util::parse_schema_rows;
 use crate::{function::JsonFunc, json::get_json, json::json_array};
 use crate::{Connection, Result, TransactionState};
 use crate::{Rows, DATABASE_VERSION};
+use macros::Description;
 
 use datetime::{exec_date, exec_time, exec_unixepoch};
 
@@ -50,32 +51,10 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::{Rc, Weak};
 
-use uuid::{ContextV7, Timestamp, Uuid};
-
 pub type BranchOffset = i64;
-use macros::Description;
 pub type CursorID = usize;
 
 pub type PageIdx = usize;
-
-#[allow(dead_code)]
-#[derive(Debug)]
-pub enum Func {
-    Scalar(ScalarFunc),
-    #[cfg(feature = "json")]
-    Json(JsonFunc),
-}
-
-impl Display for Func {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let str = match self {
-            Func::Scalar(scalar_func) => scalar_func.to_string(),
-            #[cfg(feature = "json")]
-            Func::Json(json_func) => json_func.to_string(),
-        };
-        write!(f, "{}", str)
-    }
-}
 
 #[derive(Description, Debug)]
 pub enum Insn {
@@ -2535,7 +2514,7 @@ impl Program {
                                 state.registers[*dest] = exec_replace(source, pattern, replacement);
                             }
                         },
-                        Func::Extention(extfn) => match extfn {
+                        crate::function::Func::Extension(extfn) => match extfn {
                             #[cfg(feature = "uuid")]
                             ExtFunc::Uuid(uuidfn) => match uuidfn {
                                 UuidFunc::Uuid4 | UuidFunc::Uuid4Str => {


### PR DESCRIPTION
#509 

Started the discussion on discord about possibly supporting UUID types natively. This PR only implements the `sqlean` extension's functions and behavior, with the only changes being:

1. uuid's are returned as `blob`s by default. (that was an assumption I made considering perf, thinking this would be preferred if UUID ended up being a supported native type.  if `text` is preferred I can change it)
2.  `uuidv7` types here can accept an argument of seconds since epoch to customize the embedded timestamp. The func `uuidv7_timestamp_ms(string_or_blob_v7)` allows the user to convert their uuid7 back into the timestamp. 

![image](https://github.com/user-attachments/assets/ca53ee9b-f1f1-410b-955f-acd140bd4989)
