### PR TITLE
draft: Convert ExtFunc usage to ExternalFunc

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -5,7 +5,8 @@ use std::rc::Rc;
 
 pub struct ExternalFunc {
     pub name: String,
-    pub func: Box<dyn Fn(&[crate::types::Value]) -> crate::Result<crate::types::OwnedValue>>,
+    pub func:
+        Box<dyn Fn(Option<&[crate::types::Value]>) -> crate::Result<crate::types::OwnedValue>>,
 }
 
 impl Debug for ExternalFunc {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -162,7 +162,7 @@ impl Database {
     pub fn define_scalar_function<S: AsRef<str>>(
         &self,
         name: S,
-        func: impl Fn(&[Value]) -> Result<OwnedValue> + 'static,
+        func: impl Fn(Option<&[Value]>) -> Result<OwnedValue> + 'static,
     ) {
         let func = function::ExternalFunc {
             name: name.as_ref().to_string(),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1601,7 +1601,7 @@ impl Program {
                             _ => unreachable!(), // when more extension types are added
                         },
                         crate::function::Func::External(f) => {
-                            let result = (f.func)(&[])?;
+                            let result = (f.func)(None)?;
                             state.registers[*dest] = result;
                         }
                         crate::function::Func::Math(math_func) => match math_func.arity() {


### PR DESCRIPTION
#583 

Following the example of this [commit](https://github.com/tursodatabase/limbo/commit/0aabcddf18fed76be57bb12ed0aa44585f205808), to convert the usage of `ExtFunc`  in `core/ext` to `ExternalFunc`.
