### PR TITLE
Simplify working with labels

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -13,7 +13,7 @@ use crate::Result;
 use super::emitter::Resolver;
 use super::plan::{TableReference, TableReferenceType};
 
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct ConditionMetadata {
     pub jump_if_condition_is_true: bool,
     pub jump_target_when_true: BranchOffset,
@@ -87,128 +87,92 @@ pub fn translate_condition_expr(
             match op {
                 ast::Operator::Greater => {
                     if condition_metadata.jump_if_condition_is_true {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Gt {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_true,
-                            },
-                            condition_metadata.jump_target_when_true,
-                        )
+                        program.emit_insn(Insn::Gt {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_true,
+                        })
                     } else {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Le {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_false,
-                            },
-                            condition_metadata.jump_target_when_false,
-                        )
+                        program.emit_insn(Insn::Le {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_false,
+                        })
                     }
                 }
                 ast::Operator::GreaterEquals => {
                     if condition_metadata.jump_if_condition_is_true {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Ge {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_true,
-                            },
-                            condition_metadata.jump_target_when_true,
-                        )
+                        program.emit_insn(Insn::Ge {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_true,
+                        })
                     } else {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Lt {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_false,
-                            },
-                            condition_metadata.jump_target_when_false,
-                        )
+                        program.emit_insn(Insn::Lt {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_false,
+                        })
                     }
                 }
                 ast::Operator::Less => {
                     if condition_metadata.jump_if_condition_is_true {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Lt {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_true,
-                            },
-                            condition_metadata.jump_target_when_true,
-                        )
+                        program.emit_insn(Insn::Lt {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_true,
+                        })
                     } else {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Ge {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_false,
-                            },
-                            condition_metadata.jump_target_when_false,
-                        )
+                        program.emit_insn(Insn::Ge {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_false,
+                        })
                     }
                 }
                 ast::Operator::LessEquals => {
                     if condition_metadata.jump_if_condition_is_true {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Le {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_true,
-                            },
-                            condition_metadata.jump_target_when_true,
-                        )
+                        program.emit_insn(Insn::Le {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_true,
+                        })
                     } else {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Gt {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_false,
-                            },
-                            condition_metadata.jump_target_when_false,
-                        )
+                        program.emit_insn(Insn::Gt {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_false,
+                        })
                     }
                 }
                 ast::Operator::Equals => {
                     if condition_metadata.jump_if_condition_is_true {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Eq {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_true,
-                            },
-                            condition_metadata.jump_target_when_true,
-                        )
+                        program.emit_insn(Insn::Eq {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_true,
+                        })
                     } else {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Ne {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_false,
-                            },
-                            condition_metadata.jump_target_when_false,
-                        )
+                        program.emit_insn(Insn::Ne {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_false,
+                        })
                     }
                 }
                 ast::Operator::NotEquals => {
                     if condition_metadata.jump_if_condition_is_true {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Ne {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_true,
-                            },
-                            condition_metadata.jump_target_when_true,
-                        )
+                        program.emit_insn(Insn::Ne {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_true,
+                        })
                     } else {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Eq {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_false,
-                            },
-                            condition_metadata.jump_target_when_false,
-                        )
+                        program.emit_insn(Insn::Eq {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_false,
+                        })
                     }
                 }
                 ast::Operator::Is => todo!(),
@@ -228,23 +192,17 @@ pub fn translate_condition_expr(
                         dest: reg,
                     });
                     if condition_metadata.jump_if_condition_is_true {
-                        program.emit_insn_with_label_dependency(
-                            Insn::If {
-                                reg,
-                                target_pc: condition_metadata.jump_target_when_true,
-                                null_reg: reg,
-                            },
-                            condition_metadata.jump_target_when_true,
-                        )
+                        program.emit_insn(Insn::If {
+                            reg,
+                            target_pc: condition_metadata.jump_target_when_true,
+                            null_reg: reg,
+                        })
                     } else {
-                        program.emit_insn_with_label_dependency(
-                            Insn::IfNot {
-                                reg,
-                                target_pc: condition_metadata.jump_target_when_false,
-                                null_reg: reg,
-                            },
-                            condition_metadata.jump_target_when_false,
-                        )
+                        program.emit_insn(Insn::IfNot {
+                            reg,
+                            target_pc: condition_metadata.jump_target_when_false,
+                            null_reg: reg,
+                        })
                     }
                 } else {
                     crate::bail_parse_error!("unsupported literal type in condition");
@@ -257,23 +215,17 @@ pub fn translate_condition_expr(
                     dest: reg,
                 });
                 if condition_metadata.jump_if_condition_is_true {
-                    program.emit_insn_with_label_dependency(
-                        Insn::If {
-                            reg,
-                            target_pc: condition_metadata.jump_target_when_true,
-                            null_reg: reg,
-                        },
-                        condition_metadata.jump_target_when_true,
-                    )
+                    program.emit_insn(Insn::If {
+                        reg,
+                        target_pc: condition_metadata.jump_target_when_true,
+                        null_reg: reg,
+                    })
                 } else {
-                    program.emit_insn_with_label_dependency(
-                        Insn::IfNot {
-                            reg,
-                            target_pc: condition_metadata.jump_target_when_false,
-                            null_reg: reg,
-                        },
-                        condition_metadata.jump_target_when_false,
-                    )
+                    program.emit_insn(Insn::IfNot {
+                        reg,
+                        target_pc: condition_metadata.jump_target_when_false,
+                        null_reg: reg,
+                    })
                 }
             }
             unimpl => todo!("literal {:?} not implemented", unimpl),
