### PR TITLE
Add support for `rowid` keyword

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1545,6 +1545,15 @@ pub fn translate_expr(
                 }
             }
         }
+        ast::Expr::RowId { database: _, table } => {
+            let tbl_ref = referenced_tables.as_ref().unwrap().get(*table).unwrap();
+            let cursor_id = program.resolve_cursor_id(&tbl_ref.table_identifier);
+            program.emit_insn(Insn::RowId {
+                cursor_id,
+                dest: target_register,
+            });
+            Ok(target_register)
+        }
         ast::Expr::InList { .. } => todo!(),
         ast::Expr::InSelect { .. } => todo!(),
         ast::Expr::InTable { .. } => todo!(),

--- a/testing/join.test
+++ b/testing/join.test
@@ -114,14 +114,6 @@ do_execsql_test left-join-row-id {
 13|
 14|}
 
-do_execsql_test left-join-row-id-2 {
-    select u.rowid, p.rowid from users u left join products as p using(rowid) where u.rowid >= 10 limit 5;
-} {10|10
-11|11
-12|
-13|
-14|}
-
 do_execsql_test left-join-constant-condition-true {
     select u.first_name, p.name from users u left join products as p on true limit 1;
 } {Jamie|hat}

--- a/testing/join.test
+++ b/testing/join.test
@@ -106,6 +106,22 @@ Jamie|coat
 Jamie|accessories
 Cindy|}
 
+do_execsql_test left-join-row-id {
+    select u.rowid, p.rowid from users u left join products as p on u.rowid = p.rowid where u.rowid >= 10 limit 5;
+} {10|10
+11|11
+12|
+13|
+14|}
+
+do_execsql_test left-join-row-id-2 {
+    select u.rowid, p.rowid from users u left join products as p using(rowid) where u.rowid >= 10 limit 5;
+} {10|10
+11|11
+12|
+13|
+14|}
+
 do_execsql_test left-join-constant-condition-true {
     select u.first_name, p.name from users u left join products as p on true limit 1;
 } {Jamie|hat}

--- a/testing/select.test
+++ b/testing/select.test
@@ -85,7 +85,7 @@ do_execsql_test select-rowid {
 } {5|Edward}
 
 do_execsql_test select-rowid-2 {
-    select users.rowid, first_name from users u where rowid = 5;
+    select u.rowid, first_name from users u where rowid = 5;
 } {5|Edward}
 
 do_execsql_test seekrowid {

--- a/testing/select.test
+++ b/testing/select.test
@@ -80,6 +80,14 @@ do_execsql_test select_with_quoting_2 {
   select "users".`id` from users where `users`.[id] = 5;
 } {5}
 
+do_execsql_test select-rowid {
+    select rowid, first_name from users u where rowid = 5;
+} {5|Edward}
+
+do_execsql_test select-rowid-2 {
+    select users.rowid, first_name from users u where rowid = 5;
+} {5|Edward}
+
 do_execsql_test seekrowid {
     select * from users u where u.id = 5;
 } {"5|Edward|Miller|christiankramer@example.com|725-281-1033|08522 English Plain|Lake Keith|ID|23283|15"}

--- a/vendored/sqlite3-parser/src/parser/ast/check.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/check.rs
@@ -194,6 +194,9 @@ impl CreateTableBody {
         {
             let mut generated_count = 0;
             for c in columns.values() {
+                if c.col_name == "rowid" {
+                    return Err(custom_err!("cannot use reserved word: ROWID"));
+                }
                 for cs in &c.constraints {
                     if let ColumnConstraint::Generated { .. } = cs.constraint {
                         generated_count += 1;

--- a/vendored/sqlite3-parser/src/parser/ast/fmt.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/fmt.rs
@@ -728,6 +728,7 @@ impl ToTokens for Expr {
                 }
                 s.append(TK_RP, None)
             }
+            Self::RowId { .. } => Ok(()),
             Self::Subquery(query) => {
                 s.append(TK_LP, None)?;
                 query.to_tokens(s)?;

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -338,6 +338,13 @@ pub enum Expr {
         /// is the column a rowid alias
         is_rowid_alias: bool,
     },
+    /// `ROWID`
+    RowId {
+        /// the x in `x.y.z`. index of the db in catalog.
+        database: Option<usize>,
+        /// the y in `x.y.z`. index of the table in catalog.
+        table: usize,
+    },
     /// `IN`
     InList {
         /// expression


### PR DESCRIPTION
https://github.com/tursodatabase/limbo/issues/241

support keyword `rowid`

check if rowid exists when creating table

```shell
explain SELECT rowid FROM users WHERE rowid = 1;

addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     12    0                    0   Start at 12
1     OpenReadAsync      0     2     0                    0   table=users, root=2
2     OpenReadAwait      0     0     0                    0   
3     RewindAsync        0     0     0                    0   
4     RewindAwait        0     11    0                    0   Rewind table users
5       RowId            0     2     0                    0   r[2]=users.rowid
6       Ne               2     3     9                    0   if r[2]!=r[3] goto 9
7       RowId            0     1     0                    0   r[1]=users.rowid
8       ResultRow        1     1     0                    0   output=r[1]
9     NextAsync          0     0     0                    0   
10    NextAwait          0     5     0                    0   
11    Halt               0     0     0                    0   
12    Transaction        0     0     0                    0   
13    Integer            1     3     0                    0   r[3]=1
14    Goto               0     1     0                    0   
```