### PR TITLE
Fix quote escape in literals

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -2075,8 +2075,8 @@ pub fn get_name(
     }
 }
 
-// Sanitaizes a string literal by removing single quote at front and back
-// and escaping double single quotes
+/// Sanitaizes a string literal by removing single quote at front and back
+/// and escaping double single quotes
 pub fn sanitize_string(input: &str) -> String {
     input[1..input.len() - 1].replace("''", "'").to_string()
 }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1854,7 +1854,7 @@ pub fn translate_expr(
             }
             ast::Literal::String(s) => {
                 program.emit_insn(Insn::String8 {
-                    value: s[1..s.len() - 1].replace("''", "'").to_string(),
+                    value: sanitize_string(s),
                     dest: target_register,
                 });
                 Ok(target_register)
@@ -2073,4 +2073,10 @@ pub fn get_name(
         }
         _ => fallback(),
     }
+}
+
+// Sanitaizes a string literal by removing single quote at front and back
+// and escaping double single quotes
+pub fn sanitize_string(input: &str) -> String {
+    input[1..input.len() - 1].replace("''", "'").to_string()
 }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1854,7 +1854,7 @@ pub fn translate_expr(
             }
             ast::Literal::String(s) => {
                 program.emit_insn(Insn::String8 {
-                    value: s[1..s.len() - 1].to_string(),
+                    value: s[1..s.len() - 1].replace("''", "'").to_string(),
                     dest: target_register,
                 });
                 Ok(target_register)

--- a/testing/select.test
+++ b/testing/select.test
@@ -11,6 +11,10 @@ do_execsql_test select-const-2 {
   SELECT 2
 } {2}
 
+do_execsql_test select-text-escape-1 {
+  SELECT '''a'
+} {'a}
+
 do_execsql_test select-blob-empty {
   SELECT x'';
 } {}


### PR DESCRIPTION
Previously we were not escaping the quotes properly in stirng literals as shown below. The PR fixes that

limbo output without this PR
```
limbo> select '''a';
''a
limbo>  explain select '''a';
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     4     0                    0   Start at 4
1     String8            0     1     0     ''a            0   r[1]='''a'
2     ResultRow          1     1     0                    0   output=r[1]
3     Halt               0     0     0                    0
4     Transaction        0     0     0                    0
5     Goto               0     1     0                    0
```

sqlite3 output
```
sqlite> select '''a';
'a
sqlite> explain select '''a';
addr  opcode         p1    p2    p3    p4             p5  comment      
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     4     0                    0
1     String8        0     1     0     'a             0
2     ResultRow      1     1     0                    0
3     Halt           0     0     0                    0
4     Goto           0     1     0                    0 
```

limbo output with this PR
```
limbo> select '''a';
'a
limbo> explain select '''a';
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     4     0                    0   Start at 4
1     String8            0     1     0     'a             0   r[1]=''a'
2     ResultRow          1     1     0                    0   output=r[1]
3     Halt               0     0     0                    0
4     Transaction        0     0     0                    0
5     Goto               0     1     0                    0
```