### PR TITLE
Support uncorrelated FROM clause subqueries

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -298,8 +298,8 @@ impl Connection {
                 Cmd::ExplainQueryPlan(stmt) => {
                     match stmt {
                         ast::Stmt::Select(select) => {
-                            let plan = prepare_select_plan(&self.schema.borrow(), select)?;
-                            let plan = optimize_plan(plan)?;
+                            let mut plan = prepare_select_plan(&self.schema.borrow(), select)?;
+                            optimize_plan(&mut plan)?;
                             println!("{}", plan);
                         }
                         _ => todo!(),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -250,7 +250,7 @@ impl Connection {
                         self.header.clone(),
                         self.pager.clone(),
                         Rc::downgrade(self),
-                        &syms,
+                        syms,
                     )?);
                     Ok(Statement::new(program, self.pager.clone()))
                 }
@@ -278,7 +278,7 @@ impl Connection {
                         self.header.clone(),
                         self.pager.clone(),
                         Rc::downgrade(self),
-                        &syms,
+                        syms,
                     )?);
                     let stmt = Statement::new(program, self.pager.clone());
                     Ok(Some(Rows { stmt }))
@@ -290,7 +290,7 @@ impl Connection {
                         self.header.clone(),
                         self.pager.clone(),
                         Rc::downgrade(self),
-                        &syms,
+                        syms,
                     )?;
                     program.explain();
                     Ok(None)
@@ -327,7 +327,7 @@ impl Connection {
                         self.header.clone(),
                         self.pager.clone(),
                         Rc::downgrade(self),
-                        &syms,
+                        syms,
                     )?;
                     program.explain();
                 }
@@ -339,7 +339,7 @@ impl Connection {
                         self.header.clone(),
                         self.pager.clone(),
                         Rc::downgrade(self),
-                        &syms,
+                        syms,
                     )?;
                     let mut state = vdbe::ProgramState::new(program.max_registers);
                     program.step(&mut state, self.pager.clone())?;

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -71,6 +71,14 @@ impl Table {
         }
     }
 
