### PR TITLE
Improve error reporting in Python bindings

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -105,8 +105,9 @@ impl Cursor {
         // TODO: use stmt_is_dml to set rowcount
         if stmt_is_dml {
             return Err(PyErr::new::<NotSupportedError, _>(
-                "DML statements (INSERT/UPDATE/DELETE) are not fully supported in this version"
-            ).into());
+                "DML statements (INSERT/UPDATE/DELETE) are not fully supported in this version",
+            )
+            .into());
         }
 
         Ok(Cursor {
@@ -185,21 +186,21 @@ impl Cursor {
 
     pub fn close(&self) -> PyResult<()> {
         Err(PyErr::new::<NotSupportedError, _>(
-            "close() is not supported in this version"
+            "close() is not supported in this version",
         ))
     }
 
     #[pyo3(signature = (sql, parameters=None))]
     pub fn executemany(&self, sql: &str, parameters: Option<Py<PyList>>) -> PyResult<()> {
         Err(PyErr::new::<NotSupportedError, _>(
-            "executemany() is not supported in this version"
+            "executemany() is not supported in this version",
         ))
     }
 
     #[pyo3(signature = (size=None))]
     pub fn fetchmany(&self, size: Option<i64>) -> PyResult<Option<Vec<PyObject>>> {
         Err(PyErr::new::<NotSupportedError, _>(
-            "fetchmany() is not supported in this version"
+            "fetchmany() is not supported in this version",
         ))
     }
 }
@@ -238,13 +239,13 @@ impl Connection {
 
     pub fn commit(&self) -> PyResult<()> {
         Err(PyErr::new::<NotSupportedError, _>(
-            "Transactions are not supported in this version"
+            "Transactions are not supported in this version",
         ))
     }
 
     pub fn rollback(&self) -> PyResult<()> {
         Err(PyErr::new::<NotSupportedError, _>(
-            "Transactions are not supported in this version"
+            "Transactions are not supported in this version",
         ))
     }
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -104,7 +104,9 @@ impl Cursor {
 
         // TODO: use stmt_is_dml to set rowcount
         if stmt_is_dml {
-            todo!()
+            return Err(PyErr::new::<NotSupportedError, _>(
+                "DML statements (INSERT/UPDATE/DELETE) are not fully supported in this version"
+            ).into());
         }
 
         Ok(Cursor {
@@ -181,18 +183,24 @@ impl Cursor {
         }
     }
 
-    pub fn close(&self) -> Result<()> {
-        todo!()
+    pub fn close(&self) -> PyResult<()> {
+        Err(PyErr::new::<NotSupportedError, _>(
+            "close() is not supported in this version"
+        ))
     }
 
     #[pyo3(signature = (sql, parameters=None))]
-    pub fn executemany(&self, sql: &str, parameters: Option<Py<PyList>>) {
-        todo!()
+    pub fn executemany(&self, sql: &str, parameters: Option<Py<PyList>>) -> PyResult<()> {
+        Err(PyErr::new::<NotSupportedError, _>(
+            "executemany() is not supported in this version"
+        ))
     }
 
     #[pyo3(signature = (size=None))]
-    pub fn fetchmany(&self, size: Option<i64>) {
-        todo!()
+    pub fn fetchmany(&self, size: Option<i64>) -> PyResult<Option<Vec<PyObject>>> {
+        Err(PyErr::new::<NotSupportedError, _>(
+            "fetchmany() is not supported in this version"
+        ))
     }
 }
 
@@ -228,12 +236,16 @@ impl Connection {
         drop(self.conn.clone());
     }
 
-    pub fn commit(&self) {
-        todo!()
+    pub fn commit(&self) -> PyResult<()> {
+        Err(PyErr::new::<NotSupportedError, _>(
+            "Transactions are not supported in this version"
+        ))
     }
 
-    pub fn rollback(&self) {
-        todo!()
+    pub fn rollback(&self) -> PyResult<()> {
+        Err(PyErr::new::<NotSupportedError, _>(
+            "Transactions are not supported in this version"
+        ))
     }
 }
 


### PR DESCRIPTION
Solving issue #494   , changes made at 5 places where todo macros were replaced with relevant errors to avoid the crashes _for now_