### PR TITLE
Rename RowResult to StepResult

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -128,22 +128,22 @@ impl Cursor {
                 match smt_lock.step().map_err(|e| {
                     PyErr::new::<OperationalError, _>(format!("Step error: {:?}", e))
                 })? {
-                    limbo_core::RowResult::Row(row) => {
+                    limbo_core::StepResult::Row(row) => {
                         let py_row = row_to_py(py, &row);
                         return Ok(Some(py_row));
                     }
-                    limbo_core::RowResult::IO => {
+                    limbo_core::StepResult::IO => {
                         self.conn.io.run_once().map_err(|e| {
                             PyErr::new::<OperationalError, _>(format!("IO error: {:?}", e))
                         })?;
                     }
-                    limbo_core::RowResult::Interrupt => {
+                    limbo_core::StepResult::Interrupt => {
                         return Ok(None);
                     }
-                    limbo_core::RowResult::Done => {
+                    limbo_core::StepResult::Done => {
                         return Ok(None);
                     }
-                    limbo_core::RowResult::Busy => {
+                    limbo_core::StepResult::Busy => {
                         return Err(
                             PyErr::new::<OperationalError, _>("Busy error".to_string()).into()
                         );
@@ -167,22 +167,22 @@ impl Cursor {
                 match smt_lock.step().map_err(|e| {
                     PyErr::new::<OperationalError, _>(format!("Step error: {:?}", e))
                 })? {
-                    limbo_core::RowResult::Row(row) => {
+                    limbo_core::StepResult::Row(row) => {
                         let py_row = row_to_py(py, &row);
                         results.push(py_row);
                     }
-                    limbo_core::RowResult::IO => {
+                    limbo_core::StepResult::IO => {
                         self.conn.io.run_once().map_err(|e| {
                             PyErr::new::<OperationalError, _>(format!("IO error: {:?}", e))
                         })?;
                     }
-                    limbo_core::RowResult::Interrupt => {
+                    limbo_core::StepResult::Interrupt => {
                         return Ok(results);
                     }
-                    limbo_core::RowResult::Done => {
+                    limbo_core::StepResult::Done => {
                         return Ok(results);
                     }
-                    limbo_core::RowResult::Busy => {
+                    limbo_core::StepResult::Busy => {
                         return Err(
                             PyErr::new::<OperationalError, _>("Busy error".to_string()).into()
                         );

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -75,7 +75,7 @@ impl Statement {
 
     pub fn get(&self) -> JsValue {
         match self.inner.borrow_mut().step() {
-            Ok(limbo_core::RowResult::Row(row)) => {
+            Ok(limbo_core::StepResult::Row(row)) => {
                 let row_array = js_sys::Array::new();
                 for value in row.values {
                     let value = to_js_value(value);
@@ -83,10 +83,10 @@ impl Statement {
                 }
                 JsValue::from(row_array)
             }
-            Ok(limbo_core::RowResult::IO)
-            | Ok(limbo_core::RowResult::Done)
-            | Ok(limbo_core::RowResult::Interrupt)
-            | Ok(limbo_core::RowResult::Busy) => JsValue::UNDEFINED,
+            Ok(limbo_core::StepResult::IO)
+            | Ok(limbo_core::StepResult::Done)
+            | Ok(limbo_core::StepResult::Interrupt)
+            | Ok(limbo_core::StepResult::Busy) => JsValue::UNDEFINED,
             Err(e) => panic!("Error: {:?}", e),
         }
     }
@@ -95,7 +95,7 @@ impl Statement {
         let array = js_sys::Array::new();
         loop {
             match self.inner.borrow_mut().step() {
-                Ok(limbo_core::RowResult::Row(row)) => {
+                Ok(limbo_core::StepResult::Row(row)) => {
                     let row_array = js_sys::Array::new();
                     for value in row.values {
                         let value = to_js_value(value);
@@ -103,10 +103,10 @@ impl Statement {
                     }
                     array.push(&row_array);
                 }
-                Ok(limbo_core::RowResult::IO) => {}
-                Ok(limbo_core::RowResult::Interrupt) => break,
-                Ok(limbo_core::RowResult::Done) => break,
-                Ok(limbo_core::RowResult::Busy) => break,
+                Ok(limbo_core::StepResult::IO) => {}
+                Ok(limbo_core::StepResult::Interrupt) => break,
+                Ok(limbo_core::StepResult::Done) => break,
+                Ok(limbo_core::StepResult::Busy) => break,
                 Err(e) => panic!("Error: {:?}", e),
             }
         }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1,6 +1,6 @@
 use crate::opcodes_dictionary::OPCODE_DESCRIPTIONS;
 use cli_table::{Cell, Table};
-use limbo_core::{Database, LimboError, RowResult, Value};
+use limbo_core::{Database, LimboError, StepResult, Value};
 
 use clap::{Parser, ValueEnum};
 use std::{
@@ -498,7 +498,7 @@ impl Limbo {
                     }
 
                     match rows.next_row() {
-                        Ok(RowResult::Row(row)) => {
+                        Ok(StepResult::Row(row)) => {
                             for (i, value) in row.values.iter().enumerate() {
                                 if i > 0 {
                                     let _ = self.writer.write(b"|");
@@ -518,14 +518,14 @@ impl Limbo {
                             }
                             let _ = self.writeln("");
                         }
-                        Ok(RowResult::IO) => {
+                        Ok(StepResult::IO) => {
                             self.io.run_once()?;
                         }
-                        Ok(RowResult::Interrupt) => break,
-                        Ok(RowResult::Done) => {
+                        Ok(StepResult::Interrupt) => break,
+                        Ok(StepResult::Done) => {
                             break;
                         }
-                        Ok(RowResult::Busy) => {
+                        Ok(StepResult::Busy) => {
                             self.writeln("database is busy");
                             break;
                         }
@@ -543,7 +543,7 @@ impl Limbo {
                     let mut table_rows: Vec<Vec<_>> = vec![];
                     loop {
                         match rows.next_row() {
-                            Ok(RowResult::Row(row)) => {
+                            Ok(StepResult::Row(row)) => {
                                 table_rows.push(
                                     row.values
                                         .iter()
@@ -559,12 +559,12 @@ impl Limbo {
                                         .collect(),
                                 );
                             }
-                            Ok(RowResult::IO) => {
+                            Ok(StepResult::IO) => {
                                 self.io.run_once()?;
                             }
-                            Ok(RowResult::Interrupt) => break,
-                            Ok(RowResult::Done) => break,
-                            Ok(RowResult::Busy) => {
+                            Ok(StepResult::Interrupt) => break,
+                            Ok(StepResult::Done) => break,
+                            Ok(StepResult::Busy) => {
                                 self.writeln("database is busy");
                                 break;
                             }
@@ -607,18 +607,18 @@ impl Limbo {
                 let mut found = false;
                 loop {
                     match rows.next_row()? {
-                        RowResult::Row(row) => {
+                        StepResult::Row(row) => {
                             if let Some(Value::Text(schema)) = row.values.first() {
                                 let _ = self.write_fmt(format_args!("{};", schema));
                                 found = true;
                             }
                         }
-                        RowResult::IO => {
+                        StepResult::IO => {
                             self.io.run_once()?;
                         }
-                        RowResult::Interrupt => break,
-                        RowResult::Done => break,
-                        RowResult::Busy => {
+                        StepResult::Interrupt => break,
+                        StepResult::Done => break,
+                        StepResult::Busy => {
                             self.writeln("database is busy");
                             break;
                         }
@@ -664,18 +664,18 @@ impl Limbo {
                 let mut tables = String::new();
                 loop {
                     match rows.next_row()? {
-                        RowResult::Row(row) => {
+                        StepResult::Row(row) => {
                             if let Some(Value::Text(table)) = row.values.first() {
                                 tables.push_str(table);
                                 tables.push(' ');
                             }
                         }
-                        RowResult::IO => {
+                        StepResult::IO => {
                             self.io.run_once()?;
                         }
-                        RowResult::Interrupt => break,
-                        RowResult::Done => break,
-                        RowResult::Busy => {
+                        StepResult::Interrupt => break,
+                        StepResult::Done => break,
+                        StepResult::Busy => {
                             self.writeln("database is busy");
                             break;
                         }

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -40,19 +40,19 @@ fn limbo_bench(criterion: &mut Criterion) {
         b.iter(|| {
             let mut rows = stmt.query().unwrap();
             match rows.next_row().unwrap() {
-                limbo_core::RowResult::Row(row) => {
+                limbo_core::StepResult::Row(row) => {
                     assert_eq!(row.get::<i64>(0).unwrap(), 1);
                 }
-                limbo_core::RowResult::IO => {
+                limbo_core::StepResult::IO => {
                     io.run_once().unwrap();
                 }
-                limbo_core::RowResult::Interrupt => {
+                limbo_core::StepResult::Interrupt => {
                     unreachable!();
                 }
-                limbo_core::RowResult::Done => {
+                limbo_core::StepResult::Done => {
                     unreachable!();
                 }
-                limbo_core::RowResult::Busy => {
+                limbo_core::StepResult::Busy => {
                     unreachable!();
                 }
             }
@@ -68,19 +68,19 @@ fn limbo_bench(criterion: &mut Criterion) {
             b.iter(|| {
                 let mut rows = stmt.query().unwrap();
                 match rows.next_row().unwrap() {
-                    limbo_core::RowResult::Row(row) => {
+                    limbo_core::StepResult::Row(row) => {
                         assert_eq!(row.get::<i64>(0).unwrap(), 1);
                     }
-                    limbo_core::RowResult::IO => {
+                    limbo_core::StepResult::IO => {
                         io.run_once().unwrap();
                     }
-                    limbo_core::RowResult::Interrupt => {
+                    limbo_core::StepResult::Interrupt => {
                         unreachable!();
                     }
-                    limbo_core::RowResult::Done => {
+                    limbo_core::StepResult::Done => {
                         unreachable!();
                     }
-                    limbo_core::RowResult::Busy => {
+                    limbo_core::StepResult::Busy => {
                         unreachable!()
                     }
                 }
@@ -97,19 +97,19 @@ fn limbo_bench(criterion: &mut Criterion) {
             b.iter(|| {
                 let mut rows = stmt.query().unwrap();
                 match rows.next_row().unwrap() {
-                    limbo_core::RowResult::Row(row) => {
+                    limbo_core::StepResult::Row(row) => {
                         assert_eq!(row.get::<i64>(0).unwrap(), 1);
                     }
-                    limbo_core::RowResult::IO => {
+                    limbo_core::StepResult::IO => {
                         io.run_once().unwrap();
                     }
-                    limbo_core::RowResult::Interrupt => {
+                    limbo_core::StepResult::Interrupt => {
                         unreachable!();
                     }
-                    limbo_core::RowResult::Done => {
+                    limbo_core::StepResult::Done => {
                         unreachable!();
                     }
-                    limbo_core::RowResult::Busy => {
+                    limbo_core::StepResult::Busy => {
                         unreachable!()
                     }
                 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -374,14 +374,14 @@ impl Statement {
         self.state.interrupt();
     }
 
-    pub fn step(&mut self) -> Result<RowResult<'_>> {
+    pub fn step(&mut self) -> Result<StepResult<'_>> {
         let result = self.program.step(&mut self.state, self.pager.clone())?;
         match result {
-            vdbe::StepResult::Row(row) => Ok(RowResult::Row(Row { values: row.values })),
-            vdbe::StepResult::IO => Ok(RowResult::IO),
-            vdbe::StepResult::Done => Ok(RowResult::Done),
-            vdbe::StepResult::Interrupt => Ok(RowResult::Interrupt),
-            vdbe::StepResult::Busy => Ok(RowResult::Busy),
+            vdbe::StepResult::Row(row) => Ok(StepResult::Row(Row { values: row.values })),
+            vdbe::StepResult::IO => Ok(StepResult::IO),
+            vdbe::StepResult::Done => Ok(StepResult::Done),
+            vdbe::StepResult::Interrupt => Ok(StepResult::Interrupt),
+            vdbe::StepResult::Busy => Ok(StepResult::Busy),
         }
     }
 
@@ -393,7 +393,7 @@ impl Statement {
     pub fn reset(&self) {}
 }
 
-pub enum RowResult<'a> {
+pub enum StepResult<'a> {
     Row(Row<'a>),
     IO,
     Done,
@@ -421,7 +421,7 @@ impl Rows {
         Self { stmt }
     }
 
-    pub fn next_row(&mut self) -> Result<RowResult<'_>> {
+    pub fn next_row(&mut self) -> Result<StepResult<'_>> {
         self.stmt.step()
     }
 }

--- a/core/util.rs
+++ b/core/util.rs
@@ -4,7 +4,7 @@ use sqlite3_parser::ast::{Expr, FunctionTail, Literal};
 
 use crate::{
     schema::{self, Schema},
-    Result, RowResult, Rows, IO,
+    Result, Rows, StepResult, IO,
 };
 
 // https://sqlite.org/lang_keywords.html
@@ -27,7 +27,7 @@ pub fn parse_schema_rows(rows: Option<Rows>, schema: &mut Schema, io: Arc<dyn IO
     if let Some(mut rows) = rows {
         loop {
             match rows.next_row()? {
-                RowResult::Row(row) => {
+                StepResult::Row(row) => {
                     let ty = row.get::<&str>(0)?;
                     if ty != "table" && ty != "index" {
                         continue;
@@ -53,14 +53,14 @@ pub fn parse_schema_rows(rows: Option<Rows>, schema: &mut Schema, io: Arc<dyn IO
                         _ => continue,
                     }
                 }
-                RowResult::IO => {
+                StepResult::IO => {
                     // TODO: How do we ensure that the I/O we submitted to
                     // read the schema is actually complete?
                     io.run_once()?;
                 }
-                RowResult::Interrupt => break,
-                RowResult::Done => break,
-                RowResult::Busy => break,
+                StepResult::Interrupt => break,
+                StepResult::Done => break,
+                StepResult::Busy => break,
             }
         }
     }

--- a/perf/latency/limbo/src/main.rs
+++ b/perf/latency/limbo/src/main.rs
@@ -38,11 +38,11 @@ fn main() {
                     loop {
                         let row = rows.next_row().unwrap();
                         match row {
-                            limbo_core::RowResult::Row(_) => {
+                            limbo_core::StepResult::Row(_) => {
                                 count += 1;
                             }
-                            limbo_core::RowResult::IO => yield,
-                            limbo_core::RowResult::Done => break,
+                            limbo_core::StepResult::IO => yield,
+                            limbo_core::StepResult::Done => break,
                         }
                     }
                     assert!(count == 100);

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, rc::Rc};
 
-use limbo_core::{Connection, Result, RowResult};
+use limbo_core::{Connection, Result, StepResult};
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
@@ -215,7 +215,7 @@ impl Interaction {
                 let mut out = Vec::new();
                 while let Ok(row) = rows.next_row() {
                     match row {
-                        RowResult::Row(row) => {
+                        StepResult::Row(row) => {
                             let mut r = Vec::new();
                             for el in &row.values {
                                 let v = match el {
@@ -230,12 +230,12 @@ impl Interaction {
 
                             out.push(r);
                         }
-                        RowResult::IO => {}
-                        RowResult::Interrupt => {}
-                        RowResult::Done => {
+                        StepResult::IO => {}
+                        StepResult::Interrupt => {}
+                        StepResult::Done => {
                             break;
                         }
-                        RowResult::Busy => {}
+                        StepResult::Busy => {}
                     }
                 }
 

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use generation::plan::{Interaction, InteractionPlan, ResultSet};
 use generation::{pick_index, ArbitraryFrom};
-use limbo_core::{Connection, Database, Result, RowResult, IO};
+use limbo_core::{Connection, Database, Result, StepResult, IO};
 use model::table::Value;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -239,14 +239,14 @@ pub unsafe extern "C" fn sqlite3_step(stmt: *mut sqlite3_stmt) -> std::ffi::c_in
     let stmt = &mut *stmt;
     if let Ok(result) = stmt.stmt.step() {
         match result {
-            limbo_core::RowResult::IO => SQLITE_BUSY,
-            limbo_core::RowResult::Done => SQLITE_DONE,
-            limbo_core::RowResult::Interrupt => SQLITE_INTERRUPT,
-            limbo_core::RowResult::Row(row) => {
+            limbo_core::StepResult::IO => SQLITE_BUSY,
+            limbo_core::StepResult::Done => SQLITE_DONE,
+            limbo_core::StepResult::Interrupt => SQLITE_INTERRUPT,
+            limbo_core::StepResult::Row(row) => {
                 stmt.row.replace(Some(row));
                 SQLITE_ROW
             }
-            limbo_core::RowResult::Busy => SQLITE_BUSY,
+            limbo_core::StepResult::Busy => SQLITE_BUSY,
         }
     } else {
         SQLITE_ERROR

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -40,7 +40,7 @@ impl TempDatabase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use limbo_core::{CheckpointStatus, Connection, RowResult, Value};
+    use limbo_core::{CheckpointStatus, Connection, StepResult, Value};
     use log::debug;
 
     #[ignore]
@@ -63,10 +63,10 @@ mod tests {
             match conn.query(insert_query) {
                 Ok(Some(ref mut rows)) => loop {
                     match rows.next_row()? {
-                        RowResult::IO => {
+                        StepResult::IO => {
                             tmp_db.io.run_once()?;
                         }
-                        RowResult::Done => break,
+                        StepResult::Done => break,
                         _ => unreachable!(),
                     }
                 },
@@ -80,7 +80,7 @@ mod tests {
             match conn.query(list_query) {
                 Ok(Some(ref mut rows)) => loop {
                     match rows.next_row()? {
-                        RowResult::Row(row) => {
+                        StepResult::Row(row) => {
                             let first_value = row.values.first().expect("missing id");
                             let id = match first_value {
                                 Value::Integer(i) => *i as i32,
@@ -90,12 +90,12 @@ mod tests {
                             assert_eq!(current_read_index, id);
                             current_read_index += 1;
                         }
-                        RowResult::IO => {
+                        StepResult::IO => {
                             tmp_db.io.run_once()?;
                         }
-                        RowResult::Interrupt => break,
-                        RowResult::Done => break,
-                        RowResult::Busy => {
+                        StepResult::Interrupt => break,
+                        StepResult::Done => break,
+                        StepResult::Busy => {
                             panic!("Database is busy");
                         }
                     }
@@ -127,10 +127,10 @@ mod tests {
         match conn.query(insert_query) {
             Ok(Some(ref mut rows)) => loop {
                 match rows.next_row()? {
-                    RowResult::IO => {
+                    StepResult::IO => {
                         tmp_db.io.run_once()?;
                     }
-                    RowResult::Done => break,
+                    StepResult::Done => break,
                     _ => unreachable!(),
                 }
             },
@@ -146,7 +146,7 @@ mod tests {
         match conn.query(list_query) {
             Ok(Some(ref mut rows)) => loop {
                 match rows.next_row()? {
-                    RowResult::Row(row) => {
+                    StepResult::Row(row) => {
                         let first_value = &row.values[0];
                         let text = &row.values[1];
                         let id = match first_value {
@@ -161,12 +161,12 @@ mod tests {
                         assert_eq!(1, id);
                         compare_string(&huge_text, text);
                     }
-                    RowResult::IO => {
+                    StepResult::IO => {
                         tmp_db.io.run_once()?;
                     }
-                    RowResult::Interrupt => break,
-                    RowResult::Done => break,
-                    RowResult::Busy => unreachable!(),
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => unreachable!(),
                 }
             },
             Ok(None) => {}
@@ -200,10 +200,10 @@ mod tests {
             match conn.query(insert_query) {
                 Ok(Some(ref mut rows)) => loop {
                     match rows.next_row()? {
-                        RowResult::IO => {
+                        StepResult::IO => {
                             tmp_db.io.run_once()?;
                         }
-                        RowResult::Done => break,
+                        StepResult::Done => break,
                         _ => unreachable!(),
                     }
                 },
@@ -219,7 +219,7 @@ mod tests {
         match conn.query(list_query) {
             Ok(Some(ref mut rows)) => loop {
                 match rows.next_row()? {
-                    RowResult::Row(row) => {
+                    StepResult::Row(row) => {
                         let first_value = &row.values[0];
                         let text = &row.values[1];
                         let id = match first_value {
@@ -236,12 +236,12 @@ mod tests {
                         compare_string(huge_text, text);
                         current_index += 1;
                     }
-                    RowResult::IO => {
+                    StepResult::IO => {
                         tmp_db.io.run_once()?;
                     }
-                    RowResult::Interrupt => break,
-                    RowResult::Done => break,
-                    RowResult::Busy => unreachable!(),
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => unreachable!(),
                 }
             },
             Ok(None) => {}
@@ -269,10 +269,10 @@ mod tests {
             match conn.query(insert_query) {
                 Ok(Some(ref mut rows)) => loop {
                     match rows.next_row()? {
-                        RowResult::IO => {
+                        StepResult::IO => {
                             tmp_db.io.run_once()?;
                         }
-                        RowResult::Done => break,
+                        StepResult::Done => break,
                         _ => unreachable!(),
                     }
                 },
@@ -290,7 +290,7 @@ mod tests {
         match conn.query(list_query) {
             Ok(Some(ref mut rows)) => loop {
                 match rows.next_row()? {
-                    RowResult::Row(row) => {
+                    StepResult::Row(row) => {
                         let first_value = &row.values[0];
                         let id = match first_value {
                             Value::Integer(i) => *i as i32,
@@ -300,12 +300,12 @@ mod tests {
                         assert_eq!(current_index, id as usize);
                         current_index += 1;
                     }
-                    RowResult::IO => {
+                    StepResult::IO => {
                         tmp_db.io.run_once()?;
                     }
-                    RowResult::Interrupt => break,
-                    RowResult::Done => break,
-                    RowResult::Busy => unreachable!(),
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => unreachable!(),
                 }
             },
             Ok(None) => {}
@@ -329,10 +329,10 @@ mod tests {
             match conn.query(insert_query) {
                 Ok(Some(ref mut rows)) => loop {
                     match rows.next_row()? {
-                        RowResult::IO => {
+                        StepResult::IO => {
                             tmp_db.io.run_once()?;
                         }
-                        RowResult::Done => break,
+                        StepResult::Done => break,
                         _ => unreachable!(),
                     }
                 },
@@ -353,7 +353,7 @@ mod tests {
                 if let Some(ref mut rows) = conn.query(list_query).unwrap() {
                     loop {
                         match rows.next_row()? {
-                            RowResult::Row(row) => {
+                            StepResult::Row(row) => {
                                 let first_value = &row.values[0];
                                 let count = match first_value {
                                     Value::Integer(i) => *i as i32,
@@ -362,12 +362,12 @@ mod tests {
                                 log::debug!("counted {}", count);
                                 return Ok(count as usize);
                             }
-                            RowResult::IO => {
+                            StepResult::IO => {
                                 tmp_db.io.run_once()?;
                             }
-                            RowResult::Interrupt => break,
-                            RowResult::Done => break,
-                            RowResult::Busy => panic!("Database is busy"),
+                            StepResult::Interrupt => break,
+                            StepResult::Done => break,
+                            StepResult::Busy => panic!("Database is busy"),
                         }
                     }
                 }
@@ -436,10 +436,10 @@ mod tests {
         if let Some(ref mut rows) = insert_query {
             loop {
                 match rows.next_row()? {
-                    RowResult::IO => {
+                    StepResult::IO => {
                         tmp_db.io.run_once()?;
                     }
-                    RowResult::Done => break,
+                    StepResult::Done => break,
                     _ => unreachable!(),
                 }
             }
@@ -450,17 +450,17 @@ mod tests {
         if let Some(ref mut rows) = select_query {
             loop {
                 match rows.next_row()? {
-                    RowResult::Row(row) => {
+                    StepResult::Row(row) => {
                         if let Value::Integer(id) = row.values[0] {
                             assert_eq!(id, 1, "First insert should have rowid 1");
                         }
                     }
-                    RowResult::IO => {
+                    StepResult::IO => {
                         tmp_db.io.run_once()?;
                     }
-                    RowResult::Interrupt => break,
-                    RowResult::Done => break,
-                    RowResult::Busy => panic!("Database is busy"),
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => panic!("Database is busy"),
                 }
             }
         }
@@ -469,10 +469,10 @@ mod tests {
         match conn.query("INSERT INTO test_rowid (id, val) VALUES (5, 'test2')") {
             Ok(Some(ref mut rows)) => loop {
                 match rows.next_row()? {
-                    RowResult::IO => {
+                    StepResult::IO => {
                         tmp_db.io.run_once()?;
                     }
-                    RowResult::Done => break,
+                    StepResult::Done => break,
                     _ => unreachable!(),
                 }
             },
@@ -485,17 +485,17 @@ mod tests {
         match conn.query("SELECT last_insert_rowid()") {
             Ok(Some(ref mut rows)) => loop {
                 match rows.next_row()? {
-                    RowResult::Row(row) => {
+                    StepResult::Row(row) => {
                         if let Value::Integer(id) = row.values[0] {
                             last_id = id;
                         }
                     }
-                    RowResult::IO => {
+                    StepResult::IO => {
                         tmp_db.io.run_once()?;
                     }
-                    RowResult::Interrupt => break,
-                    RowResult::Done => break,
-                    RowResult::Busy => panic!("Database is busy"),
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => panic!("Database is busy"),
                 }
             },
             Ok(None) => {}


### PR DESCRIPTION
The name "row result" is confusing because it really *is* a result from a step() call. The only difference is how a row is represented as we return from VDBE or from a statement.

Therefore, rename RowResult to StepResult.