### PR TITLE
enable sqpoll by default in io_uring

### DIFF
--- a/core/io/linux.rs
+++ b/core/io/linux.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 use thiserror::Error;
 
 const MAX_IOVECS: usize = 128;
+const SQPOLL_IDLE: u32 = 1000;
 
 #[derive(Debug, Error)]
 enum LinuxIOError {
@@ -49,7 +50,13 @@ struct InnerLinuxIO {
 
 impl LinuxIO {
     pub fn new() -> Result<Self> {
-        let ring = io_uring::IoUring::new(MAX_IOVECS as u32)?;
+        let ring = match io_uring::IoUring::builder()
+            .setup_sqpoll(SQPOLL_IDLE)
+            .build(MAX_IOVECS as u32)
+        {
+            Ok(ring) => ring,
+            Err(_) => io_uring::IoUring::new(MAX_IOVECS as u32)?,
+        };
         let inner = InnerLinuxIO {
             ring: WrappedIOUring {
                 ring,


### PR DESCRIPTION
EDIT: will continue iterating on these ideas, as discussed on discord.

for now, this has been changed to just enable `IORING_ENABLE_SQPOLL` by default. This is supported sin `5.11`, and I believe the last debian release < that reached EOL in July, so shouldn't be an issue.