+    pub fn get_root_page(&self) -> usize {
+        match self {
+            Table::BTree(table) => table.root_page,
+            Table::Index(_) => unimplemented!(),
+            Table::Pseudo(_) => unimplemented!(),
+        }
+    }
+
     pub fn get_name(&self) -> &str {
         match self {
             Self::BTree(table) => &table.name,
@@ -209,6 +217,10 @@ pub struct PseudoTable {
 impl PseudoTable {
     pub fn new() -> Self {
         Self { columns: vec![] }
+    }
+
+    pub fn new_with_columns(columns: Vec<Column>) -> Self {
+        Self { columns }
     }
 
     pub fn add_column(&mut self, name: &str, ty: Type, primary_key: bool) {

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -1,12 +1,15 @@
+use crate::schema::Table;
 use crate::translate::emitter::emit_program;
 use crate::translate::optimizer::optimize_plan;
-use crate::translate::plan::{BTreeTableReference, DeletePlan, Plan, SourceOperator};
+use crate::translate::plan::{DeletePlan, Plan, SourceOperator};
 use crate::translate::planner::{parse_limit, parse_where};
 use crate::{schema::Schema, storage::sqlite3_ondisk::DatabaseHeader, vdbe::Program};
 use crate::{Connection, Result, SymbolTable};
 use sqlite3_parser::ast::{Expr, Limit, QualifiedName};
 use std::rc::Weak;
 use std::{cell::RefCell, rc::Rc};
+
+use super::plan::{TableReference, TableReferenceType};
 
 pub fn translate_delete(
     schema: &Schema,
@@ -17,9 +20,9 @@ pub fn translate_delete(
     connection: Weak<Connection>,
     syms: &SymbolTable,
 ) -> Result<Program> {
-    let delete_plan = prepare_delete_plan(schema, tbl_name, where_clause, limit)?;
-    let optimized_plan = optimize_plan(delete_plan)?;
-    emit_program(database_header, optimized_plan, connection, syms)
+    let mut delete_plan = prepare_delete_plan(schema, tbl_name, where_clause, limit)?;
+    optimize_plan(&mut delete_plan)?;
+    emit_program(database_header, delete_plan, connection, syms)
 }
 
 pub fn prepare_delete_plan(
@@ -33,15 +36,16 @@ pub fn prepare_delete_plan(
         None => crate::bail_corrupt_error!("Parse error: no such table: {}", tbl_name),
     };
 
-    let table_ref = BTreeTableReference {
-        table: table.clone(),
+    let btree_table_ref = TableReference {
+        table: Table::BTree(table.clone()),
         table_identifier: table.name.clone(),
         table_index: 0,
+        reference_type: TableReferenceType::BTreeTable,
     };
-    let referenced_tables = vec![table_ref.clone()];
+    let referenced_tables = vec![btree_table_ref.clone()];
 
     // Parse the WHERE clause
-    let resolved_where_clauses = parse_where(where_clause, &[table_ref.clone()])?;
+    let resolved_where_clauses = parse_where(where_clause, &referenced_tables)?;
 
     // Parse the LIMIT clause
     let resolved_limit = limit.and_then(parse_limit);
@@ -49,7 +53,7 @@ pub fn prepare_delete_plan(
     let plan = DeletePlan {
         source: SourceOperator::Scan {
             id: 0,
-            table_reference: table_ref.clone(),
+            table_reference: btree_table_ref,
             predicates: resolved_where_clauses.clone(),
             iter_dir: None,
         },

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -90,10 +90,7 @@ pub struct LoopLabels {
 /// generation process.
 #[derive(Debug)]
 pub struct Metadata {
-    // labels for the instructions that either:
-    // - jump to the start of the current loop. (e.g. a Next instruction jumps here)
-    // - jump to the Next instruction (or equivalent) in the current operator. (e.g. a condition evaluates to false, so the current row is skipped)
-    // - jump to the end of the current loop. (e.g. an index seek results in no key matching the seek condition, so execution will jump to the end of the loop)
+    // A typical query plan is a nested loop. Each loop has its own LoopLabels (see the definition of LoopLabels for more details)
     loop_labels: HashMap<usize, LoopLabels>,
     // label for the instruction that jumps to the next phase of the query after the main loop
     // we don't know ahead of time what that is (GROUP BY, ORDER BY, etc.)

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -129,7 +129,6 @@ pub enum OperationMode {
 fn prologue() -> Result<(ProgramBuilder, Metadata, BranchOffset, BranchOffset)> {
     let mut program = ProgramBuilder::new();
     let init_label = program.allocate_label();
-    let halt_label = program.allocate_label();
 
     program.emit_insn_with_label_dependency(
         Insn::Init {
@@ -1414,7 +1413,6 @@ fn close_loop(
             close_loop(program, left, metadata)?;
         }
         SourceOperator::Scan {
-            id,
             table_reference,
             iter_dir,
             ..
@@ -1451,7 +1449,6 @@ fn close_loop(
             }
         }
         SourceOperator::Search {
-            id,
             table_reference,
             search,
             ..

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -211,7 +211,7 @@ fn use_indexes(
             use_indexes(right, referenced_tables, available_indexes)?;
             Ok(())
         }
-        SourceOperator::Nothing => Ok(()),
+        SourceOperator::Nothing { .. } => Ok(()),
     }
 }
 
@@ -335,7 +335,7 @@ fn eliminate_constants(
 
             Ok(ConstantConditionEliminationResult::Continue)
         }
-        SourceOperator::Nothing => Ok(ConstantConditionEliminationResult::Continue),
+        SourceOperator::Nothing { .. } => Ok(ConstantConditionEliminationResult::Continue),
     }
 }
 
@@ -430,7 +430,7 @@ fn push_predicates(
         // Base cases - nowhere else to push to
         SourceOperator::Scan { .. } => Ok(()),
         SourceOperator::Search { .. } => Ok(()),
-        SourceOperator::Nothing => Ok(()),
+        SourceOperator::Nothing { .. } => Ok(()),
     }
 }
 
@@ -585,7 +585,7 @@ fn push_predicate(
 
             Ok(None)
         }
-        SourceOperator::Nothing => Ok(Some(predicate)),
+        SourceOperator::Nothing { .. } => Ok(Some(predicate)),
     }
 }
 
@@ -1016,11 +1016,5 @@ trait TakeOwnership {
 impl TakeOwnership for ast::Expr {
     fn take_ownership(&mut self) -> Self {
         std::mem::replace(self, ast::Expr::Literal(ast::Literal::Null))
-    }
-}
-
-impl TakeOwnership for SourceOperator {
-    fn take_ownership(&mut self) -> Self {
-        std::mem::replace(self, Self::Nothing)
     }
 }

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -5,14 +5,15 @@ use sqlite3_parser::ast;
 use crate::{schema::Index, Result};
 
 use super::plan::{
-    get_table_ref_bitmask_for_ast_expr, get_table_ref_bitmask_for_operator, BTreeTableReference,
-    DeletePlan, Direction, IterationDirection, Plan, Search, SelectPlan, SourceOperator,
+    get_table_ref_bitmask_for_ast_expr, get_table_ref_bitmask_for_operator, DeletePlan, Direction,
+    IterationDirection, Plan, Search, SelectPlan, SourceOperator, TableReference,
+    TableReferenceType,
 };
 
-pub fn optimize_plan(plan: Plan) -> Result<Plan> {
+pub fn optimize_plan(plan: &mut Plan) -> Result<()> {
     match plan {
-        Plan::Select(plan) => optimize_select_plan(plan).map(Plan::Select),
-        Plan::Delete(plan) => optimize_delete_plan(plan).map(Plan::Delete),
+        Plan::Select(plan) => optimize_select_plan(plan),
+        Plan::Delete(plan) => optimize_delete_plan(plan),
     }
 }
 
@@ -21,13 +22,14 @@ pub fn optimize_plan(plan: Plan) -> Result<Plan> {
  * TODO: these could probably be done in less passes,
  * but having them separate makes them easier to understand
  */
-fn optimize_select_plan(mut plan: SelectPlan) -> Result<SelectPlan> {
+fn optimize_select_plan(plan: &mut SelectPlan) -> Result<()> {
+    optimize_subqueries(&mut plan.source)?;
     eliminate_between(&mut plan.source, &mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constants(&mut plan.source, &mut plan.where_clause)?
     {
         plan.contains_constant_false_condition = true;
-        return Ok(plan);
+        return Ok(());
     }
 
     push_predicates(
@@ -49,16 +51,16 @@ fn optimize_select_plan(mut plan: SelectPlan) -> Result<SelectPlan> {
         &plan.available_indexes,
     )?;
 
-    Ok(plan)
+    Ok(())
 }
 
-fn optimize_delete_plan(mut plan: DeletePlan) -> Result<DeletePlan> {
+fn optimize_delete_plan(plan: &mut DeletePlan) -> Result<()> {
     eliminate_between(&mut plan.source, &mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constants(&mut plan.source, &mut plan.where_clause)?
     {
         plan.contains_constant_false_condition = true;
-        return Ok(plan);
+        return Ok(());
     }
 
     use_indexes(
@@ -67,13 +69,28 @@ fn optimize_delete_plan(mut plan: DeletePlan) -> Result<DeletePlan> {
         &plan.available_indexes,
     )?;
 
-    Ok(plan)
+    Ok(())
+}
+
+fn optimize_subqueries(operator: &mut SourceOperator) -> Result<()> {
+    match operator {
+        SourceOperator::Subquery { plan, .. } => {
+            optimize_select_plan(&mut *plan)?;
+            Ok(())
+        }
+        SourceOperator::Join { left, right, .. } => {
+            optimize_subqueries(left)?;
+            optimize_subqueries(right)?;
+            Ok(())
+        }
+        _ => Ok(()),
+    }
 }
 
 fn _operator_is_already_ordered_by(
     operator: &mut SourceOperator,
     key: &mut ast::Expr,
-    referenced_tables: &[BTreeTableReference],
+    referenced_tables: &[TableReference],
     available_indexes: &Vec<Rc<Index>>,
 ) -> Result<bool> {
     match operator {
@@ -109,7 +126,7 @@ fn _operator_is_already_ordered_by(
 fn eliminate_unnecessary_orderby(
     operator: &mut SourceOperator,
     order_by: &mut Option<Vec<(ast::Expr, Direction)>>,
-    referenced_tables: &[BTreeTableReference],
+    referenced_tables: &[TableReference],
     available_indexes: &Vec<Rc<Index>>,
 ) -> Result<()> {
     if order_by.is_none() {
@@ -141,10 +158,11 @@ fn eliminate_unnecessary_orderby(
  */
 fn use_indexes(
     operator: &mut SourceOperator,
-    referenced_tables: &[BTreeTableReference],
+    referenced_tables: &[TableReference],
     available_indexes: &[Rc<Index>],
 ) -> Result<()> {
     match operator {
+        SourceOperator::Subquery { .. } => Ok(()),
         SourceOperator::Search { .. } => Ok(()),
         SourceOperator::Scan {
             table_reference,
@@ -161,10 +179,7 @@ fn use_indexes(
                 let f = fs[i].take_ownership();
                 let table_index = referenced_tables
                     .iter()
-                    .position(|t| {
-                        Rc::ptr_eq(&t.table, &table_reference.table)
-                            && t.table_identifier == table_reference.table_identifier
-                    })
+                    .position(|t| t.table_identifier == table_reference.table_identifier)
                     .unwrap();
                 match try_extract_index_search_expression(
                     f,
@@ -229,6 +244,7 @@ fn eliminate_constants(
         }
     }
     match operator {
+        SourceOperator::Subquery { .. } => Ok(ConstantConditionEliminationResult::Continue),
         SourceOperator::Join {
             left,
             right,
@@ -334,7 +350,7 @@ fn eliminate_constants(
 fn push_predicates(
     operator: &mut SourceOperator,
     where_clause: &mut Option<Vec<ast::Expr>>,
-    referenced_tables: &Vec<BTreeTableReference>,
+    referenced_tables: &Vec<TableReference>,
 ) -> Result<()> {
     // First try to push down any predicates from the WHERE clause
     if let Some(predicates) = where_clause {
@@ -357,6 +373,7 @@ fn push_predicates(
     }
 
     match operator {
+        SourceOperator::Subquery { .. } => Ok(()),
         SourceOperator::Join {
             left,
             right,
@@ -424,9 +441,64 @@ fn push_predicates(
 fn push_predicate(
     operator: &mut SourceOperator,
     predicate: ast::Expr,
-    referenced_tables: &Vec<BTreeTableReference>,
+    referenced_tables: &Vec<TableReference>,
 ) -> Result<Option<ast::Expr>> {
     match operator {
+        SourceOperator::Subquery {
+            predicates,
+            table_reference,
+            ..
+        } => {
+            // **TODO**: we are currently just evaluating the predicate after the subquery yields,
+            // and not trying to do anythign more sophisticated.
+            // E.g. literally: SELECT * FROM (SELECT * FROM t1) sub WHERE sub.col = 'foo'
+            //
+            // It is possible, and not overly difficult, to determine that we can also push the
+            // predicate into the subquery coroutine itself before it yields. The above query would
+            // effectively become: SELECT * FROM (SELECT * FROM t1 WHERE col = 'foo') sub
+            //
+            // This matters more in cases where the subquery builds some kind of sorter/index in memory
+            // (or on disk) and in those cases pushing the predicate down to the coroutine will make the
+            // subquery produce less intermediate data. In cases where no intermediate data structures are
+            // built, it doesn't matter.
+            //
+            // Moreover, in many cases the subquery can even be completely eliminated, e.g. the above original
+            // query would become: SELECT * FROM t1 WHERE col = 'foo' without the subquery.
+            // **END TODO**
+
+            // Find position of this subquery in referenced_tables array
+            let subquery_index = referenced_tables
+                .iter()
+                .position(|t| {
+                    t.table_identifier == table_reference.table_identifier
+                        && matches!(t.reference_type, TableReferenceType::Subquery { .. })
+                })
+                .unwrap();
+
+            // Get bitmask showing which tables this predicate references
+            let predicate_bitmask =
+                get_table_ref_bitmask_for_ast_expr(referenced_tables, &predicate)?;
+
+            // Each table has a bit position based on join order from left to right
+            // e.g. in SELECT * FROM t1 JOIN t2 JOIN t3
+            // t1 is position 0 (001), t2 is position 1 (010), t3 is position 2 (100)
+            // To push a predicate to a given table, it can only reference that table and tables to its left
+            // Example: For table t2 at position 1 (bit 010):
+            // - Can push: 011 (t2 + t1), 001 (just t1), 010 (just t2)
+            // - Can't push: 110 (t2 + t3)
+            let next_table_on_the_right_in_join_bitmask = 1 << (subquery_index + 1);
+            if predicate_bitmask >= next_table_on_the_right_in_join_bitmask {
+                return Ok(Some(predicate));
+            }
+
+            if predicates.is_none() {
+                predicates.replace(vec![predicate]);
+            } else {
+                predicates.as_mut().unwrap().push(predicate);
+            }
+
+            Ok(None)
+        }
         SourceOperator::Scan {
             predicates,
             table_reference,
@@ -435,7 +507,10 @@ fn push_predicate(
             // Find position of this table in referenced_tables array
             let table_index = referenced_tables
                 .iter()
-                .position(|t| t.table_identifier == table_reference.table_identifier)
+                .position(|t| {
+                    t.table_identifier == table_reference.table_identifier
+                        && t.reference_type == TableReferenceType::BTreeTable
+                })
                 .unwrap();
 
             // Get bitmask showing which tables this predicate references
@@ -595,7 +670,7 @@ pub trait Optimizable {
     fn check_index_scan(
         &mut self,
         table_index: usize,
-        referenced_tables: &[BTreeTableReference],
+        referenced_tables: &[TableReference],
         available_indexes: &[Rc<Index>],
     ) -> Result<Option<usize>>;
 }
@@ -614,7 +689,7 @@ impl Optimizable for ast::Expr {
     fn check_index_scan(
         &mut self,
         table_index: usize,
-        referenced_tables: &[BTreeTableReference],
+        referenced_tables: &[TableReference],
         available_indexes: &[Rc<Index>],
     ) -> Result<Option<usize>> {
         match self {
@@ -623,12 +698,9 @@ impl Optimizable for ast::Expr {
                     return Ok(None);
                 }
                 for (idx, index) in available_indexes.iter().enumerate() {
-                    if index.table_name == referenced_tables[*table].table.name {
-                        let column = referenced_tables[*table]
-                            .table
-                            .columns
-                            .get(*column)
-                            .unwrap();
+                    let table_ref = &referenced_tables[*table];
+                    if index.table_name == table_ref.table.get_name() {
+                        let column = table_ref.table.get_column_at(*column);
                         if index.columns.first().unwrap().name == column.name {
                             return Ok(Some(idx));
                         }
@@ -793,7 +865,7 @@ pub enum Either<T, U> {
 pub fn try_extract_index_search_expression(
     expr: ast::Expr,
     table_index: usize,
-    referenced_tables: &[BTreeTableReference],
+    referenced_tables: &[TableReference],
     available_indexes: &[Rc<Index>],
 ) -> Result<Either<ast::Expr, Search>> {
     match expr {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -167,7 +167,7 @@ impl SourceOperator {
                 .enumerate()
                 .map(|(i, col)| (table_reference.table_index, col, i))
                 .collect(),
-            SourceOperator::Nothing => Vec::new(),
+            SourceOperator::Nothing { .. } => Vec::new(),
         }
     }
 }
@@ -222,7 +222,9 @@ pub enum SourceOperator {
     // Nothing operator
     // This operator is used to represent an empty query.
     // e.g. SELECT * from foo WHERE 0 will eventually be optimized to Nothing.
-    Nothing,
+    Nothing {
+        id: usize,
+    },
 }
 
 /// The type of the table reference, either BTreeTable or Subquery
@@ -306,7 +308,7 @@ impl SourceOperator {
             SourceOperator::Scan { id, .. } => *id,
             SourceOperator::Search { id, .. } => *id,
             SourceOperator::Subquery { id, .. } => *id,
-            SourceOperator::Nothing => unreachable!(),
+            SourceOperator::Nothing { id } => *id,
         }
     }
 }
@@ -445,7 +447,7 @@ impl Display for SourceOperator {
                 SourceOperator::Subquery { plan, .. } => {
                     fmt_operator(&plan.source, f, level + 1, last)
                 }
-                SourceOperator::Nothing => Ok(()),
+                SourceOperator::Nothing { .. } => Ok(()),
             }
         }
         writeln!(f, "QUERY PLAN")?;
@@ -490,7 +492,7 @@ pub fn get_table_ref_bitmask_for_operator<'a>(
                     .unwrap();
         }
         SourceOperator::Subquery { .. } => {}
-        SourceOperator::Nothing => {}
+        SourceOperator::Nothing { .. } => {}
     }
     Ok(table_refs_mask)
 }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -324,7 +324,12 @@ pub fn parse_from(
     operator_id_counter: &mut OperatorIdCounter,
 ) -> Result<(SourceOperator, Vec<TableReference>)> {
     if from.as_ref().and_then(|f| f.select.as_ref()).is_none() {
-        return Ok((SourceOperator::Nothing, vec![]));
+        return Ok((
+            SourceOperator::Nothing {
+                id: operator_id_counter.get_next_id(),
+            },
+            vec![],
+        ));
     }
 
     let mut table_index = 0;

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -125,7 +125,7 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                                         plan.result_columns.push(ResultSetColumn {
                                             name: get_name(
                                                 maybe_alias.as_ref(),
-                                                &expr,
+                                                expr,
                                                 &plan.referenced_tables,
                                                 || format!("expr_{}", result_column_idx),
                                             ),
@@ -135,11 +135,11 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                                     }
                                     Ok(_) => {
                                         let contains_aggregates =
-                                            resolve_aggregates(&expr, &mut aggregate_expressions);
+                                            resolve_aggregates(expr, &mut aggregate_expressions);
                                         plan.result_columns.push(ResultSetColumn {
                                             name: get_name(
                                                 maybe_alias.as_ref(),
-                                                &expr,
+                                                expr,
                                                 &plan.referenced_tables,
                                                 || format!("expr_{}", result_column_idx),
                                             ),
@@ -169,7 +169,7 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                                     plan.result_columns.push(ResultSetColumn {
                                         name: get_name(
                                             maybe_alias.as_ref(),
-                                            &expr,
+                                            expr,
                                             &plan.referenced_tables,
                                             || format!("expr_{}", result_column_idx),
                                         ),
@@ -189,7 +189,7 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                                 plan.result_columns.push(ResultSetColumn {
                                     name: get_name(
                                         maybe_alias.as_ref(),
-                                        &expr,
+                                        expr,
                                         &plan.referenced_tables,
                                         || format!("expr_{}", result_column_idx),
                                     ),

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -2,6 +2,8 @@ use std::rc::Weak;
 use std::{cell::RefCell, rc::Rc};
 
 use super::emitter::emit_program;
+use super::expr::get_name;
+use super::plan::SelectQueryType;
 use crate::function::Func;
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
 use crate::translate::optimizer::optimize_plan;
@@ -23,15 +25,15 @@ pub fn translate_select(
     connection: Weak<Connection>,
     syms: &SymbolTable,
 ) -> Result<Program> {
-    let select_plan = prepare_select_plan(schema, select)?;
-    let optimized_plan = optimize_plan(select_plan)?;
-    emit_program(database_header, optimized_plan, connection, syms)
+    let mut select_plan = prepare_select_plan(schema, select)?;
+    optimize_plan(&mut select_plan)?;
+    emit_program(database_header, select_plan, connection, syms)
 }
 
 pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan> {
     match select.body.select {
         ast::OneSelect::Select {
-            columns,
+            mut columns,
             from,
             where_clause,
             group_by,
@@ -58,13 +60,14 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                 referenced_tables,
                 available_indexes: schema.indexes.clone().into_values().flatten().collect(),
                 contains_constant_false_condition: false,
+                query_type: SelectQueryType::TopLevel,
             };
 
             // Parse the WHERE clause
             plan.where_clause = parse_where(where_clause, &plan.referenced_tables)?;
 
             let mut aggregate_expressions = Vec::new();
-            for column in columns.clone() {
+            for (result_column_idx, column) in columns.iter_mut().enumerate() {
                 match column {
                     ast::ResultColumn::Star => {
                         plan.source.select_star(&mut plan.result_columns);
@@ -80,7 +83,7 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                             crate::bail_parse_error!("Table {} not found", name.0);
                         }
                         let table_reference = referenced_table.unwrap();
-                        for (idx, col) in table_reference.table.columns.iter().enumerate() {
+                        for (idx, col) in table_reference.columns().iter().enumerate() {
                             plan.result_columns.push(ResultSetColumn {
                                 expr: ast::Expr::Column {
                                     database: None, // TODO: support different databases
@@ -88,13 +91,14 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                                     column: idx,
                                     is_rowid_alias: col.is_rowid_alias,
                                 },
+                                name: col.name.clone(),
                                 contains_aggregates: false,
                             });
                         }
                     }
-                    ast::ResultColumn::Expr(mut expr, _) => {
-                        bind_column_references(&mut expr, &plan.referenced_tables)?;
-                        match &expr {
+                    ast::ResultColumn::Expr(ref mut expr, maybe_alias) => {
+                        bind_column_references(expr, &plan.referenced_tables)?;
+                        match expr {
                             ast::Expr::FunctionCall {
                                 name,
                                 distinctness: _,
@@ -119,6 +123,12 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                                         };
                                         aggregate_expressions.push(agg.clone());
                                         plan.result_columns.push(ResultSetColumn {
+                                            name: get_name(
+                                                maybe_alias.as_ref(),
+                                                &expr,
+                                                &plan.referenced_tables,
+                                                || format!("expr_{}", result_column_idx),
+                                            ),
                                             expr: expr.clone(),
                                             contains_aggregates: true,
                                         });
@@ -127,6 +137,12 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                                         let contains_aggregates =
                                             resolve_aggregates(&expr, &mut aggregate_expressions);
                                         plan.result_columns.push(ResultSetColumn {
+                                            name: get_name(
+                                                maybe_alias.as_ref(),
+                                                &expr,
+                                                &plan.referenced_tables,
+                                                || format!("expr_{}", result_column_idx),
+                                            ),
                                             expr: expr.clone(),
                                             contains_aggregates,
                                         });
@@ -151,6 +167,12 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                                     };
                                     aggregate_expressions.push(agg.clone());
                                     plan.result_columns.push(ResultSetColumn {
+                                        name: get_name(
+                                            maybe_alias.as_ref(),
+                                            &expr,
+                                            &plan.referenced_tables,
+                                            || format!("expr_{}", result_column_idx),
+                                        ),
                                         expr: expr.clone(),
                                         contains_aggregates: true,
                                     });
@@ -163,8 +185,14 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
                             }
                             expr => {
                                 let contains_aggregates =
-                                    resolve_aggregates(expr, &mut aggregate_expressions);
+                                    resolve_aggregates(&expr, &mut aggregate_expressions);
                                 plan.result_columns.push(ResultSetColumn {
+                                    name: get_name(
+                                        maybe_alias.as_ref(),
+                                        &expr,
+                                        &plan.referenced_tables,
+                                        || format!("expr_{}", result_column_idx),
+                                    ),
                                     expr: expr.clone(),
                                     contains_aggregates,
                                 });

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2308,7 +2308,8 @@ impl Program {
                         {
                             state.pc = *end_offset;
                         } else {
-                            // swap
+                            // swap the program counter with the value in the yield register
+                            // this is the mechanism that allows jumping back and forth between the coroutine and the caller
                             (state.pc, state.registers[*yield_reg]) =
                                 (pc, OwnedValue::Integer(state.pc + 1));
                         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -99,7 +99,7 @@ pub struct ProgramState {
     registers: Vec<OwnedValue>,
     last_compare: Option<std::cmp::Ordering>,
     deferred_seek: Option<(CursorID, CursorID)>,
-    ended_coroutine: bool, // flag to notify yield coroutine finished
+    ended_coroutine: HashMap<usize, bool>, // flag to indicate that a coroutine has ended (key is the yield register)
     regex_cache: RegexCache,
     interrupted: bool,
 }
@@ -115,7 +115,7 @@ impl ProgramState {
             registers,
             last_compare: None,
             deferred_seek: None,
-            ended_coroutine: false,
+            ended_coroutine: HashMap::new(),
             regex_cache: RegexCache::new(),
             interrupted: false,
         }
@@ -179,6 +179,7 @@ impl Program {
             }
             let insn = &self.insns[state.pc as usize];
             trace_insn(self, state.pc as InsnReference, insn);
+            // print_insn(self, state.pc as InsnReference, insn, "".to_string());
             let mut cursors = state.cursors.borrow_mut();
             match insn {
                 Insn::Init { target_pc } => {
@@ -2279,12 +2280,18 @@ impl Program {
                     jump_on_definition,
                     start_offset,
                 } => {
+                    assert!(*jump_on_definition >= 0);
                     state.registers[*yield_reg] = OwnedValue::Integer(*start_offset);
-                    state.pc = *jump_on_definition;
+                    state.ended_coroutine.insert(*yield_reg, false);
+                    state.pc = if *jump_on_definition == 0 {
+                        state.pc + 1
+                    } else {
+                        *jump_on_definition
+                    };
                 }
                 Insn::EndCoroutine { yield_reg } => {
                     if let OwnedValue::Integer(pc) = state.registers[*yield_reg] {
-                        state.ended_coroutine = true;
+                        state.ended_coroutine.insert(*yield_reg, true);
                         state.pc = pc - 1; // yield jump is always next to yield. Here we substract 1 to go back to yield instruction
                     } else {
                         unreachable!();
@@ -2295,7 +2302,7 @@ impl Program {
                     end_offset,
                 } => {
                     if let OwnedValue::Integer(pc) = state.registers[*yield_reg] {
-                        if state.ended_coroutine {
+                        if *state.ended_coroutine.get(yield_reg).unwrap_or(&false) {
                             state.pc = *end_offset;
                         } else {
                             // swap
@@ -2303,7 +2310,10 @@ impl Program {
                                 (pc, OwnedValue::Integer(state.pc + 1));
                         }
                     } else {
-                        unreachable!();
+                        unreachable!(
+                            "yield_reg {} contains non-integer value: {:?}",
+                            *yield_reg, state.registers[*yield_reg]
+                        );
                     }
                 }
                 Insn::InsertAsync {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2301,7 +2301,11 @@ impl Program {
                     end_offset,
                 } => {
                     if let OwnedValue::Integer(pc) = state.registers[*yield_reg] {
-                        if *state.ended_coroutine.get(yield_reg).unwrap_or(&false) {
+                        if *state
+                            .ended_coroutine
+                            .get(yield_reg)
+                            .expect("coroutine not initialized")
+                        {
                             state.pc = *end_offset;
                         } else {
                             // swap

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -179,7 +179,6 @@ impl Program {
             }
             let insn = &self.insns[state.pc as usize];
             trace_insn(self, state.pc as InsnReference, insn);
-            // print_insn(self, state.pc as InsnReference, insn, "".to_string());
             let mut cursors = state.cursors.borrow_mut();
             match insn {
                 Insn::Init { target_pc } => {

--- a/testing/all.test
+++ b/testing/all.test
@@ -17,4 +17,5 @@ source $testdir/pragma.test
 source $testdir/scalar-functions.test
 source $testdir/scalar-functions-datetime.test
 source $testdir/select.test
+source $testdir/subquery.test
 source $testdir/where.test

--- a/testing/subquery.test
+++ b/testing/subquery.test
@@ -1,0 +1,194 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test subquery-inner-filter {
+    select sub.loud_hat from (
+        select concat(name, '!!!') as loud_hat 
+        from products where name = 'hat'
+    ) sub;
+} {hat!!!}
+
+do_execsql_test subquery-outer-filter {
+    select sub.loud_hat from (
+        select concat(name, '!!!') as loud_hat 
+        from products
+    ) sub where sub.loud_hat = 'hat!!!'
+} {hat!!!}
+
+do_execsql_test subquery-without-alias {
+    select loud_hat from (
+        select concat(name, '!!!') as loud_hat 
+        from products where name = 'hat'
+    );
+} {hat!!!}
+
+do_execsql_test subquery-no-alias-on-col {
+    select price from (
+        select * from products where name = 'hat'
+    )
+} {79.0}
+
+do_execsql_test subquery-no-alias-on-col-named {
+    select price from (
+        select price from products where name = 'hat'
+    )
+} {79.0}
+
+do_execsql_test subquery-select-star {
+    select * from (
+        select price, price + 1.0, name from products where name = 'hat'
+    )
+} {79.0|80.0|hat}
+
+do_execsql_test subquery-select-table-star {
+    select sub.* from (
+        select price, price + 1.0, name from products where name = 'hat'
+    ) sub
+} {79.0|80.0|hat}
+
+do_execsql_test nested-subquery {
+    select sub.loudest_hat from (
+        select upper(nested_sub.loud_hat) as loudest_hat from (
+            select concat(name, '!!!') as loud_hat 
+            from products where name = 'hat'
+        ) nested_sub 
+    ) sub;
+} {HAT!!!}
+
+do_execsql_test subquery-orderby-limit {
+    select upper(sub.loud_name) as loudest_name 
+    from (
+        select concat(name, '!!!') as loud_name 
+        from products 
+        order by name 
+        limit 3
+    ) sub;
+} {ACCESSORIES!!!
+BOOTS!!!
+CAP!!!}
+
+do_execsql_test table-join-subquery {
+    select sub.product_name, p.name 
+    from products p join (
+        select name as product_name 
+        from products
+    ) sub on p.name = sub.product_name where p.name = 'hat'
+} {hat|hat}
+
+do_execsql_test subquery-join-table {
+    select sub.product_name, p.name
+    from (
+        select name as product_name 
+        from products
+    ) sub join products p on sub.product_name = p.name where sub.product_name = 'hat'
+} {hat|hat}
+
+do_execsql_test subquery-join-subquery {
+    select sub1.sus_name, sub2.truthful_name
+    from (
+        select name as sus_name
+        from products
+        where name = 'cap'
+    ) sub1 join (
+        select concat('no ', name) as truthful_name
+        from products 
+        where name = 'cap'
+    ) sub2;
+} {"cap|no cap"}
+
+do_execsql_test select-star-table-subquery {
+    select * 
+    from products p join (
+        select name, price 
+        from products
+        where name = 'hat'
+    ) sub on p.name = sub.name;
+} {1|hat|79.0|hat|79.0}
+
+do_execsql_test select-star-subquery-table {
+    select * 
+    from (
+        select name, price 
+        from products
+        where name = 'hat'
+    ) sub join products p on sub.name = p.name;
+} {hat|79.0|1|hat|79.0}
+
+do_execsql_test select-star-subquery-subquery {
+    select *
+    from (
+        select name, price 
+        from products
+        where name = 'hat'
+    ) sub1 join (
+        select price
+        from products 
+        where name = 'hat'
+    ) sub2 on sub1.price = sub2.price;
+} {hat|79.0|79.0}
+
+
+do_execsql_test subquery-inner-grouping {
+    select is_jennifer, person_count
+    from (
+        select first_name = 'Jennifer' as is_jennifer, count(1) as person_count from users
+        group by first_name = 'Jennifer'
+    ) order by person_count asc
+} {1|151
+0|9849}
+
+do_execsql_test subquery-outer-grouping {
+    select is_jennifer, count(1) as person_count
+    from (
+        select first_name = 'Jennifer' as is_jennifer from users
+    ) group by is_jennifer order by count(1) asc
+} {1|151
+0|9849}
+
+do_execsql_test subquery-join-using-with-outer-limit {
+    SELECT p.name, sub.funny_name 
+    FROM products p 
+    JOIN (
+        select id, concat(name, '-lol') as funny_name 
+        from products
+    ) sub USING (id) 
+    LIMIT 3;
+} {"hat|hat-lol
+cap|cap-lol
+shirt|shirt-lol"}
+
+do_execsql_test subquery-join-using-with-inner-limit {
+    SELECT p.name, sub.funny_name 
+    FROM products p 
+    JOIN (
+        select id, concat(name, '-lol') as funny_name 
+        from products
+        limit 3
+    ) sub USING (id);
+} {"hat|hat-lol
+cap|cap-lol
+shirt|shirt-lol"}
+
+do_execsql_test subquery-join-using-with-both-limits {
+    SELECT p.name, sub.funny_name 
+    FROM products p 
+    JOIN (
+        select id, concat(name, '-lol') as funny_name 
+        from products
+        limit 3
+    ) sub USING (id)
+    LIMIT 2;
+} {"hat|hat-lol
+cap|cap-lol"}
+
+do_execsql_test subquery-containing-join {
+    select foo, bar 
+    from (
+        select p.name as foo, u.first_name as bar 
+        from products p join users u using (id)
+    ) limit 3;
+} {hat|Jamie
+cap|Cindy
+shirt|Tommy}


### PR DESCRIPTION
I will warn that this PR is quite big out of necessity, since subqueries are, as the name implies, queries within queries, so everything that works with a regular query should also work with a subquery, roughly speaking.

---

- Adds support for:
    * uncorrelated subqueries in FROM clause (i.e. appear as a "table", and do not refer to outer tables). Example of this at the end of the PR description.
    * column and subquery aliasing (`select sub.renamed from (select name as renamed from products) sub`)
    * inner and outer filtering of subqueries (`select sub.name from (select name from products where name = 'joe') sub`, and,  `select sub.name from (select name from products) sub where sub.name = 'joe'`)
    * joining between regular tables and subqueries
    * joining between multiple subqueries
    * in general working with subqueries should roughly equal working with regular tables
- Main idea: subqueries are just wrappers of a `SelectPlan` that never emit ResultRows, instead they `Yield` control back to the parent query, and the parent query can copy the subquery result values into a ResultRow. New variant `SourceOperator::Subquery` that wraps a subquery `SelectPlan`.
- Plans can now not only refer to btree tables (`select p.name from products`) but also subqueries (`select sub.foo from (select name as foo from products) sub`. Hence this PR also adds support for column aliases which didn't exist before.
    * An `Expr::Column` that refers to a regular table will result in an `Insn::Column` (i.e. a read from disk/memory) whereas an `Expr::Column` that refers to a subquery will result in an `Insn::Copy` (from register to register) instead
- Subquery handling is entirely unoptimized, there's no predicate pushdown from outer query to subqueries, or elimination of redundant subqueries (e.g. in the trivial example `SELECT * FROM (SELECT * FROM users) sub` the subquery can just be entirely removed)

---

This PR does not add support (yet) for:

- subqueries in result columns: `SELECT t.foo, (SELECT .......) as column_from_subquery FROM t`
- subqueries in WHERE clauses e.g. `SELECT * FROM t1 WHERE t1.foo IN (SELECT ...)`
- subquery-related optimizations, of which there are plenty available. No analysis is done regarding e.g. whether predicates on the outer query level could be pushed into the subquery, or whether the subquery could be entirely eliminated. Both of the above can probably be done fairly easily for a bunch of trivial cases.

---

Example bytecode with comments added:

```
limbo> EXPLAIN SELECT p.name, sub.funny_name FROM products p JOIN (
  select id, concat(name, '-lol') as funny_name from products
) sub USING (id) LIMIT 3;

addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     31    0                    0   Start at 31

// Coroutine implementation starts at insn 2, jump immediately to 14
1     InitCoroutine      1     14    2                    0   

2     OpenReadAsync      0     3     0                    0   table=products, root=3
3     OpenReadAwait      0     0     0                    0   
4     RewindAsync        0     0     0                    0   
5     RewindAwait        0     13    0                    0   Rewind table products
6       RowId            0     2     0                    0   r[2]=products.rowid
7       Column           0     1     4                    0   r[4]=products.name
8       String8          0     5     0     -lol           0   r[5]='-lol'
9       Function         0     4     3     concat         0   r[3]=func(r[4..5])

// jump back to main loop of query (insn 20)
10      Yield            1     0     0                    0   

11    NextAsync          0     0     0                    0   
12    NextAwait          0     6     0                    0   
13    EndCoroutine       1     0     0                    0   
14    OpenReadAsync      1     3     0                    0   table=p, root=3
15    OpenReadAwait      0     0     0                    0   
16    RewindAsync        1     0     0                    0   
17    RewindAwait        1     30    0                    0   Rewind table p

// Since this subquery is the inner loop of the join, reinitialize it on every iteration of the outer loop
18      InitCoroutine    1     0     2                    0   

// Jump back to the subquery implementation to assign another row into registers
19      Yield            1     28    0                    0   

20      RowId            1     8     0                    0   r[8]=p.rowid

// Copy sub.id
21      Copy             2     9     0                    0   r[9]=r[2]

// p.id == sub.id?
22      Ne               8     9     27                   0   if r[8]!=r[9] goto 27
23      Column           1     1     6                    0   r[6]=p.name

// copy sub.funny_name
24      Copy             3     7     0                    0   r[7]=r[3]

25      ResultRow        6     2     0                    0   output=r[6..7]
26      DecrJumpZero     10    30    0                    0   if (--r[10]==0) goto 30
27      Goto             0     19    0                    0   
28    NextAsync          1     0     0                    0   
29    NextAwait          1     18    0                    0   
30    Halt               0     0     0                    0   
31    Transaction        0     0     0                    0   
32    Integer            3     10    0                    0   r[10]=3
33    Goto               0     1     0                    0 
```