### PR TITLE
Remove SQLite headers dependency from compat tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ make test
 To run the test suite with SQLite, type:
 
 ```
-SQLITE_EXEC=sqlite3 make test
+SQLITE_EXEC=sqlite3 SQLITE_FLAGS="" make test
 ```
 
 When working on a new feature, please consider adding a test case for it.

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ SQLITE_EXEC ?= ./target/debug/limbo
 
 # Static library to use for SQLite C API compatibility tests.
 BASE_SQLITE_LIB = ./target/$(CURRENT_RUST_TARGET)/debug/liblimbo_sqlite3.a
+# Static library headers to use for SQLITE C API compatibility tests
+BASE_SQLITE_LIB_HEADERS = ./target/$(CURRENT_RUST_TARGET)/debug/include/limbo_sqlite3
+
 
 # On darwin link core foundation
 ifeq ($(UNAME_S),Darwin)
@@ -16,6 +19,8 @@ ifeq ($(UNAME_S),Darwin)
 else
     SQLITE_LIB ?= ../../$(BASE_SQLITE_LIB)
 endif
+
+SQLITE_LIB_HEADERS ?= ../../$(BASE_SQLITE_LIB_HEADERS)
 
 all: check-rust-version check-wasm-target limbo limbo-wasm
 .PHONY: all
@@ -69,5 +74,5 @@ test-compat:
 .PHONY: test-compat
 
 test-sqlite3: limbo-c
-	LIBS="$(SQLITE_LIB)" make -C sqlite3/tests test
+	LIBS="$(SQLITE_LIB)" HEADERS="$(SQLITE_LIB_HEADERS)" make -C sqlite3/tests test
 .PHONY: test-sqlite3

--- a/sqlite3/include/sqlite3.h
+++ b/sqlite3/include/sqlite3.h
@@ -13,7 +13,9 @@
 
 #define SQLITE_NOMEM 7
 
-#define SQLITE_NOTFOUND 14
+#define SQLITE_NOTFOUND 12
+
+#define SQLITE_CANTOPEN 14
 
 #define SQLITE_MISUSE 21
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -20,7 +20,8 @@ pub const SQLITE_ABORT: ffi::c_int = 4;
 pub const SQLITE_BUSY: ffi::c_int = 5;
 pub const SQLITE_NOMEM: ffi::c_int = 7;
 pub const SQLITE_INTERRUPT: ffi::c_int = 9;
-pub const SQLITE_NOTFOUND: ffi::c_int = 14;
+pub const SQLITE_NOTFOUND: ffi::c_int = 12;
+pub const SQLITE_CANTOPEN: ffi::c_int = 14;
 pub const SQLITE_MISUSE: ffi::c_int = 21;
 pub const SQLITE_ROW: ffi::c_int = 100;
 pub const SQLITE_DONE: ffi::c_int = 101;
@@ -121,7 +122,7 @@ pub unsafe extern "C" fn sqlite3_open(
             *db_out = Box::leak(Box::new(sqlite3::new(db, conn)));
             SQLITE_OK
         }
-        Err(_e) => SQLITE_NOTFOUND,
+        Err(_e) => SQLITE_CANTOPEN,
     }
 }
 

--- a/sqlite3/tests/Makefile
+++ b/sqlite3/tests/Makefile
@@ -29,7 +29,7 @@ test: $(PROGRAM)
 
 %.o: %.c
 	$(E) "  CC      " $@
-	$(Q) $(CC) $(CFLAGS) -c $< -o $@
+	$(Q) $(CC) $(CFLAGS) -c $< -o $@ -I$(HEADERS)
 
 $(PROGRAM): $(OBJS)
 	$(E) "  LINK    " $@


### PR DESCRIPTION
* Add SQLITE_FLAGS env variable handling to compatibility tests as SQLite does not handle `-q` flag
* Fix inconsistent SQLITE_NOTFOUND error code and add SQLITE_CANTOPEN code
* Improve compatibility tests to display errors instead of hanging indefinitely 