### PR TITLE
core: disk serialization changes to align with sqlite

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1514,7 +1514,6 @@ impl BTreeCursor {
         if record_buf.len() <= payload_overflow_threshold_max {
             // enough allowed space to fit inside a btree page
             cell_payload.extend_from_slice(record_buf.as_slice());
-            cell_payload.resize(cell_payload.len() + 4, 0);
             return;
         }
         log::debug!("fill_cell_payload(overflow)");

--- a/core/types.rs
+++ b/core/types.rs
@@ -528,3 +528,206 @@ pub trait Cursor {
     fn get_null_flag(&self) -> bool;
     fn btree_create(&mut self, flags: usize) -> u32;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+
+    #[test]
+    fn test_serialize_null() {
+        let record = OwnedRecord::new(vec![OwnedValue::Null]);
+        let mut buf = Vec::new();
+        record.serialize(&mut buf);
+
+        let header_length = record.values.len() + 1;
+        let header = &buf[0..header_length];
+        // First byte should be header size
+        assert_eq!(header[0], header_length as u8);
+        // Second byte should be serial type for NULL
+        assert_eq!(header[1], SERIAL_TYPE_INTEGER_ZERO as u8);
+        // Check that the buffer is empty after the header
+        assert_eq!(buf.len(), header_length);
+    }
+
+    #[test]
+    fn test_serialize_integers() {
+        let record = OwnedRecord::new(vec![
+            OwnedValue::Integer(42),                // Should use SERIAL_TYPE_I8
+            OwnedValue::Integer(1000),              // Should use SERIAL_TYPE_I16
+            OwnedValue::Integer(1_000_000),         // Should use SERIAL_TYPE_I24
+            OwnedValue::Integer(1_000_000_000),     // Should use SERIAL_TYPE_I32
+            OwnedValue::Integer(1_000_000_000_000), // Should use SERIAL_TYPE_I48
+            OwnedValue::Integer(i64::MAX),          // Should use SERIAL_TYPE_I64
+        ]);
+        let mut buf = Vec::new();
+        record.serialize(&mut buf);
+
+        let header_length = record.values.len() + 1;
+        let header = &buf[0..header_length];
+        // First byte should be header size
+        assert!(header[0] == header_length as u8); // Header should be larger than number of values
+
+        // Check that correct serial types were chosen
+        assert_eq!(header[1], SERIAL_TYPE_I8 as u8);
+        assert_eq!(header[2], SERIAL_TYPE_I16 as u8);
+        assert_eq!(header[3], SERIAL_TYPE_I24 as u8);
+        assert_eq!(header[4], SERIAL_TYPE_I32 as u8);
+        assert_eq!(header[5], SERIAL_TYPE_I48 as u8);
+        assert_eq!(header[6], SERIAL_TYPE_I64 as u8);
+
+        // test that the bytes after the header can be interpreted as the correct values
+        let mut cur_offset = header_length;
+        let i8_bytes = &buf[cur_offset..cur_offset + size_of::<i8>()];
+        cur_offset += size_of::<i8>();
+        let i16_bytes = &buf[cur_offset..cur_offset + size_of::<i16>()];
+        cur_offset += size_of::<i16>();
+        let i24_bytes = &buf[cur_offset..cur_offset + size_of::<i32>() - 1];
+        cur_offset += size_of::<i32>() - 1; // i24
+        let i32_bytes = &buf[cur_offset..cur_offset + size_of::<i32>()];
+        cur_offset += size_of::<i32>();
+        let i48_bytes = &buf[cur_offset..cur_offset + size_of::<i64>() - 2];
+        cur_offset += size_of::<i64>() - 2; // i48
+        let i64_bytes = &buf[cur_offset..cur_offset + size_of::<i64>()];
+
+        let val_int8 = i8::from_be_bytes(i8_bytes.try_into().unwrap());
+        let val_int16 = i16::from_be_bytes(i16_bytes.try_into().unwrap());
+
+        let mut leading_0 = vec![0];
+        leading_0.extend(i24_bytes);
+        let val_int24 = i32::from_be_bytes(leading_0.try_into().unwrap());
+
+        let val_int32 = i32::from_be_bytes(i32_bytes.try_into().unwrap());
+
+        let mut leading_00 = vec![0, 0];
+        leading_00.extend(i48_bytes);
+        let val_int48 = i64::from_be_bytes(leading_00.try_into().unwrap());
+
+        let val_int64 = i64::from_be_bytes(i64_bytes.try_into().unwrap());
+
+        assert_eq!(val_int8, 42);
+        assert_eq!(val_int16, 1000);
+        assert_eq!(val_int24, 1_000_000);
+        assert_eq!(val_int32, 1_000_000_000);
+        assert_eq!(val_int48, 1_000_000_000_000);
+        assert_eq!(val_int64, i64::MAX);
+
+        // assert correct size of buffer: header + values (bytes per value depends on serial type)
+        assert_eq!(
+            buf.len(),
+            header_length
+                + size_of::<i8>()
+                + size_of::<i16>()
+                + (size_of::<i32>() - 1) // i24
+                + size_of::<i32>()
+                + (size_of::<i64>() - 2) // i48
+                + size_of::<f64>()
+        );
+    }
+
+    #[test]
+    fn test_serialize_float() {
+        let record = OwnedRecord::new(vec![OwnedValue::Float(3.14159)]);
+        let mut buf = Vec::new();
+        record.serialize(&mut buf);
+
+        let header_length = record.values.len() + 1;
+        let header = &buf[0..header_length];
+        // First byte should be header size
+        assert_eq!(header[0], header_length as u8);
+        // Second byte should be serial type for FLOAT
+        assert_eq!(header[1], SERIAL_TYPE_F64 as u8);
+        // Check that the bytes after the header can be interpreted as the float
+        let float_bytes = &buf[header_length..header_length + size_of::<f64>()];
+        let float = f64::from_be_bytes(float_bytes.try_into().unwrap());
+        assert_eq!(float, 3.14159);
+        // Check that buffer length is correct
+        assert_eq!(buf.len(), header_length + size_of::<f64>());
+    }
+
+    #[test]
+    fn test_serialize_text() {
+        let text = Rc::new("hello".to_string());
+        let record = OwnedRecord::new(vec![OwnedValue::Text(LimboText::new(text.clone()))]);
+        let mut buf = Vec::new();
+        record.serialize(&mut buf);
+
+        let header_length = record.values.len() + 1;
+        let header = &buf[0..header_length];
+        // First byte should be header size
+        assert_eq!(header[0], header_length as u8);
+        // Second byte should be serial type for TEXT, which is (len * 2 + 13)
+        assert_eq!(header[1], (5 * 2 + 13) as u8);
+        // Check the actual text bytes
+        assert_eq!(&buf[2..7], b"hello");
+        // Check that buffer length is correct
+        assert_eq!(buf.len(), header_length + text.len());
+    }
+
+    #[test]
+    fn test_serialize_blob() {
+        let blob = Rc::new(vec![1, 2, 3, 4, 5]);
+        let record = OwnedRecord::new(vec![OwnedValue::Blob(blob.clone())]);
+        let mut buf = Vec::new();
+        record.serialize(&mut buf);
+
+        let header_length = record.values.len() + 1;
+        let header = &buf[0..header_length];
+        // First byte should be header size
+        assert_eq!(header[0], header_length as u8);
+        // Second byte should be serial type for BLOB, which is (len * 2 + 12)
+        assert_eq!(header[1], (5 * 2 + 12) as u8);
+        // Check the actual blob bytes
+        assert_eq!(&buf[2..7], &[1, 2, 3, 4, 5]);
+        // Check that buffer length is correct
+        assert_eq!(buf.len(), header_length + blob.len());
+    }
+
+    #[test]
+    fn test_serialize_mixed_types() {
+        let text = Rc::new("test".to_string());
+        let record = OwnedRecord::new(vec![
+            OwnedValue::Null,
+            OwnedValue::Integer(42),
+            OwnedValue::Float(3.14),
+            OwnedValue::Text(LimboText::new(text.clone())),
+        ]);
+        let mut buf = Vec::new();
+        record.serialize(&mut buf);
+
+        let header_length = record.values.len() + 1;
+        let header = &buf[0..header_length];
+        // First byte should be header size
+        assert_eq!(header[0], header_length as u8);
+        // Second byte should be serial type for NULL
+        assert_eq!(header[1], SERIAL_TYPE_INTEGER_ZERO as u8);
+        // Third byte should be serial type for I8
+        assert_eq!(header[2], SERIAL_TYPE_I8 as u8);
+        // Fourth byte should be serial type for F64
+        assert_eq!(header[3], SERIAL_TYPE_F64 as u8);
+        // Fifth byte should be serial type for TEXT, which is (len * 2 + 13)
+        assert_eq!(header[4], (4 * 2 + 13) as u8);
+
+        // Check that the bytes after the header can be interpreted as the correct values
+        let mut cur_offset = header_length;
+        let i8_bytes = &buf[cur_offset..cur_offset + size_of::<i8>()];
+        cur_offset += size_of::<i8>();
+        let f64_bytes = &buf[cur_offset..cur_offset + size_of::<f64>()];
+        cur_offset += size_of::<f64>();
+        let text_bytes = &buf[cur_offset..cur_offset + text.len()];
+
+        let val_int8 = i8::from_be_bytes(i8_bytes.try_into().unwrap());
+        let val_float = f64::from_be_bytes(f64_bytes.try_into().unwrap());
+        let val_text = String::from_utf8(text_bytes.to_vec()).unwrap();
+
+        assert_eq!(val_int8, 42);
+        assert_eq!(val_float, 3.14);
+        assert_eq!(val_text, "test");
+
+        // Check that buffer length is correct
+        assert_eq!(
+            buf.len(),
+            header_length + size_of::<i8>() + size_of::<f64>() + text.len()
+        );
+    }
+}


### PR DESCRIPTION
This PR's genesis is from investigating #532, but I still can't reliably reproduce it on either `main` or this branch so I don't know if this PR _fixes_ anything, but I guess it aligns us more with sqlite anyway

---

Anyway: I looked at DBs created with limbo and with sqlite using [ImHex](https://github.com/WerWolv/ImHex) and the differences seem to be:

1. SQLite uses varint according to [the spec](https://www.sqlite.org/fileformat.html#record_format), whereas limbo always encodes integers as i64
2. Limbo adds 4 bytes of zeros for overflow page pointer (even in cases where the cell doesnt overflow)
3. Limbo adds a space after `CREATE TABLE name` before the `(` even when user doesn't specify it?

I implemented the following:

- Fix 1: Varint serialization of i8, i16, i24, i32, i48 and i64 according to payload, instead of always using i64
- Fix 2: Removed the 4 bytes reserved for overflow page pointer in non-overflow cases