### PR TITLE
feat: use covering indexes

### DIFF
--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -6,6 +6,7 @@ use crate::translate::planner::{parse_limit, parse_where};
 use crate::{schema::Schema, storage::sqlite3_ondisk::DatabaseHeader, vdbe::Program};
 use crate::{Connection, Result, SymbolTable};
 use sqlite3_parser::ast::{Expr, Limit, QualifiedName};
+use std::collections::BTreeSet;
 use std::rc::Weak;
 use std::{cell::RefCell, rc::Rc};
 
@@ -58,6 +59,7 @@ pub fn prepare_delete_plan(
             iter_dir: None,
         },
         result_columns: vec![],
+        related_columns: BTreeSet::new(),
         where_clause: resolved_where_clauses,
         order_by: None,
         limit: resolved_limit,

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -6,7 +6,6 @@ use crate::translate::planner::{parse_limit, parse_where};
 use crate::{schema::Schema, storage::sqlite3_ondisk::DatabaseHeader, vdbe::Program};
 use crate::{Connection, Result, SymbolTable};
 use sqlite3_parser::ast::{Expr, Limit, QualifiedName};
-use std::collections::BTreeSet;
 use std::rc::Weak;
 use std::{cell::RefCell, rc::Rc};
 
@@ -59,7 +58,6 @@ pub fn prepare_delete_plan(
             iter_dir: None,
         },
         result_columns: vec![],
