### PR TITLE
Fix `sqlite_version()` out of bound panics

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1555,7 +1555,7 @@ pub fn translate_expr(
                             program.emit_insn(Insn::Copy {
                                 src_reg: output_register,
                                 dst_reg: target_register,
-                                amount: 1,
+                                amount: 0,
                             });
                             Ok(target_register)
                         }

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -809,6 +809,10 @@ do_execsql_test cast-small-float-to-numeric {
   SELECT typeof(CAST('1.23' AS NUMERIC)), CAST('1.23' AS NUMERIC);
 } {real|1.23}
 
+do_execsql_test_regex sqlite-version-should-return-valid-output {
+  SELECT sqlite_version();
+} {\d+\.\d+\.\d+}
+
 # TODO COMPAT: sqlite returns 9.22337203685478e+18, do we care...?
 # do_execsql_test cast-large-text-to-numeric {
 #   SELECT typeof(CAST('9223372036854775808' AS NUMERIC)), CAST('9223372036854775808' AS NUMERIC);

--- a/testing/tester.tcl
+++ b/testing/tester.tcl
@@ -26,6 +26,23 @@ proc do_execsql_test {test_name sql_statements expected_outputs} {
     }
 }
 
+proc do_execsql_test_regex {test_name sql_statements expected_regex} {
+    foreach db $::test_dbs {
+        puts [format "(%s) %s Running test: %s" $db [string repeat " " [expr {40 - [string length $db]}]] $test_name]
+        set combined_sql [string trim $sql_statements]
+        set actual_output [evaluate_sql $::sqlite_exec $db $combined_sql]
+
+        # Validate the actual output against the regular expression
+        if {![regexp $expected_regex $actual_output]} {
+            puts "Test FAILED: '$sql_statements'"
+            puts "returned '$actual_output'"
+            puts "expected to match regex '$expected_regex'"
+            exit 1
+        }
+    }
+}
+
+
 proc do_execsql_test_on_specific_db {db_name test_name sql_statements expected_outputs} {
     puts [format "(%s) %s Running test: %s" $db_name [string repeat " " [expr {40 - [string length $db_name]}]] $test_name]
     set combined_sql [string trim $sql_statements]


### PR DESCRIPTION
#560 

Changes to `translate_expr` function:

* [`core/translate/expr.rs`](diffhunk://#diff-371865d5d7b8bcaed649413c687492e61e94f21387cd9b2c47d989a033888c8bL1558-R1560): Changed the `amount` parameter in the `Insn::Copy` instruction from `1` to `0`.

Enhancements to the testing framework:

* [`testing/scalar-functions.test`](diffhunk://#diff-a046d58ab24eee8207f0ce3199f8d0a609edcef9c24b8ed7f242f7a60e6c1e61R812-R815): Added a new test `do_execsql_test_regex` to validate that the `sqlite_version` function returns a valid output.
* [`testing/tester.tcl`](diffhunk://#diff-316cca92d85df3f78558cc3e60d7420c1fd19a23ecf2bbea534db93ab08ea3ecR29-R45): Introduced a new procedure `do_execsql_test_regex` to support regex-based validation of SQL outputs.