### PR TITLE
Fix file creation in GenericIO `open_file` function

### DIFF
--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -15,7 +15,11 @@ impl GenericIO {
 impl IO for GenericIO {
     fn open_file(&self, path: &str, flags: OpenFlags, _direct: bool) -> Result<Rc<dyn File>> {
         trace!("open_file(path = {})", path);
-        let file = std::fs::File::open(path)?;
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(matches!(flags, OpenFlags::Create))
+            .open(path)?;
         Ok(Rc::new(GenericFile {
             file: RefCell::new(file),
         }))


### PR DESCRIPTION
`cargo test` is always failing on FreeBSD, the following is one of the errors:

```
---- tests::test_simple_overflow_page stdout ----
thread 'tests::test_simple_overflow_page' panicked at test/src/lib.rs:32:84:
called `Result::unwrap()` on an `Err` value: IOError(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```

After some digging, I found that the `open_file` function in `core/io/generic.rs` does not respect the `OpenFlags::Create` flag. This commit adds support for file creation in the `open_file` function.

`cargo test` now passes on FreeBSD.