### PR TITLE
Rename IO backends to support Linux platforms without io_uring

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ name = "limbo_core"
 path = "lib.rs"
 
 [features]
-default = ["fs", "json", "uuid"]
+default = ["fs", "json", "uuid", "io_uring"]
 fs = []
 json = [
     "dep:jsonb",
@@ -22,11 +22,12 @@ json = [
     "dep:pest_derive",
 ]
 uuid = ["dep:uuid"]
+io_uring = ["dep:io-uring"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-io-uring = "0.6.1"
+io-uring = { version = "0.6.1", optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(target_family = "unix")'.dependencies]
 polling = "3.7.2"
 rustix = "0.38.34"
 

--- a/core/error.rs
+++ b/core/error.rs
@@ -21,7 +21,7 @@ pub enum LimboError {
     IOError(#[from] std::io::Error),
     #[cfg(all(target_os = "linux", feature = "io_uring"))]
     #[error("I/O error: {0}")]
-    LinuxIOError(String),
+    UringIOError(String),
     #[error("Locking error: {0}")]
     LockingError(String),
     #[cfg(target_family = "unix")]

--- a/core/error.rs
+++ b/core/error.rs
@@ -19,12 +19,12 @@ pub enum LimboError {
     EnvVarError(#[from] std::env::VarError),
     #[error("I/O error: {0}")]
     IOError(#[from] std::io::Error),
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "io_uring"))]
     #[error("I/O error: {0}")]
     LinuxIOError(String),
     #[error("Locking error: {0}")]
     LockingError(String),
-    #[cfg(target_os = "macos")]
+    #[cfg(target_family = "unix")]
     #[error("I/O error: {0}")]
     RustixIOError(#[from] rustix::io::Errno),
     #[error("Parse error: {0}")]

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -165,7 +165,7 @@ impl IO for UringIO {
         while let Some(cqe) = ring.get_completion() {
             let result = cqe.result();
             if result < 0 {
-                return Err(LimboError::LinuxIOError(format!(
+                return Err(LimboError::UringIOError(format!(
                     "{} cqe: {:?}",
                     UringIOError::IOUringCQError(result),
                     cqe

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -164,14 +164,14 @@ impl Buffer {
 }
 
 cfg_block! {
-    #[cfg(target_os = "linux")] {
-        mod linux;
-        pub use linux::LinuxIO as PlatformIO;
+    #[cfg(all(target_os = "linux", feature = "io_uring"))] {
+        mod io_uring;
+        pub use io_uring::UringIO as PlatformIO;
     }
 
-    #[cfg(target_os = "macos")] {
-        mod darwin;
-        pub use darwin::DarwinIO as PlatformIO;
+    #[cfg(any(all(target_os = "linux",not(feature = "io_uring")), target_os = "macos"))] {
+        mod unix;
+        pub use unix::UnixIO as PlatformIO;
     }
 
     #[cfg(target_os = "windows")] {


### PR DESCRIPTION
As was suggested in #502 I have renamed the IO backends from `darwin` to `unix` and from `linux` to `io_uring`. The `unix` backend is now available to Linux platforms without io_uring.

A few things to confirm

- [ ] The `cfg()` blocks for `target_os = "macos"` now use `target_family = "unix"`. If this is not wanted, it can be changed to `target_os = "macos"` and `target_os = "linux"` with an `any()`
- [ ] These commits introduce a new feature `io_uring` but that is a choice that may not be liked.
- [ ] The `io_uring` feature is on by default, which right now cannot be changed if building the root project. However, this matches the previous behavior of using `io_uring` on Linux. What is the path to let platforms without support disable the feature? Should a root level feature be defined?
- [x] I have run the tests with and without the feature and executed `make` successfully. However, I am on Linux and don't have access to a Mac, so someone would need to try that this doesn't break anything, although the changes are pretty simple. _Oops, forgot about CI, that should take care of it._

On the topic of letting platforms disable io_uring support, the primary example is Google, which posted this [blog](https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html) in 2023 about disabling io_uring by default in most of their servers/platforms, including Android (prime candidate user for a SQLite rewrite).

Another way to implement compatibility for platforms with io_uring disabled, without using the feature flag, would be to make a Linux PlatformIO wrapper that implements `IO` and tries to build a UringIO. If that fails, it builds a UnixIO and returns that as the `Arch<dyn IO>`. This, however, would require changing
```rust
impl PlatformIO {
    pub fn new() -> Result<Self>{
    }
}
```

to

```rust
impl UringIO {
    pub fn new() -> Result<Box<dyn IO>> {
    }
}
```
and then

```rust
match limbo_core::PlatformIO::new() {
            Ok(io) => Arc::from(io),
}
```

Let me know what you think