-        related_columns: BTreeSet::new(),
         where_clause: resolved_where_clauses,
         order_by: None,
         limit: resolved_limit,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1150,11 +1150,11 @@ fn open_loop(
 fn try_index_cover(
     program: &mut ProgramBuilder,
     related_columns: &BTreeSet<ColumnBinding>,
-    table_reference: &BTreeTableReference,
+    table_reference: &TableReference,
     index_cursor_id: CursorID,
     table_cursor_id: CursorID,
 ) -> bool {
-    let BTreeTableReference {
+    let TableReference {
         table, table_index, ..
     } = table_reference;
 
@@ -1167,7 +1167,7 @@ fn try_index_cover(
             index_column_map.insert(pos, i);
         }
         if let Some(pos) = table
-            .columns
+            .columns()
             .iter()
             .position(|column| column.is_rowid_alias)
         {

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -2,18 +2,18 @@
 // It handles translating high-level SQL operations into low-level bytecode that can be executed by the virtual machine.
 
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 
 use sqlite3_parser::ast::{self};
 
 use crate::schema::{Column, PseudoTable, Table};
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
-use crate::translate::plan::{ColumnBinding, DeletePlan, IterationDirection, Plan, Search};
+use crate::translate::plan::{DeletePlan, IterationDirection, Plan, Search};
 use crate::types::{OwnedRecord, OwnedValue};
 use crate::util::exprs_are_equivalent;
 use crate::vdbe::builder::ProgramBuilder;
-use crate::vdbe::{insn::Insn, BranchOffset, CursorID, Program};
+use crate::vdbe::{insn::Insn, BranchOffset, Program};
 use crate::{Connection, Result, SymbolTable};
 
 use super::expr::{
@@ -378,7 +378,6 @@ fn emit_query(
     open_loop(
         program,
         &mut plan.source,
-        &plan.related_columns,
         &plan.referenced_tables,
         metadata,
         syms,
@@ -471,7 +470,6 @@ fn emit_program_for_delete(
     open_loop(
         &mut program,
         &mut plan.source,
-        &plan.related_columns,
         &plan.referenced_tables,
         &mut metadata,
         syms,
@@ -666,34 +664,26 @@ fn init_source(
             search,
             ..
         } => {
-            let table_cursor_id = program.alloc_cursor_id(
-                Some(table_reference.table_identifier.clone()),
-                Some(table_reference.table.clone()),
-            );
+            let mut is_cover = false;
 
-            match mode {
-                OperationMode::SELECT => {
-                    program.emit_insn(Insn::OpenReadAsync {
-                        cursor_id: table_cursor_id,
-                        root_page: table_reference.table.get_root_page(),
-                    });
-                    program.emit_insn(Insn::OpenReadAwait {});
-                }
-                OperationMode::DELETE => {
-                    program.emit_insn(Insn::OpenWriteAsync {
-                        cursor_id: table_cursor_id,
-                        root_page: table_reference.table.get_root_page(),
-                    });
-                    program.emit_insn(Insn::OpenWriteAwait {});
-                }
-                _ => {
-                    unimplemented!()
-                }
-            }
-
-            if let Search::IndexSearch { index, .. } = search {
-                let index_cursor_id = program
-                    .alloc_cursor_id(Some(index.name.clone()), Some(Table::Index(index.clone())));
+            if let Search::IndexSearch {
+                index,
+                cover_mapping,
+                ..
+            } = search
+            {
+                let index_cursor_id = if cover_mapping.is_some() {
+                    is_cover = true;
+                    program.alloc_cursor_id(
+                        Some(table_reference.table_identifier.clone()),
+                        Some(Table::Index(index.clone())),
+                    )
+                } else {
+                    program.alloc_cursor_id(
+                        Some(index.name.clone()),
+                        Some(Table::Index(index.clone())),
+                    )
+                };
 
                 match mode {
                     OperationMode::SELECT => {
@@ -716,6 +706,33 @@ fn init_source(
                 }
             }
 
+            if !is_cover {
+                let table_cursor_id = program.alloc_cursor_id(
+                    Some(table_reference.table_identifier.clone()),
+                    Some(table_reference.table.clone()),
+                );
+
+                match mode {
+                    OperationMode::SELECT => {
+                        program.emit_insn(Insn::OpenReadAsync {
+                            cursor_id: table_cursor_id,
+                            root_page: table_reference.table.get_root_page(),
+                        });
+                        program.emit_insn(Insn::OpenReadAwait {});
+                    }
+                    OperationMode::DELETE => {
+                        program.emit_insn(Insn::OpenWriteAsync {
+                            cursor_id: table_cursor_id,
+                            root_page: table_reference.table.get_root_page(),
+                        });
+                        program.emit_insn(Insn::OpenWriteAwait {});
+                    }
+                    _ => {
+                        unimplemented!()
+                    }
+                }
+            }
+
             Ok(())
         }
         SourceOperator::Nothing { .. } => Ok(()),
@@ -728,7 +745,6 @@ fn init_source(
 fn open_loop(
     program: &mut ProgramBuilder,
     source: &mut SourceOperator,
-    related_columns: &BTreeSet<ColumnBinding>,
     referenced_tables: &[TableReference],
     metadata: &mut Metadata,
     syms: &SymbolTable,
@@ -803,14 +819,7 @@ fn open_loop(
             outer,
             ..
         } => {
-            open_loop(
-                program,
-                left,
-                related_columns,
-                referenced_tables,
-                metadata,
-                syms,
-            )?;
+            open_loop(program, left, referenced_tables, metadata, syms)?;
 
             let loop_labels = metadata
                 .loop_labels
@@ -828,14 +837,7 @@ fn open_loop(
                 jump_target_when_false = lj_meta.check_match_flag_label;
             }
 
-            open_loop(
-                program,
-                right,
-                related_columns,
-                referenced_tables,
-                metadata,
-                syms,
-            )?;
+            open_loop(program, right, referenced_tables, metadata, syms)?;
 
             if let Some(predicates) = predicates {
                 let jump_target_when_true = program.allocate_label();
@@ -938,6 +940,7 @@ fn open_loop(
             predicates,
             ..
         } => {
+            let mut is_index_cover = false;
             let table_cursor_id = program.resolve_cursor_id(&table_reference.table_identifier);
             let loop_labels = metadata
                 .loop_labels
@@ -946,8 +949,21 @@ fn open_loop(
             // Open the loop for the index search.
             // Rowid equality point lookups are handled with a SeekRowid instruction which does not loop, since it is a single row lookup.
             if !matches!(search, Search::RowidEq { .. }) {
-                let index_cursor_id = if let Search::IndexSearch { index, .. } = search {
-                    Some(program.resolve_cursor_id(&index.name))
+                let index_cursor_id = if let Search::IndexSearch {
+                    index,
+                    cover_mapping,
+                    ..
+                } = search
+                {
+                    if let Some(cover_mapping) = &cover_mapping {
+                        program
+                            .table_remapping_cursors
+                            .insert(table_cursor_id, cover_mapping.clone());
+                        is_index_cover = true;
+                        Some(table_cursor_id)
+                    } else {
+                        Some(program.resolve_cursor_id(&index.name))
+                    }
                 } else {
                     None
                 };
@@ -1086,19 +1102,11 @@ fn open_loop(
                     _ => {}
                 }
 
-                if let Some(index_cursor_id) = index_cursor_id {
-                    if !try_index_cover(
-                        program,
-                        related_columns,
-                        table_reference,
+                if let (Some(index_cursor_id), false) = (index_cursor_id, is_index_cover) {
+                    program.emit_insn(Insn::DeferredSeek {
                         index_cursor_id,
                         table_cursor_id,
-                    ) {
-                        program.emit_insn(Insn::DeferredSeek {
-                            index_cursor_id,
-                            table_cursor_id,
-                        });
-                    }
+                    });
                 }
             }
 
@@ -1145,54 +1153,6 @@ fn open_loop(
         }
         SourceOperator::Nothing { .. } => Ok(()),
     }
-}
-
-fn try_index_cover(
-    program: &mut ProgramBuilder,
-    related_columns: &BTreeSet<ColumnBinding>,
-    table_reference: &TableReference,
-    index_cursor_id: CursorID,
-    table_cursor_id: CursorID,
-) -> bool {
-    let TableReference {
-        table, table_index, ..
-    } = table_reference;
-
-    if let (_, Some(Table::Index(index))) = &program.cursor_ref[index_cursor_id] {
-        let mut index_column_map = HashMap::with_capacity(index.columns.len());
-        let index_clone = Rc::clone(index);
-        for (i, index_column) in index_clone.columns.iter().enumerate() {
-            // SAFETY: the column in the index must exist in the table
-            let (pos, _) = table.get_column(&index_column.name).unwrap();
-            index_column_map.insert(pos, i);
-        }
-        if let Some(pos) = table
-            .columns()
-            .iter()
-            .position(|column| column.is_rowid_alias)
-        {
-            index_column_map.insert(pos, index_column_map.len());
-        }
-
-        let lower = ColumnBinding {
-            table: *table_index,
-            column: 0,
-        };
-        let upper = ColumnBinding {
-            table: table_index + 1,
-            column: 0,
-        };
-        let is_cover = related_columns
-            .range(lower..upper)
-            .all(|binding| index_column_map.contains_key(&binding.column));
-        if is_cover {
-            program
-                .index_cover_cursors
-                .insert(table_cursor_id, (index_cursor_id, index_column_map));
-            return true;
-        }
-    }
-    false
 }
 
 /// SQLite (and so Limbo) processes joins as a nested loop.
@@ -1532,7 +1492,17 @@ fn close_loop(
                 return Ok(());
             }
             let cursor_id = match search {
-                Search::IndexSearch { index, .. } => program.resolve_cursor_id(&index.name),
+                Search::IndexSearch {
+                    index,
+                    cover_mapping,
+                    ..
+                } => {
+                    if cover_mapping.is_some() {
+                        program.resolve_cursor_id(&table_reference.table_identifier)
+                    } else {
+                        program.resolve_cursor_id(&index.name)
+                    }
+                }
                 Search::RowidSearch { .. } => {
                     program.resolve_cursor_id(&table_reference.table_identifier)
                 }

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1166,9 +1166,12 @@ fn try_index_cover(
             let (pos, _) = table.get_column(&index_column.name).unwrap();
             index_column_map.insert(pos, i);
         }
-        for pk_name in table.primary_key_column_names.iter() {
-            // SAFETY: the primary key column must exist in the table
-            let (pos, _) = table.get_column(pk_name).unwrap();
+        if table.has_rowid {
+            let pos = table
+                .columns
+                .iter()
+                .position(|column| column.is_rowid_alias)
+                .unwrap();
             index_column_map.insert(pos, index_column_map.len());
         }
 

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1090,7 +1090,7 @@ fn open_loop(
                     if !try_index_cover(
                         program,
                         related_columns,
-                        &table_reference,
+                        table_reference,
                         index_cursor_id,
                         table_cursor_id,
                     ) {
@@ -1172,15 +1172,16 @@ fn try_index_cover(
             index_column_map.insert(pos, index_column_map.len());
         }
 
-        let len = table.columns.len();
         let lower = ColumnBinding {
             table: *table_index,
             column: 0,
         };
-
+        let upper = ColumnBinding {
+            table: table_index + 1,
+            column: 0,
+        };
         let is_cover = related_columns
-            .range(lower..)
-            .take(len)
+            .range(lower..upper)
             .all(|binding| index_column_map.contains_key(&binding.column));
         if is_cover {
             program

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1166,12 +1166,11 @@ fn try_index_cover(
             let (pos, _) = table.get_column(&index_column.name).unwrap();
             index_column_map.insert(pos, i);
         }
-        if table.has_rowid {
-            let pos = table
-                .columns
-                .iter()
-                .position(|column| column.is_rowid_alias)
-                .unwrap();
+        if let Some(pos) = table
+            .columns
+            .iter()
+            .position(|column| column.is_rowid_alias)
+        {
             index_column_map.insert(pos, index_column_map.len());
         }
 

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1976,20 +1976,19 @@ pub fn translate_expr(
                             column: columns_mapping[column],
                             dest: target_register,
                         });
+                    } else if *is_rowid_alias {
+                        program.emit_insn(Insn::RowId {
+                            cursor_id,
+                            dest: target_register,
+                        });
                     } else {
-                        if *is_rowid_alias {
-                            program.emit_insn(Insn::RowId {
-                                cursor_id,
-                                dest: target_register,
-                            });
-                        } else {
-                            program.emit_insn(Insn::Column {
-                                cursor_id,
-                                column: *column,
-                                dest: target_register,
-                            });
-                        }
+                        program.emit_insn(Insn::Column {
+                            cursor_id,
+                            column: *column,
+                            dest: target_register,
+                        });
                     }
+
                     let column = tbl_ref.table.get_column_at(*column);
                     maybe_apply_affinity(column.ty, target_register, program);
                     Ok(target_register)

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1967,12 +1967,10 @@ pub fn translate_expr(
                 // the table and read the column from the cursor.
                 TableReferenceType::BTreeTable => {
                     let cursor_id = program.resolve_cursor_id(&tbl_ref.table_identifier);
-                    if let Some((index_cursor_id, columns_mapping)) =
-                        program.index_cover_cursors.get(&cursor_id)
-                    {
+                    if let Some(columns_mapping) = program.table_remapping_cursors.get(&cursor_id) {
                         // FIXME: row_id is displayed as `column` in explain
                         program.emit_insn(Insn::Column {
-                            cursor_id: *index_cursor_id,
+                            cursor_id,
                             column: columns_mapping[column],
                             dest: target_register,
                         });

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -846,10 +846,10 @@ fn one_select_related_columns(
                 }
             }
             if let Some(from) = from {
-                from_clause_related_columns(&from, related_columns, referenced_tables)?;
+                from_clause_related_columns(from, related_columns, referenced_tables)?;
             }
             if let Some(expr) = where_clause {
-                expr_related_columns(&expr, related_columns, referenced_tables)?;
+                expr_related_columns(expr, related_columns, referenced_tables)?;
             }
             if let Some(group_by) = group_by {
                 for expr in group_by.exprs.iter() {
@@ -861,7 +861,7 @@ fn one_select_related_columns(
             }
             if let Some(windows) = window_clause {
                 for window in windows.iter().map(|window| &window.window) {
-                    window_related_columns(&window, related_columns, referenced_tables)?;
+                    window_related_columns(window, related_columns, referenced_tables)?;
                 }
             }
         }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -16,7 +16,7 @@ use crate::{
     translate::plan::Plan::{Delete, Select},
 };
 use std::cmp::Ordering;
-use std::collections::BTreeSet;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct ResultSetColumn {
@@ -77,8 +77,6 @@ pub struct SelectPlan {
     pub source: SourceOperator,
     /// the columns inside SELECT ... FROM
     pub result_columns: Vec<ResultSetColumn>,
-    /// the columns related to this plan,
-    pub related_columns: BTreeSet<ColumnBinding>,
     /// where clause split into a vec at 'AND' boundaries.
     pub where_clause: Option<Vec<ast::Expr>>,
     /// group by clause
@@ -106,8 +104,6 @@ pub struct DeletePlan {
     pub source: SourceOperator,
     /// the columns inside SELECT ... FROM
     pub result_columns: Vec<ResultSetColumn>,
-    /// the columns related to this plan,
-    pub related_columns: BTreeSet<ColumnBinding>,
     /// where clause split into a vec at 'AND' boundaries.
     pub where_clause: Option<Vec<ast::Expr>>,
     /// order by clause
@@ -324,6 +320,7 @@ pub enum Search {
         index: Rc<Index>,
         cmp_op: ast::Operator,
         cmp_expr: ast::Expr,
+        cover_mapping: Option<HashMap<usize, usize>>,
     },
 }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -11,18 +11,12 @@ use crate::{
     vdbe::BranchOffset,
     Result,
 };
-use core::fmt;
-use sqlite3_parser::ast;
-use std::cmp::Ordering;
-use std::collections::BTreeSet;
-use std::{
-    fmt::{Display, Formatter},
-    rc::Rc,
-};
 use crate::{
     schema::{PseudoTable, Type},
     translate::plan::Plan::{Delete, Select},
 };
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
 
 #[derive(Debug, Clone)]
 pub struct ResultSetColumn {
@@ -45,7 +39,7 @@ pub enum Plan {
     Delete(DeletePlan),
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ColumnBinding {
     pub table: usize,
     pub column: usize,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -14,7 +14,6 @@ use crate::{schema::Schema, vdbe::Program, Result};
 use crate::{Connection, SymbolTable};
 use sqlite3_parser::ast;
 use sqlite3_parser::ast::ResultColumn;
-use std::collections::BTreeSet;
 use std::rc::Weak;
 use std::{cell::RefCell, rc::Rc};
 
@@ -52,7 +51,6 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
             let mut plan = SelectPlan {
                 source,
                 result_columns: vec![],
-                related_columns: BTreeSet::new(),
                 where_clause: None,
                 group_by: None,
                 order_by: None,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1,6 +1,3 @@
-use std::rc::Weak;
-use std::{cell::RefCell, rc::Rc};
-
 use super::emitter::emit_program;
 use super::expr::get_name;
 use super::plan::SelectQueryType;
@@ -17,6 +14,9 @@ use crate::{schema::Schema, vdbe::Program, Result};
 use crate::{Connection, SymbolTable};
 use sqlite3_parser::ast;
 use sqlite3_parser::ast::ResultColumn;
+use std::collections::BTreeSet;
+use std::rc::Weak;
+use std::{cell::RefCell, rc::Rc};
 
 pub fn translate_select(
     schema: &Schema,
@@ -52,6 +52,7 @@ pub fn prepare_select_plan(schema: &Schema, select: ast::Select) -> Result<Plan>
             let mut plan = SelectPlan {
                 source,
                 result_columns: vec![],
+                related_columns: BTreeSet::new(),
                 where_clause: None,
                 group_by: None,
                 order_by: None,

--- a/core/util.rs
+++ b/core/util.rs
@@ -43,7 +43,11 @@ pub fn parse_schema_rows(rows: Option<Rows>, schema: &mut Schema, io: Arc<dyn IO
                             let root_page: i64 = row.get::<i64>(3)?;
                             match row.get::<&str>(4) {
                                 Ok(sql) => {
-                                    let index = schema::Index::from_sql(sql, root_page as usize)?;
+                                    let index = schema::Index::from_sql(
+                                        sql,
+                                        &schema.tables,
+                                        root_page as usize,
+                                    )?;
                                     schema.add_index(Rc::new(index));
                                 }
                                 _ => continue,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -29,8 +29,8 @@ pub struct ProgramBuilder {
     // map of instruction index to manual comment (used in EXPLAIN)
     comments: HashMap<BranchOffset, &'static str>,
     // index cursor that can cover table cursor
-    // Table Cursor -> (Index Cursor, Map<table_column index, index_column index>)
-    pub index_cover_cursors: HashMap<CursorID, (CursorID, HashMap<usize, usize>)>,
+    // Table Cursor -> Map<table_column index, index_column index>
+    pub table_remapping_cursors: HashMap<CursorID, HashMap<usize, usize>>,
 }
 
 impl ProgramBuilder {
@@ -47,7 +47,7 @@ impl ProgramBuilder {
             deferred_label_resolutions: Vec::new(),
             seekrowid_emitted_bitmask: 0,
             comments: HashMap::new(),
-            index_cover_cursors: HashMap::new(),
+            table_remapping_cursors: Default::default(),
         }
     }
 

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -28,6 +28,9 @@ pub struct ProgramBuilder {
     seekrowid_emitted_bitmask: u64,
     // map of instruction index to manual comment (used in EXPLAIN)
     comments: HashMap<BranchOffset, &'static str>,
+    // index cursor that can cover table cursor
+    // Table Cursor -> (Index Cursor, Map<table_column index, index_column index>)
+    pub index_cover_cursors: HashMap<CursorID, (CursorID, HashMap<usize, usize>)>,
 }
 
 impl ProgramBuilder {
@@ -44,6 +47,7 @@ impl ProgramBuilder {
             deferred_label_resolutions: Vec::new(),
             seekrowid_emitted_bitmask: 0,
             comments: HashMap::new(),
+            index_cover_cursors: HashMap::new(),
         }
     }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1840,7 +1840,7 @@ impl Program {
     }
 
     #[inline]
-    fn deferred_seek<'a>(
+    fn deferred_seek(
         deferred_seek: &mut Option<(CursorID, CursorID)>,
         cursors: &mut BTreeMap<CursorID, Box<dyn Cursor>>,
     ) -> Result<bool> {

--- a/testing/where.test
+++ b/testing/where.test
@@ -319,7 +319,7 @@ do_execsql_test where-age-index-seek-regression-test-2 {
 } {10000}
 
 do_execsql_test where-age-index-cover-seek {
-    select id, age from users where age > 90;
+    select id, age from users where age > 90 limit 1;
 } {120|90}
 
 do_execsql_test where-simple-between {

--- a/testing/where.test
+++ b/testing/where.test
@@ -318,6 +318,10 @@ do_execsql_test where-age-index-seek-regression-test-2 {
     select count(1) from users where age > 0;
 } {10000}
 
+do_execsql_test where-age-index-cover-seek {
+    select id, age from users where age > 90;
+} {120|90}
+
 do_execsql_test where-simple-between {
     SELECT * FROM products WHERE price BETWEEN 70 AND 100;
 } {1|hat|79.0

--- a/testing/where.test
+++ b/testing/where.test
@@ -320,7 +320,7 @@ do_execsql_test where-age-index-seek-regression-test-2 {
 
 do_execsql_test where-age-index-cover-seek {
     select id, age from users where age > 90 limit 1;
-} {120|90}
+} {54|91}
 
 do_execsql_test where-simple-between {
     SELECT * FROM products WHERE price BETWEEN 70 AND 100;


### PR DESCRIPTION
issue: https://github.com/tursodatabase/limbo/issues/364

this pr enables limbo to detect whether the relevant columns in the plan can be index covered while the index is hitting, thereby reducing the need to return to the table.

TODO: 
- [ ] : Test for `related_columns` (I refer to other optimization rules but cannot find relevant tests. Do you have any suggestions on this?)
- [ ] : FIXME: row_id is displayed as `column` in explain

```shell
explain select id, age from users where age > 90 limit 1;

addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     14    0                    0   Start at 14
1     OpenReadAsync      0     2     0                    0   table=users, root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     274   0                    0   table=age_idx, root=274
4     OpenReadAwait      0     0     0                    0   
5     Integer            90    1     0                    0   r[1]=90
6     SeekGT             1     13    1                    0   
7       Column           1     1     2                    0   r[2]=age_idx.column 1
8       Column           1     0     3                    0   r[3]=age_idx.age
9       ResultRow        2     2     0                    0   output=r[2..3]
10      DecrJumpZero     4     13    0                    0   if (--r[4]==0) goto 13
11    NextAsync          1     0     0                    0   
12    NextAwait          1     7     0                    0   
13    Halt               0     0     0                    0   
14    Transaction        0     0     0                    0   
15    Integer            1     4     0                    0   r[4]=1
16    Goto               0     1     0                    0   
```

before: 
```shell
explain select id, age from users where age > 90 limit 1;

addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     12    0                    0   Start at 12
1     OpenReadAsync      0     274   0                    0   table=users, root=274
2     OpenReadAwait      0     0     0                    0   
3     Integer            90    4     0                    0   r[4]=90
4     SeekGT             0     11    4                    0   
5       Column           0     1     2                    0   r[2]=users.column 1
6       Column           0     0     3                    0   r[3]=users.age
7       ResultRow        2     2     0                    0   output=r[2..3]
8       DecrJumpZero     1     11    0                    0   if (--r[1]==0) goto 11
9     NextAsync          0     0     0                    0   
10    NextAwait          0     5     0                    0   
11    Halt               0     0     0                    0   
12    Transaction        0     0     0                    0   
13    Integer            1     1     0                    0   r[1]=1
14    Goto               0     1     0                    0   
```