### PR TITLE
Add support for changes() and total_changes() functions

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -73,6 +73,7 @@ impl AggFunc {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScalarFunc {
     Cast,
+    Changes,
     Char,
     Coalesce,
     Concat,
@@ -102,6 +103,7 @@ pub enum ScalarFunc {
     Soundex,
     Date,
     Time,
+    TotalChanges,
     Typeof,
     Unicode,
     Quote,
@@ -118,6 +120,7 @@ impl Display for ScalarFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
             Self::Cast => "cast".to_string(),
+            Self::Changes => "changes".to_string(),
             Self::Char => "char".to_string(),
             Self::Coalesce => "coalesce".to_string(),
             Self::Concat => "concat".to_string(),
@@ -147,6 +150,7 @@ impl Display for ScalarFunc {
             Self::Soundex => "soundex".to_string(),
             Self::Date => "date".to_string(),
             Self::Time => "time".to_string(),
+            Self::TotalChanges => "total_changes".to_string(),
             Self::Typeof => "typeof".to_string(),
             Self::Unicode => "unicode".to_string(),
             Self::Quote => "quote".to_string(),
@@ -323,6 +327,8 @@ impl Func {
             "coalesce" => Ok(Self::Scalar(ScalarFunc::Coalesce)),
             "concat" => Ok(Self::Scalar(ScalarFunc::Concat)),
             "concat_ws" => Ok(Self::Scalar(ScalarFunc::ConcatWs)),
+            "changes" => Ok(Self::Scalar(ScalarFunc::Changes)),
+            "total_changes" => Ok(Self::Scalar(ScalarFunc::TotalChanges)),
             "glob" => Ok(Self::Scalar(ScalarFunc::Glob)),
             "ifnull" => Ok(Self::Scalar(ScalarFunc::IfNull)),
             "iif" => Ok(Self::Scalar(ScalarFunc::Iif)),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -141,6 +141,8 @@ impl Database {
             header,
             transaction_state: RefCell::new(TransactionState::None),
             last_insert_rowid: Cell::new(0),
+            last_change: Cell::new(0),
+            total_changes: Cell::new(0),
         });
         let rows = conn.query("SELECT * FROM sqlite_schema")?;
         let mut schema = schema.borrow_mut();
@@ -156,6 +158,8 @@ impl Database {
             header: self.header.clone(),
             last_insert_rowid: Cell::new(0),
             transaction_state: RefCell::new(TransactionState::None),
+            last_change: Cell::new(0),
+            total_changes: Cell::new(0),
         })
     }
 
@@ -231,6 +235,8 @@ pub struct Connection {
     header: Rc<RefCell<DatabaseHeader>>,
     transaction_state: RefCell<TransactionState>,
     last_insert_rowid: Cell<u64>,
+    last_change: Cell<i64>,
+    total_changes: Cell<i64>,
 }
 
 impl Connection {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1011,6 +1011,19 @@ pub fn translate_expr(
                         ScalarFunc::Cast => {
                             unreachable!("this is always ast::Expr::Cast")
                         }
+                        ScalarFunc::Changes => {
+                            if let Some(args) = args{
+                                crate::bail_parse_error!("{} fucntion with more than 0 arguments", srf);
+                            }
+                            let start_reg = program.alloc_register();
+                            program.emit_insn(Insn::Function{
+                                constant_mask: 0,
+                                start_reg,
+                                dest: target_register,
+                                func: func_ctx,
+                            });
+                            Ok(target_register)
+                        }
                         ScalarFunc::Char => {
                             let start_reg = translate_variable_sized_function_parameter_list(
                                 program,
@@ -1496,6 +1509,19 @@ pub fn translate_expr(
                             program.emit_insn(Insn::Function {
                                 constant_mask: 0,
                                 start_reg: target_register + 1,
+                                dest: target_register,
+                                func: func_ctx,
+                            });
+                            Ok(target_register)
+                        }
+                        ScalarFunc::TotalChanges => {
+                            if let Some(args) = args {
+                                crate::bail_parse_error!("{} fucntion with more than 0 arguments", srf.to_string());
+                            }
+                            let start_reg = program.alloc_register();
+                            program.emit_insn(Insn::Function{
+                                constant_mask: 0,
+                                start_reg,
                                 dest: target_register,
                                 func: func_ctx,
                             });

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1012,11 +1012,14 @@ pub fn translate_expr(
                             unreachable!("this is always ast::Expr::Cast")
                         }
                         ScalarFunc::Changes => {
-                            if let Some(args) = args{
-                                crate::bail_parse_error!("{} fucntion with more than 0 arguments", srf);
+                            if let Some(_) = args {
+                                crate::bail_parse_error!(
+                                    "{} fucntion with more than 0 arguments",
+                                    srf
+                                );
                             }
                             let start_reg = program.alloc_register();
-                            program.emit_insn(Insn::Function{
+                            program.emit_insn(Insn::Function {
                                 constant_mask: 0,
                                 start_reg,
                                 dest: target_register,
@@ -1515,11 +1518,14 @@ pub fn translate_expr(
                             Ok(target_register)
                         }
                         ScalarFunc::TotalChanges => {
-                            if let Some(args) = args {
-                                crate::bail_parse_error!("{} fucntion with more than 0 arguments", srf.to_string());
+                            if let Some(_) = args {
+                                crate::bail_parse_error!(
+                                    "{} fucntion with more than 0 arguments",
+                                    srf.to_string()
+                                );
                             }
                             let start_reg = program.alloc_register();
-                            program.emit_insn(Insn::Function{
+                            program.emit_insn(Insn::Function {
                                 constant_mask: 0,
                                 start_reg,
                                 dest: target_register,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1321,6 +1321,10 @@ impl Program {
                                 let result = exec_cast(&reg_value_argument, &reg_value_type.value);
                                 state.registers[*dest] = result;
                             }
+                            ScalarFunc::Changes => {
+                                //placeholder
+                                state.registers[*dest] = OwnedValue::Integer(0);
+                            }
                             ScalarFunc::Char => {
                                 let reg_values =
                                     state.registers[*start_reg..*start_reg + arg_count].to_vec();
@@ -1528,6 +1532,10 @@ impl Program {
                                 let result =
                                     exec_time(&state.registers[*start_reg..*start_reg + arg_count]);
                                 state.registers[*dest] = result;
+                            }
+                            ScalarFunc::TotalChanges => {
+                                //placeholder
+                                state.registers[*dest] = OwnedValue::Integer(0);
                             }
                             ScalarFunc::UnixEpoch => {
                                 if *start_reg == 0 {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1322,8 +1322,9 @@ impl Program {
                                 state.registers[*dest] = result;
                             }
                             ScalarFunc::Changes => {
-                                //placeholder
-                                state.registers[*dest] = OwnedValue::Integer(0);
+                                let res = &self.connection.upgrade().unwrap().last_change;
+                                let changes = res.get();
+                                state.registers[*dest] = OwnedValue::Integer(changes);
                             }
                             ScalarFunc::Char => {
                                 let reg_values =
@@ -1534,8 +1535,9 @@ impl Program {
                                 state.registers[*dest] = result;
                             }
                             ScalarFunc::TotalChanges => {
-                                //placeholder
-                                state.registers[*dest] = OwnedValue::Integer(0);
+                                let res = &self.connection.upgrade().unwrap().total_changes;
+                                let total_changes = res.get();
+                                state.registers[*dest] = OwnedValue::Integer(total_changes);
                             }
                             ScalarFunc::UnixEpoch => {
                                 if *start_reg == 0 {
@@ -1739,6 +1741,9 @@ impl Program {
                         if let Some(rowid) = cursor.rowid()? {
                             if let Some(conn) = self.connection.upgrade() {
                                 conn.update_last_rowid(rowid);
+                                let prev_total_changes = conn.total_changes.get();
+                                conn.last_change.set(1);
+                                conn.total_changes.set(prev_total_changes + 1);
                             }
                         }
                     }


### PR DESCRIPTION
#525

- Adds the necessary `ScalarFunc` variants to support the `changes()` & `total_changes()` SQLite function.
- Adds the necessary fields to the `Connection` struct to track changes.
- Modify the `InsertAwait` OpCode behaviour to affect the changes counter.  