### PR TITLE
Implement basic sqlite3_get_table() API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,9 +1063,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -1176,6 +1176,7 @@ name = "limbo_sqlite3"
 version = "0.0.10"
 dependencies = [
  "env_logger 0.11.5",
+ "libc",
  "limbo_core",
  "log",
 ]

--- a/sqlite3/Cargo.toml
+++ b/sqlite3/Cargo.toml
@@ -21,6 +21,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 env_logger = { version = "0.11.3", default-features = false }
+libc = "0.2.169"
 limbo_core = { path = "../core" }
 log = "0.4.22"
 


### PR DESCRIPTION
#479 

This is my first draft for implementing `sqlite3_get_table()`, it is highly inspired on the actual implementation found [here](https://raw.githubusercontent.com/rusqlite/rusqlite/92fdc11fea0ecea6400dfcb74c1c3ca36214a7d4/libsqlite3-sys/sqlite3/sqlite3.c), I made some basic manual testing in `example.c` and it works fine but an extensive test suite is recommended.