@@ -302,20 +254,14 @@ pub fn translate_condition_expr(
                     // Note that we are already breaking up our WHERE clauses into a series of terms at "AND" boundaries, so right now we won't be running into cases where jumping on true would be incorrect,
                     // but once we have e.g. parenthesization and more complex conditions, not having this 'if' here would introduce a bug.
                     if condition_metadata.jump_if_condition_is_true {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Goto {
-                                target_pc: condition_metadata.jump_target_when_true,
-                            },
-                            condition_metadata.jump_target_when_true,
-                        );
+                        program.emit_insn(Insn::Goto {
+                            target_pc: condition_metadata.jump_target_when_true,
+                        });
                     }
                 } else {
-                    program.emit_insn_with_label_dependency(
-                        Insn::Goto {
-                            target_pc: condition_metadata.jump_target_when_false,
-                        },
-                        condition_metadata.jump_target_when_false,
-                    );
+                    program.emit_insn(Insn::Goto {
+                        target_pc: condition_metadata.jump_target_when_false,
+                    });
                 }
                 return Ok(());
             }
@@ -349,35 +295,26 @@ pub fn translate_condition_expr(
                         translate_expr(program, Some(referenced_tables), expr, rhs_reg, resolver)?;
                     // If this is not the last condition, we need to jump to the 'jump_target_when_true' label if the condition is true.
                     if !last_condition {
-                        program.emit_insn_with_label_dependency(
-                            Insn::Eq {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: jump_target_when_true,
-                            },
-                            jump_target_when_true,
-                        );
+                        program.emit_insn(Insn::Eq {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: jump_target_when_true,
+                        });
                     } else {
                         // If this is the last condition, we need to jump to the 'jump_target_when_false' label if there is no match.
-                        program.emit_insn_with_label_dependency(
-                            Insn::Ne {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg,
-                                target_pc: condition_metadata.jump_target_when_false,
-                            },
-                            condition_metadata.jump_target_when_false,
-                        );
+                        program.emit_insn(Insn::Ne {
+                            lhs: lhs_reg,
+                            rhs: rhs_reg,
+                            target_pc: condition_metadata.jump_target_when_false,
+                        });
                     }
                 }
                 // If we got here, then the last condition was a match, so we jump to the 'jump_target_when_true' label if 'jump_if_condition_is_true'.
                 // If not, we can just fall through without emitting an unnecessary instruction.
                 if condition_metadata.jump_if_condition_is_true {
-                    program.emit_insn_with_label_dependency(
-                        Insn::Goto {
-                            target_pc: condition_metadata.jump_target_when_true,
-                        },
-                        condition_metadata.jump_target_when_true,
-                    );
+                    program.emit_insn(Insn::Goto {
+                        target_pc: condition_metadata.jump_target_when_true,
+                    });
                 }
             } else {
                 // If it's a NOT IN expression, we need to jump to the 'jump_target_when_false' label if any of the conditions are true.
@@ -385,24 +322,18 @@ pub fn translate_condition_expr(
                     let rhs_reg = program.alloc_register();
                     let _ =
                         translate_expr(program, Some(referenced_tables), expr, rhs_reg, resolver)?;
-                    program.emit_insn_with_label_dependency(
-                        Insn::Eq {
-                            lhs: lhs_reg,
-                            rhs: rhs_reg,
-                            target_pc: condition_metadata.jump_target_when_false,
-                        },
-                        condition_metadata.jump_target_when_false,
-                    );
+                    program.emit_insn(Insn::Eq {
+                        lhs: lhs_reg,
+                        rhs: rhs_reg,
+                        target_pc: condition_metadata.jump_target_when_false,
+                    });
                 }
                 // If we got here, then none of the conditions were a match, so we jump to the 'jump_target_when_true' label if 'jump_if_condition_is_true'.
                 // If not, we can just fall through without emitting an unnecessary instruction.
                 if condition_metadata.jump_if_condition_is_true {
-                    program.emit_insn_with_label_dependency(
-                        Insn::Goto {
-                            target_pc: condition_metadata.jump_target_when_true,
-                        },
-                        condition_metadata.jump_target_when_true,
-                    );
+                    program.emit_insn(Insn::Goto {
+                        target_pc: condition_metadata.jump_target_when_true,
+                    });
                 }
             }
 
