### PR TITLE
Auto-create index in CREATE TABLE when necessary

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1360,8 +1360,8 @@ fn close_loop(
             iter_dir,
             ..
         } => {
-            let cursor_id = program.resolve_cursor_id(&table_reference.table_identifier);
             program.resolve_label(loop_labels.next, program.offset());
+            let cursor_id = program.resolve_cursor_id(&table_reference.table_identifier);
             if iter_dir
                 .as_ref()
                 .is_some_and(|dir| *dir == IterationDirection::Backwards)

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1843,7 +1843,7 @@ impl Program {
                     }
                     state.pc += 1;
                 }
-                Insn::CreateBtree { db, root, flags: _ } => {
+                Insn::CreateBtree { db, root, flags } => {
                     if *db > 0 {
                         // TODO: implement temp datbases
                         todo!("temp databases not implemented yet");
@@ -1854,7 +1854,7 @@ impl Program {
                         self.database_header.clone(),
                     ));
 
-                    let root_page = cursor.btree_create(1);
+                    let root_page = cursor.btree_create(*flags);
                     state.registers[*root] = OwnedValue::Integer(root_page as i64);
                     state.pc += 1;
                 }


### PR DESCRIPTION
Closes #448 

Adds support for:

- Automatically creating index on the PRIMARY KEY if the pk is not a rowid alias
- Parsing the automatically created index into memory, for use in queries
    * `testing/testing_norowidalias.db` now uses the PK indexes and some tests were failing -- looks like taking the index into use revealed some bugs in our codegen :) I fixed those in later commits.

Does not add support for:

- Inserting to the index during writes to the table