### PR TITLE
Support like function with escape

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -116,8 +116,8 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | instr(X,Y)                   | Yes    |         |
 | last_insert_rowid()          | Yes    |         |
 | length(X)                    | Yes    |         |
-| like(X,Y)                    | No     |         |
-| like(X,Y,Z)                  | No     |         |
+| like(X,Y)                    | Yes    |         |
+| like(X,Y,Z)                  | Yes    |         |
 | likelihood(X,Y)              | No     |         |
 | likely(X)                    | No     |         |
 | load_extension(X)            | No     |         |

--- a/core/vdbe/likeop.rs
+++ b/core/vdbe/likeop.rs
@@ -1,0 +1,87 @@
+use regex::{Regex, RegexBuilder};
+
+use crate::{types::OwnedValue, LimboError};
+
+pub fn construct_like_escape_arg(escape_value: &OwnedValue) -> Result<char, LimboError> {
+    match escape_value {
+        OwnedValue::Text(text) => {
+            let mut escape_chars = text.value.chars();
+            match (escape_chars.next(), escape_chars.next()) {
+                (Some(escape), None) => Ok(escape),
+                _ => {
+                    return Result::Err(LimboError::Constraint(
+                        "ESCAPE expression must be a single character".to_string(),
+                    ))
+                }
+            }
+        }
+        _ => {
+            unreachable!("Like on non-text registers");
+        }
+    }
+}
+
+// Implements LIKE pattern matching with escape
+pub fn exec_like_with_escape(pattern: &str, text: &str, escape: char) -> bool {
+    construct_like_regex_with_escape(pattern, escape).is_match(text)
+}
+
+fn construct_like_regex_with_escape(pattern: &str, escape: char) -> Regex {
+    let mut regex_pattern = String::with_capacity(pattern.len() * 2);
+
+    regex_pattern.push('^');
+
+    let mut chars = pattern.chars();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            esc_ch if esc_ch == escape => {
+                if let Some(escaped_char) = chars.next() {
+                    if regex_syntax::is_meta_character(escaped_char) {
+                        regex_pattern.push('\\');
+                    }
+                    regex_pattern.push(escaped_char);
+                }
+            }
+            '%' => regex_pattern.push_str(".*"),
+            '_' => regex_pattern.push('.'),
+            c => {
+                if regex_syntax::is_meta_character(c) {
+                    regex_pattern.push('\\');
+                }
+                regex_pattern.push(c);
+            }
+        }
+    }
+
+    regex_pattern.push('$');
+
+    RegexBuilder::new(&regex_pattern)
+        .case_insensitive(true)
+        .dot_matches_new_line(true)
+        .build()
+        .unwrap()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_exec_like_with_escape() {
+        assert!(exec_like_with_escape("abcX%", "abc%", 'X'));
+        assert!(!exec_like_with_escape("abcX%", "abc5", 'X'));
+        assert!(!exec_like_with_escape("abcX%", "abc", 'X'));
+        assert!(!exec_like_with_escape("abcX%", "abcX%", 'X'));
+        assert!(!exec_like_with_escape("abcX%", "abc%%", 'X'));
+        assert!(exec_like_with_escape("abcX_", "abc_", 'X'));
+        assert!(!exec_like_with_escape("abcX_", "abc5", 'X'));
+        assert!(!exec_like_with_escape("abcX_", "abc", 'X'));
+        assert!(!exec_like_with_escape("abcX_", "abcX_", 'X'));
+        assert!(!exec_like_with_escape("abcX_", "abc__", 'X'));
+        assert!(exec_like_with_escape("abcXX", "abcX", 'X'));
+        assert!(!exec_like_with_escape("abcXX", "abc5", 'X'));
+        assert!(!exec_like_with_escape("abcXX", "abc", 'X'));
+        assert!(!exec_like_with_escape("abcXX", "abcXX", 'X'));
+    }
+}

--- a/testing/like.test
+++ b/testing/like.test
@@ -89,3 +89,48 @@ do_execsql_test like-with-dollar {
 do_execsql_test like-with-dot {
   select like('%a.a', 'aaaa')
 } {0}
+
+do_execsql_test like-fn-esc-1  { 
+    SELECT like('abcX%', 'abc%' , 'X') 
+} 1
+do_execsql_test like-fn-esc-2  { 
+    SELECT like('abcX%', 'abc5' , 'X') 
+} 0
+do_execsql_test like-fn-esc-3  { 
+    SELECT like('abcX%', 'abc', 'X') 
+} 0
+do_execsql_test like-fn-esc-4  { 
+    SELECT like('abcX%', 'abcX%', 'X') 
+} 0
+do_execsql_test like-fn-esc-5  { 
+    SELECT like('abcX%', 'abc%%', 'X') 
+} 0
+
+do_execsql_test like-fn-esc-6  { 
+    SELECT like('abcX_', 'abc_' , 'X') 
+} 1
+do_execsql_test like-fn-esc-7  { 
+    SELECT like('abcX_', 'abc5' , 'X') 
+} 0
+do_execsql_test like-fn-esc-8  { 
+    SELECT like('abcX_', 'abc'  , 'X') 
+} 0
+do_execsql_test like-fn-esc-9  { 
+    SELECT like('abcX_', 'abcX_', 'X') 
+} 0
+do_execsql_test like-fn-esc-10 { 
+    SELECT like('abcX_', 'abc__', 'X') 
+} 0
+
+do_execsql_test like-fn-esc-11 { 
+    SELECT like('abcXX', 'abcX' , 'X') 
+} 1
+do_execsql_test like-fn-esc-12 { 
+    SELECT like('abcXX', 'abc5' , 'X') 
+} 0
+do_execsql_test like-fn-esc-13 { 
+    SELECT like('abcXX', 'abc'  , 'X') 
+} 0
+do_execsql_test like-fn-esc-14 { 
+    SELECT like('abcXX', 'abcXX', 'X') 
+} 0


### PR DESCRIPTION
I have added support for like function with escape i.e like(X,Y,Z) .

There is good opportunity to refactor/cleanup the like operations which can be done in another PR, as I wanted to keep the changes small .