@@ -464,42 +395,30 @@ pub fn translate_condition_expr(
             }
             if !*not {
                 if condition_metadata.jump_if_condition_is_true {
-                    program.emit_insn_with_label_dependency(
-                        Insn::If {
-                            reg: cur_reg,
-                            target_pc: condition_metadata.jump_target_when_true,
-                            null_reg: cur_reg,
-                        },
-                        condition_metadata.jump_target_when_true,
-                    );
-                } else {
-                    program.emit_insn_with_label_dependency(
-                        Insn::IfNot {
-                            reg: cur_reg,
-                            target_pc: condition_metadata.jump_target_when_false,
-                            null_reg: cur_reg,
-                        },
-                        condition_metadata.jump_target_when_false,
-                    );
-                }
-            } else if condition_metadata.jump_if_condition_is_true {
-                program.emit_insn_with_label_dependency(
-                    Insn::IfNot {
+                    program.emit_insn(Insn::If {
                         reg: cur_reg,
                         target_pc: condition_metadata.jump_target_when_true,
                         null_reg: cur_reg,
-                    },
-                    condition_metadata.jump_target_when_true,
-                );
-            } else {
-                program.emit_insn_with_label_dependency(
-                    Insn::If {
+                    });
+                } else {
+                    program.emit_insn(Insn::IfNot {
                         reg: cur_reg,
                         target_pc: condition_metadata.jump_target_when_false,
                         null_reg: cur_reg,
-                    },
-                    condition_metadata.jump_target_when_false,
-                );
+                    });
+                }
+            } else if condition_metadata.jump_if_condition_is_true {
+                program.emit_insn(Insn::IfNot {
+                    reg: cur_reg,
+                    target_pc: condition_metadata.jump_target_when_true,
+                    null_reg: cur_reg,
+                });
+            } else {
+                program.emit_insn(Insn::If {
+                    reg: cur_reg,
+                    target_pc: condition_metadata.jump_target_when_false,
+                    null_reg: cur_reg,
+                });
             }
         }
         ast::Expr::Parenthesized(exprs) => {
@@ -707,23 +626,17 @@ pub fn translate_expr(
                 translate_expr(program, referenced_tables, when_expr, expr_reg, resolver)?;
                 match base_reg {
                     // CASE 1 WHEN 0 THEN 0 ELSE 1 becomes 1==0, Ne branch to next clause
-                    Some(base_reg) => program.emit_insn_with_label_dependency(
-                        Insn::Ne {
-                            lhs: base_reg,
-                            rhs: expr_reg,
-                            target_pc: next_case_label,
-                        },
-                        next_case_label,
-                    ),
+                    Some(base_reg) => program.emit_insn(Insn::Ne {
+                        lhs: base_reg,
+                        rhs: expr_reg,
+                        target_pc: next_case_label,
+                    }),
                     // CASE WHEN 0 THEN 0 ELSE 1 becomes ifnot 0 branch to next clause
-                    None => program.emit_insn_with_label_dependency(
-                        Insn::IfNot {
-                            reg: expr_reg,
-                            target_pc: next_case_label,
-                            null_reg: 1,
-                        },
-                        next_case_label,
-                    ),
+                    None => program.emit_insn(Insn::IfNot {
+                        reg: expr_reg,
+                        target_pc: next_case_label,
+                        null_reg: 1,
+                    }),
                 };
                 // THEN...
                 translate_expr(
@@ -733,12 +646,9 @@ pub fn translate_expr(
                     target_register,
                     resolver,
                 )?;
-                program.emit_insn_with_label_dependency(
-                    Insn::Goto {
-                        target_pc: return_label,
-                    },
-                    return_label,
-                );
+                program.emit_insn(Insn::Goto {
+                    target_pc: return_label,
+                });
                 // This becomes either the next WHEN, or in the last WHEN/THEN, we're
                 // assured to have at least one instruction corresponding to the ELSE immediately follow.
                 program.preassign_label_to_next_insn(next_case_label);
@@ -984,13 +894,10 @@ pub fn translate_expr(
                                     resolver,
                                 )?;
                                 if index < args.len() - 1 {
-                                    program.emit_insn_with_label_dependency(
-                                        Insn::NotNull {
-                                            reg,
-                                            target_pc: label_coalesce_end,
-                                        },
-                                        label_coalesce_end,
-                                    );
+                                    program.emit_insn(Insn::NotNull {
+                                        reg,
+                                        target_pc: label_coalesce_end,
+                                    });
                                 }
                             }
                             program.preassign_label_to_next_insn(label_coalesce_end);
@@ -1085,7 +992,7 @@ pub fn translate_expr(
                             )?;
                             program.emit_insn(Insn::NotNull {
                                 reg: temp_reg,
-                                target_pc: program.offset() + 2,
+                                target_pc: program.offset().add(2u32),
                             });
 
                             translate_expr(
@@ -1120,14 +1027,11 @@ pub fn translate_expr(
                                 resolver,
                             )?;
                             let jump_target_when_false = program.allocate_label();
-                            program.emit_insn_with_label_dependency(
-                                Insn::IfNot {
-                                    reg: temp_reg,
-                                    target_pc: jump_target_when_false,
-                                    null_reg: 1,
-                                },
-                                jump_target_when_false,
-                            );
+                            program.emit_insn(Insn::IfNot {
+                                reg: temp_reg,
+                                target_pc: jump_target_when_false,
+                                null_reg: 1,
+                            });
                             translate_expr(
                                 program,
                                 referenced_tables,
@@ -1136,12 +1040,9 @@ pub fn translate_expr(
                                 resolver,
                             )?;
                             let jump_target_result = program.allocate_label();
-                            program.emit_insn_with_label_dependency(
-                                Insn::Goto {
-                                    target_pc: jump_target_result,
-                                },
-                                jump_target_result,
-                            );
+                            program.emit_insn(Insn::Goto {
+                                target_pc: jump_target_result,
+                            });
                             program.resolve_label(jump_target_when_false, program.offset());
                             translate_expr(
                                 program,
@@ -2033,7 +1934,7 @@ fn wrap_eval_jump_expr(
         value: 1, // emit True by default
         dest: target_register,
     });
-    program.emit_insn_with_label_dependency(insn, if_true_label);
+    program.emit_insn(insn);
     program.emit_insn(Insn::Integer {
         value: 0, // emit False if we reach this point (no jump)
         dest: target_register,

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -194,7 +194,7 @@ pub fn open_loop(
             // In case the subquery is an inner loop, it needs to be reinitialized on each iteration of the outer loop.
             program.emit_insn(Insn::InitCoroutine {
                 yield_reg,
-                jump_on_definition: 0,
+                jump_on_definition: BranchOffset::Offset(0),
                 start_offset: coroutine_implementation_start,
             });
             let LoopLabels {
@@ -205,18 +205,15 @@ pub fn open_loop(
                 .labels_main_loop
                 .get(id)
                 .expect("subquery has no loop labels");
-            program.defer_label_resolution(loop_start, program.offset() as usize);
+            program.resolve_label(loop_start, program.offset());
             // A subquery within the main loop of a parent query has no cursor, so instead of advancing the cursor,
             // it emits a Yield which jumps back to the main loop of the subquery itself to retrieve the next row.
             // When the subquery coroutine completes, this instruction jumps to the label at the top of the termination_label_stack,
             // which in this case is the end of the Yield-Goto loop in the parent query.
-            program.emit_insn_with_label_dependency(
-                Insn::Yield {
-                    yield_reg,
-                    end_offset: loop_end,
-                },
-                loop_end,
-            );
+            program.emit_insn(Insn::Yield {
+                yield_reg,
+                end_offset: loop_end,
+            });
 
             // These are predicates evaluated outside of the subquery,
             // so they are translated here.
@@ -291,10 +288,7 @@ pub fn open_loop(
 
             if *outer {
                 let lj_meta = t_ctx.meta_left_joins.get(id).unwrap();
-                program.defer_label_resolution(
-                    lj_meta.label_match_flag_set_true,
-                    program.offset() as usize,
-                );
+                program.resolve_label(lj_meta.label_match_flag_set_true, program.offset());
                 program.emit_insn(Insn::Integer {
                     value: 1,
                     dest: lj_meta.reg_match_flag,
@@ -326,7 +320,7 @@ pub fn open_loop(
                 .labels_main_loop
                 .get(id)
                 .expect("scan has no loop labels");
-            program.emit_insn_with_label_dependency(
+            program.emit_insn(
                 if iter_dir
                     .as_ref()
                     .is_some_and(|dir| *dir == IterationDirection::Backwards)
@@ -341,9 +335,8 @@ pub fn open_loop(
                         pc_if_empty: loop_end,
                     }
                 },
-                loop_end,
             );
-            program.defer_label_resolution(loop_start, program.offset() as usize);
+            program.resolve_label(loop_start, program.offset());
 
             if let Some(preds) = predicates {
                 for expr in preds {
@@ -420,28 +413,25 @@ pub fn open_loop(
                     _ => unreachable!(),
                 }
                 // If we try to seek to a key that is not present in the table/index, we exit the loop entirely.
-                program.emit_insn_with_label_dependency(
-                    match cmp_op {
-                        ast::Operator::Equals | ast::Operator::GreaterEquals => Insn::SeekGE {
-                            is_index: index_cursor_id.is_some(),
-                            cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
-                            start_reg: cmp_reg,
-                            num_regs: 1,
-                            target_pc: loop_end,
-                        },
-                        ast::Operator::Greater
-                        | ast::Operator::Less
-                        | ast::Operator::LessEquals => Insn::SeekGT {
-                            is_index: index_cursor_id.is_some(),
-                            cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
-                            start_reg: cmp_reg,
-                            num_regs: 1,
-                            target_pc: loop_end,
-                        },
-                        _ => unreachable!(),
+                program.emit_insn(match cmp_op {
+                    ast::Operator::Equals | ast::Operator::GreaterEquals => Insn::SeekGE {
+                        is_index: index_cursor_id.is_some(),
+                        cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
+                        start_reg: cmp_reg,
+                        num_regs: 1,
+                        target_pc: loop_end,
                     },
-                    loop_end,
-                );
+                    ast::Operator::Greater | ast::Operator::Less | ast::Operator::LessEquals => {
+                        Insn::SeekGT {
+                            is_index: index_cursor_id.is_some(),
+                            cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
+                            start_reg: cmp_reg,
+                            num_regs: 1,
+                            target_pc: loop_end,
+                        }
+                    }
+                    _ => unreachable!(),
+                });
                 if *cmp_op == ast::Operator::Less || *cmp_op == ast::Operator::LessEquals {
                     translate_expr(
                         program,
@@ -452,7 +442,7 @@ pub fn open_loop(
                     )?;
                 }
 
-                program.defer_label_resolution(loop_start, program.offset() as usize);
+                program.resolve_label(loop_start, program.offset());
                 // TODO: We are currently only handling ascending indexes.
                 // For conditions like index_key > 10, we have already seeked to the first key greater than 10, and can just scan forward.
                 // For conditions like index_key < 10, we are at the beginning of the index, and will scan forward and emit IdxGE(10) with a conditional jump to the end.
@@ -466,56 +456,44 @@ pub fn open_loop(
                 match cmp_op {
                     ast::Operator::Equals | ast::Operator::LessEquals => {
                         if let Some(index_cursor_id) = index_cursor_id {
-                            program.emit_insn_with_label_dependency(
-                                Insn::IdxGT {
-                                    cursor_id: index_cursor_id,
-                                    start_reg: cmp_reg,
-                                    num_regs: 1,
-                                    target_pc: loop_end,
-                                },
-                                loop_end,
-                            );
+                            program.emit_insn(Insn::IdxGT {
+                                cursor_id: index_cursor_id,
+                                start_reg: cmp_reg,
+                                num_regs: 1,
+                                target_pc: loop_end,
+                            });
                         } else {
                             let rowid_reg = program.alloc_register();
                             program.emit_insn(Insn::RowId {
                                 cursor_id: table_cursor_id,
                                 dest: rowid_reg,
                             });
-                            program.emit_insn_with_label_dependency(
-                                Insn::Gt {
-                                    lhs: rowid_reg,
-                                    rhs: cmp_reg,
-                                    target_pc: loop_end,
-                                },
-                                loop_end,
-                            );
+                            program.emit_insn(Insn::Gt {
+                                lhs: rowid_reg,
+                                rhs: cmp_reg,
+                                target_pc: loop_end,
+                            });
                         }
                     }
                     ast::Operator::Less => {
                         if let Some(index_cursor_id) = index_cursor_id {
-                            program.emit_insn_with_label_dependency(
-                                Insn::IdxGE {
-                                    cursor_id: index_cursor_id,
-                                    start_reg: cmp_reg,
-                                    num_regs: 1,
-                                    target_pc: loop_end,
-                                },
-                                loop_end,
-                            );
+                            program.emit_insn(Insn::IdxGE {
+                                cursor_id: index_cursor_id,
+                                start_reg: cmp_reg,
+                                num_regs: 1,
+                                target_pc: loop_end,
+                            });
                         } else {
                             let rowid_reg = program.alloc_register();
                             program.emit_insn(Insn::RowId {
                                 cursor_id: table_cursor_id,
                                 dest: rowid_reg,
                             });
-                            program.emit_insn_with_label_dependency(
-                                Insn::Ge {
-                                    lhs: rowid_reg,
-                                    rhs: cmp_reg,
-                                    target_pc: loop_end,
-                                },
-                                loop_end,
-                            );
+                            program.emit_insn(Insn::Ge {
+                                lhs: rowid_reg,
+                                rhs: cmp_reg,
+                                target_pc: loop_end,
+                            });
                         }
                     }
                     _ => {}
@@ -538,14 +516,11 @@ pub fn open_loop(
                     src_reg,
                     &t_ctx.resolver,
                 )?;
-                program.emit_insn_with_label_dependency(
-                    Insn::SeekRowid {
-                        cursor_id: table_cursor_id,
-                        src_reg,
-                        target_pc: next,
-                    },
-                    next,
-                );
+                program.emit_insn(Insn::SeekRowid {
+                    cursor_id: table_cursor_id,
+                    src_reg,
+                    target_pc: next,
+                });
             }
             if let Some(predicates) = predicates {
                 for predicate in predicates.iter() {
@@ -748,12 +723,9 @@ pub fn close_loop(
             // A subquery has no cursor to call NextAsync on, so it just emits a Goto
             // to the Yield instruction, which in turn jumps back to the main loop of the subquery,
             // so that the next row from the subquery can be read.
-            program.emit_insn_with_label_dependency(
-                Insn::Goto {
-                    target_pc: loop_labels.loop_start,
-                },
-                loop_labels.loop_start,
-            );
+            program.emit_insn(Insn::Goto {
+                target_pc: loop_labels.loop_start,
+            });
         }
         SourceOperator::Join {
             id,
@@ -771,7 +743,7 @@ pub fn close_loop(
                 // If the left join match flag has been set to 1, we jump to the next row on the outer table,
                 // i.e. continue to the next row of t1 in our example.
                 program.resolve_label(lj_meta.label_match_flag_check_value, program.offset());
-                let jump_offset = program.offset() + 3;
+                let jump_offset = program.offset().add(3u32);
                 program.emit_insn(Insn::IfPos {
                     reg: lj_meta.reg_match_flag,
                     target_pc: jump_offset,
@@ -799,12 +771,9 @@ pub fn close_loop(
                 // and we will end up back in the IfPos instruction above, which will then
                 // check the match flag again, and since it is now 1, we will jump to the
                 // next row in the left table.
-                program.emit_insn_with_label_dependency(
-                    Insn::Goto {
-                        target_pc: lj_meta.label_match_flag_set_true,
-                    },
-                    lj_meta.label_match_flag_set_true,
-                );
+                program.emit_insn(Insn::Goto {
+                    target_pc: lj_meta.label_match_flag_set_true,
+                });
 
                 assert!(program.offset() == jump_offset);
             }
@@ -830,21 +799,15 @@ pub fn close_loop(
                 .as_ref()
                 .is_some_and(|dir| *dir == IterationDirection::Backwards)
             {
-                program.emit_insn_with_label_dependency(
-                    Insn::PrevAwait {
-                        cursor_id,
-                        pc_if_next: loop_labels.loop_start,
-                    },
-                    loop_labels.loop_start,
-                );
+                program.emit_insn(Insn::PrevAwait {
+                    cursor_id,
+                    pc_if_next: loop_labels.loop_start,
+                });
             } else {
-                program.emit_insn_with_label_dependency(
-                    Insn::NextAwait {
-                        cursor_id,
-                        pc_if_next: loop_labels.loop_start,
-                    },
-                    loop_labels.loop_start,
-                );
+                program.emit_insn(Insn::NextAwait {
+                    cursor_id,
+                    pc_if_next: loop_labels.loop_start,
+                });
             }
         }
         SourceOperator::Search {
@@ -866,13 +829,10 @@ pub fn close_loop(
             };
 
             program.emit_insn(Insn::NextAsync { cursor_id });
-            program.emit_insn_with_label_dependency(
-                Insn::NextAwait {
-                    cursor_id,
-                    pc_if_next: loop_labels.loop_start,
-                },
-                loop_labels.loop_start,
-            );
+            program.emit_insn(Insn::NextAwait {
+                cursor_id,
+                pc_if_next: loop_labels.loop_start,
+            });
         }
         SourceOperator::Nothing { .. } => {}
     };

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -388,12 +388,9 @@ fn translate_create_table(
     if schema.get_table(tbl_name.name.0.as_str()).is_some() {
         if if_not_exists {
             let init_label = program.allocate_label();
-            program.emit_insn_with_label_dependency(
-                Insn::Init {
-                    target_pc: init_label,
-                },
-                init_label,
-            );
+            program.emit_insn(Insn::Init {
+                target_pc: init_label,
+            });
             let start_offset = program.offset();
             program.emit_insn(Insn::Halt {
                 err_code: 0,
@@ -414,12 +411,9 @@ fn translate_create_table(
 
     let parse_schema_label = program.allocate_label();
     let init_label = program.allocate_label();
-    program.emit_insn_with_label_dependency(
-        Insn::Init {
-            target_pc: init_label,
-        },
-        init_label,
-    );
+    program.emit_insn(Insn::Init {
+        target_pc: init_label,
+    });
     let start_offset = program.offset();
     // TODO: ReadCookie
     // TODO: If
@@ -544,12 +538,9 @@ fn translate_pragma(
 ) -> Result<Program> {
     let mut program = ProgramBuilder::new();
     let init_label = program.allocate_label();
-    program.emit_insn_with_label_dependency(
-        Insn::Init {
-            target_pc: init_label,
-        },
-        init_label,
-    );
+    program.emit_insn(Insn::Init {
+        target_pc: init_label,
+    });
     let start_offset = program.offset();
     let mut write = false;
     match body {
@@ -581,7 +572,6 @@ fn translate_pragma(
     program.emit_insn(Insn::Goto {
         target_pc: start_offset,
     });
-    program.resolve_deferred_labels();
     Ok(program.build(database_header, connection))
 }
 

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -110,15 +110,12 @@ pub fn emit_order_by(
         num_fields: num_columns_in_sorter,
     });
 
-    program.emit_insn_with_label_dependency(
-        Insn::SorterSort {
-            cursor_id: sort_cursor,
-            pc_if_empty: sort_loop_end_label,
-        },
-        sort_loop_end_label,
-    );
+    program.emit_insn(Insn::SorterSort {
+        cursor_id: sort_cursor,
+        pc_if_empty: sort_loop_end_label,
+    });
 
-    program.defer_label_resolution(sort_loop_start_label, program.offset() as usize);
+    program.resolve_label(sort_loop_start_label, program.offset());
     program.emit_insn(Insn::SorterData {
         cursor_id: sort_cursor,
         dest_reg: reg_sorter_data,
@@ -140,13 +137,10 @@ pub fn emit_order_by(
 
     emit_result_row_and_limit(program, t_ctx, plan, start_reg, Some(sort_loop_end_label))?;
 
-    program.emit_insn_with_label_dependency(
-        Insn::SorterNext {
-            cursor_id: sort_cursor,
-            pc_if_next: sort_loop_start_label,
-        },
-        sort_loop_start_label,
-    );
+    program.emit_insn(Insn::SorterNext {
+        cursor_id: sort_cursor,
+        pc_if_next: sort_loop_start_label,
+    });
 
     program.resolve_label(sort_loop_end_label, program.offset());
 

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -294,7 +294,7 @@ fn parse_from_clause_table(
             };
             subplan.query_type = SelectQueryType::Subquery {
                 yield_reg: usize::MAX, // will be set later in bytecode emission
-                coroutine_implementation_start: BranchOffset::MAX, // will be set later in bytecode emission
+                coroutine_implementation_start: BranchOffset::Placeholder, // will be set later in bytecode emission
             };
             let identifier = maybe_alias
                 .map(|a| match a {

--- a/core/translate/result_row.rs
+++ b/core/translate/result_row.rs
@@ -54,7 +54,7 @@ pub fn emit_result_row_and_limit(
         SelectQueryType::Subquery { yield_reg, .. } => {
             program.emit_insn(Insn::Yield {
                 yield_reg: *yield_reg,
-                end_offset: 0,
+                end_offset: BranchOffset::Offset(0),
             });
         }
     }
@@ -71,13 +71,10 @@ pub fn emit_result_row_and_limit(
             dest: t_ctx.reg_limit.unwrap(),
         });
         program.mark_last_insn_constant();
-        program.emit_insn_with_label_dependency(
-            Insn::DecrJumpZero {
-                reg: t_ctx.reg_limit.unwrap(),
-                target_pc: label_on_limit_reached.unwrap(),
-            },
-            label_on_limit_reached.unwrap(),
-        );
+        program.emit_insn(Insn::DecrJumpZero {
+            reg: t_ctx.reg_limit.unwrap(),
+            target_pc: label_on_limit_reached.unwrap(),
+        });
     }
     Ok(())
 }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -72,7 +72,7 @@ pub fn emit_subquery<'a>(
     t_ctx: &mut TranslateCtx<'a>,
 ) -> Result<usize> {
     let yield_reg = program.alloc_register();
-    let coroutine_implementation_start_offset = program.offset() + 1;
+    let coroutine_implementation_start_offset = program.offset().add(1u32);
     match &mut plan.query_type {
         SelectQueryType::Subquery {
             yield_reg: y,
@@ -100,14 +100,11 @@ pub fn emit_subquery<'a>(
         resolver: Resolver::new(t_ctx.resolver.symbol_table),
     };
     let subquery_body_end_label = program.allocate_label();
-    program.emit_insn_with_label_dependency(
-        Insn::InitCoroutine {
-            yield_reg,
-            jump_on_definition: subquery_body_end_label,
-            start_offset: coroutine_implementation_start_offset,
-        },
-        subquery_body_end_label,
-    );
+    program.emit_insn(Insn::InitCoroutine {
+        yield_reg,
+        jump_on_definition: subquery_body_end_label,
+        start_offset: coroutine_implementation_start_offset,
+    });
     // Normally we mark each LIMIT value as a constant insn that is emitted only once, but in the case of a subquery,
     // we need to initialize it every time the subquery is run; otherwise subsequent runs of the subquery will already
     // have the LIMIT counter at 0, and will never return rows.

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -13,11 +13,11 @@ pub fn insn_to_str(
             Insn::Init { target_pc } => (
                 "Init",
                 0,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("Start at {}", target_pc),
+                format!("Start at {}", target_pc.to_debug_int()),
             ),
             Insn::Add { lhs, rhs, dest } => (
                 "Add",
@@ -114,11 +114,11 @@ pub fn insn_to_str(
             Insn::NotNull { reg, target_pc } => (
                 "NotNull",
                 *reg as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("r[{}]!=NULL -> goto {}", reg, target_pc),
+                format!("r[{}]!=NULL -> goto {}", reg, target_pc.to_debug_int()),
             ),
             Insn::Compare {
                 start_reg_a,
@@ -145,9 +145,9 @@ pub fn insn_to_str(
                 target_pc_gt,
             } => (
                 "Jump",
-                *target_pc_lt as i32,
-                *target_pc_eq as i32,
-                *target_pc_gt as i32,
+                target_pc_lt.to_debug_int(),
+                target_pc_eq.to_debug_int(),
+                target_pc_gt.to_debug_int(),
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
                 "".to_string(),
@@ -178,13 +178,16 @@ pub fn insn_to_str(
             } => (
                 "IfPos",
                 *reg as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
                 format!(
                     "r[{}]>0 -> r[{}]-={}, goto {}",
-                    reg, reg, decrement_by, target_pc
+                    reg,
+                    reg,
+                    decrement_by,
+                    target_pc.to_debug_int()
                 ),
             ),
             Insn::Eq {
@@ -195,10 +198,15 @@ pub fn insn_to_str(
                 "Eq",
                 *lhs as i32,
                 *rhs as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if r[{}]==r[{}] goto {}", lhs, rhs, target_pc),
+                format!(
+                    "if r[{}]==r[{}] goto {}",
+                    lhs,
+                    rhs,
+                    target_pc.to_debug_int()
+                ),
             ),
             Insn::Ne {
                 lhs,
@@ -208,10 +216,15 @@ pub fn insn_to_str(
                 "Ne",
                 *lhs as i32,
                 *rhs as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if r[{}]!=r[{}] goto {}", lhs, rhs, target_pc),
+                format!(
+                    "if r[{}]!=r[{}] goto {}",
+                    lhs,
+                    rhs,
+                    target_pc.to_debug_int()
+                ),
             ),
             Insn::Lt {
                 lhs,
@@ -221,10 +234,10 @@ pub fn insn_to_str(
                 "Lt",
                 *lhs as i32,
                 *rhs as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if r[{}]<r[{}] goto {}", lhs, rhs, target_pc),
+                format!("if r[{}]<r[{}] goto {}", lhs, rhs, target_pc.to_debug_int()),
             ),
             Insn::Le {
                 lhs,
@@ -234,10 +247,15 @@ pub fn insn_to_str(
                 "Le",
                 *lhs as i32,
                 *rhs as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if r[{}]<=r[{}] goto {}", lhs, rhs, target_pc),
+                format!(
+                    "if r[{}]<=r[{}] goto {}",
+                    lhs,
+                    rhs,
+                    target_pc.to_debug_int()
+                ),
             ),
             Insn::Gt {
                 lhs,
@@ -247,10 +265,10 @@ pub fn insn_to_str(
                 "Gt",
                 *lhs as i32,
                 *rhs as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if r[{}]>r[{}] goto {}", lhs, rhs, target_pc),
+                format!("if r[{}]>r[{}] goto {}", lhs, rhs, target_pc.to_debug_int()),
             ),
             Insn::Ge {
                 lhs,
@@ -260,10 +278,15 @@ pub fn insn_to_str(
                 "Ge",
                 *lhs as i32,
                 *rhs as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if r[{}]>=r[{}] goto {}", lhs, rhs, target_pc),
+                format!(
+                    "if r[{}]>=r[{}] goto {}",
+                    lhs,
+                    rhs,
+                    target_pc.to_debug_int()
+                ),
             ),
             Insn::If {
                 reg,
@@ -272,11 +295,11 @@ pub fn insn_to_str(
             } => (
                 "If",
                 *reg as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 *null_reg as i32,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if r[{}] goto {}", reg, target_pc),
+                format!("if r[{}] goto {}", reg, target_pc.to_debug_int()),
             ),
             Insn::IfNot {
                 reg,
@@ -285,11 +308,11 @@ pub fn insn_to_str(
             } => (
                 "IfNot",
                 *reg as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 *null_reg as i32,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if !r[{}] goto {}", reg, target_pc),
+                format!("if !r[{}] goto {}", reg, target_pc.to_debug_int()),
             ),
             Insn::OpenReadAsync {
                 cursor_id,
@@ -347,7 +370,7 @@ pub fn insn_to_str(
             } => (
                 "RewindAwait",
                 *cursor_id as i32,
-                *pc_if_empty as i32,
+                pc_if_empty.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -431,7 +454,7 @@ pub fn insn_to_str(
             } => (
                 "NextAwait",
                 *cursor_id as i32,
-                *pc_if_next as i32,
+                pc_if_next.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -461,7 +484,7 @@ pub fn insn_to_str(
             Insn::Goto { target_pc } => (
                 "Goto",
                 0,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -473,7 +496,7 @@ pub fn insn_to_str(
             } => (
                 "Gosub",
                 *return_reg as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -562,7 +585,7 @@ pub fn insn_to_str(
                 "SeekRowid",
                 *cursor_id as i32,
                 *src_reg as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
                 format!(
@@ -572,7 +595,7 @@ pub fn insn_to_str(
                         .0
                         .as_ref()
                         .unwrap_or(&format!("cursor {}", cursor_id)),
-                    target_pc
+                    target_pc.to_debug_int()
                 ),
             ),
             Insn::DeferredSeek {
@@ -596,7 +619,7 @@ pub fn insn_to_str(
             } => (
                 "SeekGT",
                 *cursor_id as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 *start_reg as i32,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -611,7 +634,7 @@ pub fn insn_to_str(
             } => (
                 "SeekGE",
                 *cursor_id as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 *start_reg as i32,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -625,7 +648,7 @@ pub fn insn_to_str(
             } => (
                 "IdxGT",
                 *cursor_id as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 *start_reg as i32,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -639,7 +662,7 @@ pub fn insn_to_str(
             } => (
                 "IdxGE",
                 *cursor_id as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 *start_reg as i32,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -648,11 +671,11 @@ pub fn insn_to_str(
             Insn::DecrJumpZero { reg, target_pc } => (
                 "DecrJumpZero",
                 *reg as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if (--r[{}]==0) goto {}", reg, target_pc),
+                format!("if (--r[{}]==0) goto {}", reg, target_pc.to_debug_int()),
             ),
             Insn::AggStep {
                 func,
@@ -742,7 +765,7 @@ pub fn insn_to_str(
             } => (
                 "SorterSort",
                 *cursor_id as i32,
-                *pc_if_empty as i32,
+                pc_if_empty.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -754,7 +777,7 @@ pub fn insn_to_str(
             } => (
                 "SorterNext",
                 *cursor_id as i32,
-                *pc_if_next as i32,
+                pc_if_next.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -792,8 +815,8 @@ pub fn insn_to_str(
             } => (
                 "InitCoroutine",
                 *yield_reg as i32,
-                *jump_on_definition as i32,
-                *start_offset as i32,
+                jump_on_definition.to_debug_int(),
+                start_offset.to_debug_int(),
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
                 "".to_string(),
@@ -813,7 +836,7 @@ pub fn insn_to_str(
             } => (
                 "Yield",
                 *yield_reg as i32,
-                *end_offset as i32,
+                end_offset.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -898,7 +921,7 @@ pub fn insn_to_str(
             } => (
                 "NotExists",
                 *cursor as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 *rowid_reg as i32,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
@@ -968,11 +991,11 @@ pub fn insn_to_str(
             Insn::IsNull { src, target_pc } => (
                 "IsNull",
                 *src as i32,
-                *target_pc as i32,
+                target_pc.to_debug_int(),
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("if (r[{}]==NULL) goto {}", src, target_pc),
+                format!("if (r[{}]==NULL) goto {}", src, target_pc.to_debug_int()),
             ),
             Insn::ParseSchema { db, where_clause } => (
                 "ParseSchema",


### PR DESCRIPTION
TLDR: no need to call either of:

---

program.emit_insn_with_label_dependency() -> just call program.emit_insn()

program.defer_label_resolution() -> just call program.resolve_label()

---

Changes:

- make BranchOffset an explicit enum (Label, Offset, Placeholder)
- remove program.emit_insn_with_label_dependency() - label dependency is automatically detected
- for label to offset mapping, use a hashmap from label(negative i32) to offset (positive u32)
- resolve all labels in program.build()
- remove program.defer_label_resolution() - all labels are resolved in build()