### PR TITLE
Extended `balance_root` to handle root underflow case

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1302,7 +1302,7 @@ impl BTreeCursor {
                 self.pager.load_page(child_page.clone())?;
                 return Ok(CursorResult::IO);
             }
-    
+
             let child_contents = child_page.get().contents.as_mut().unwrap();
 
             // Defragment child before inserting its cells into root because root is smaller than child due to it

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1271,6 +1271,10 @@ impl BTreeCursor {
                 .expect("This shouldn't have happened, child page not found");
             let child_contents = child_page.get().contents.as_mut().unwrap();
 
+            // Defragment child before inserting its cells into root because root is smaller than child due to it
+            // containing header.
+            self.defragment_page(child_contents, self.database_header.borrow());
+
             let necessary_space = self.calculate_used_space(child_contents);
             let available_space = if is_page_1 {
                 self.usable_space() - DATABASE_HEADER_SIZE

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -370,7 +370,7 @@ fn write_header_to_buf(buf: &mut [u8], header: &DatabaseHeader) {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum PageType {
     IndexInterior = 2,
     TableInterior = 5,
@@ -421,9 +421,13 @@ impl PageContent {
     }
 
     pub fn maybe_page_type(&self) -> Option<PageType> {
-        match self.read_u8(0).try_into() {
-            Ok(v) => Some(v),
-            Err(_) => None, // this could be an overflow page
+        let page_type = self.read_u8(0);
+        match page_type {
+            2 => Some(PageType::IndexInterior),
+            5 => Some(PageType::TableInterior),
+            10 => Some(PageType::IndexLeaf),
+            13 => Some(PageType::TableLeaf),
+            _ => None, // This handles overflow pages and any other non-btree page types
         }
     }
 
@@ -534,11 +538,14 @@ impl PageContent {
     }
 
     pub fn rightmost_pointer(&self) -> Option<u32> {
-        match self.page_type() {
-            PageType::IndexInterior => Some(self.read_u32(8)),
-            PageType::TableInterior => Some(self.read_u32(8)),
-            PageType::IndexLeaf => None,
-            PageType::TableLeaf => None,
+        match self.maybe_page_type() {
+            Some(page_type) => match page_type {
+                PageType::IndexInterior => Some(self.read_u32(8)),
+                PageType::TableInterior => Some(self.read_u32(8)),
+                PageType::IndexLeaf => None,
+                PageType::TableLeaf => None,
+            },
+            None => None, // Handle overflow pages by returning None
         }
     }
 
@@ -650,11 +657,15 @@ impl PageContent {
     }
 
     pub fn is_leaf(&self) -> bool {
-        match self.page_type() {
-            PageType::IndexInterior => false,
-            PageType::TableInterior => false,
-            PageType::IndexLeaf => true,
-            PageType::TableLeaf => true,
+        // First check if this is a btree page by looking at the type
+        match self.maybe_page_type() {
+            Some(page_type) => match page_type {
+                PageType::IndexInterior => false,
+                PageType::TableInterior => false,
+                PageType::IndexLeaf => true,
+                PageType::TableLeaf => true,
+            },
+            None => false, // Overflow pages are not leaf pages
         }
     }
 


### PR DESCRIPTION
Balance root now handles root underflow case:

- Root becomes underflow when its empty. Its a special case.
- We try and copy root's child into root.
- If successful we delete the child and update pointers.
- If unsuccessful because the child can't fit inside the root, we early return and handle the child overflow in `balance_leaf`
