### PR TITLE
fix: index seek wrong on `SeekOp::LT`\`SeekOp::GT`

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -464,9 +464,15 @@ impl BTreeCursor {
                         };
                         let record = crate::storage::sqlite3_ondisk::read_record(payload)?;
                         let found = match op {
-                            SeekOp::GT => record > *index_key,
-                            SeekOp::GE => record >= *index_key,
-                            SeekOp::EQ => record == *index_key,
+                            SeekOp::GT => {
+                                &record.values[..record.values.len() - 1] > &index_key.values
+                            }
+                            SeekOp::GE => {
+                                &record.values[..record.values.len() - 1] >= &index_key.values
+                            }
+                            SeekOp::EQ => {
+                                &record.values[..record.values.len() - 1] == &index_key.values
+                            }
                         };
                         self.stack.advance();
                         if found {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -417,6 +417,7 @@ impl BTreeCursor {
     /// Move the cursor to the record that matches the seek key and seek operation.
     /// This may be used to seek to a specific record in a point query (e.g. SELECT * FROM table WHERE col = 10)
     /// or e.g. find the first record greater than the seek key in a range query (e.g. SELECT * FROM table WHERE col > 10).
+    /// We don't include the rowid in the comparison and that's why the last value from the record is not included.
     fn seek(
         &mut self,
         key: SeekKey<'_>,

--- a/testing/where.test
+++ b/testing/where.test
@@ -318,6 +318,10 @@ do_execsql_test where-age-index-seek-regression-test-2 {
     select count(1) from users where age > 0;
 } {10000}
 
+do_execsql_test where-age-index-seek-regression-test-3 {
+    select age from users where age > 90 limit 1;
+} {91}
+
 do_execsql_test where-simple-between {
     SELECT * FROM products WHERE price BETWEEN 70 AND 100;
 } {1|hat|79.0


### PR DESCRIPTION
data does not match predicate when using index, e.g: `select id, age from users where age > 90 limit 1;` will return data with age  90

the reason is that the current index seek directly uses record for comparison, but the record of the index itself is longer than the record of the key (because it contains the primary key), so Gt is invalid.

since only single-column indexes are currently supported: https://github.com/tursodatabase/limbo/pull/350, only the first value of the record is currently used for comparison.
