### PR TITLE
Fix Java naming 

### DIFF
--- a/bindings/java/rs_src/limbo_db.rs
+++ b/bindings/java/rs_src/limbo_db.rs
@@ -8,7 +8,7 @@ const ERROR_CODE_ETC: i32 = 9999;
 
 #[no_mangle]
 #[allow(clippy::arc_with_non_send_sync)]
-pub extern "system" fn Java_org_github_tursodatabase_core_LimboDB__1open_1utf8<'local>(
+pub extern "system" fn Java_org_github_tursodatabase_core_LimboDB_openUtf8<'local>(
     mut env: JNIEnv<'local>,
     obj: JObject<'local>,
     file_name_byte_arr: JByteArray<'local>,

--- a/bindings/java/rs_src/limbo_db.rs
+++ b/bindings/java/rs_src/limbo_db.rs
@@ -56,12 +56,14 @@ fn set_err_msg_and_throw_exception<'local>(
     err_code: i32,
     err_msg: String,
 ) {
-    let error_message_pointer = Box::into_raw(Box::new(err_msg)) as i64;
+    let error_message_bytes = env
+        .byte_array_from_slice(err_msg.as_bytes())
+        .expect("Failed to convert to byte array");
     match env.call_method(
         obj,
-        "newSQLException",
-        "(IJ)Lorg/github/tursodatabase/exceptions/LimboException;",
-        &[err_code.into(), error_message_pointer.into()],
+        "throwLimboException",
+        "(I[B)V",
+        &[err_code.into(), (&error_message_bytes).into()],
     ) {
         Ok(_) => {
             // do nothing because above method will always return Err
@@ -70,17 +72,4 @@ fn set_err_msg_and_throw_exception<'local>(
             // do nothing because our java app will handle Err
         }
     }
-}
-
-#[no_mangle]
-pub unsafe extern "system" fn Java_org_github_tursodatabase_core_LimboDB_getErrorMessageUtf8<
-    'local,
->(
-    env: JNIEnv<'local>,
-    _obj: JObject<'local>,
-    error_message_ptr: jlong,
-) -> JByteArray<'local> {
-    let error_message = Box::from_raw(error_message_ptr as *mut String);
-    let error_message_bytes = error_message.as_bytes();
-    env.byte_array_from_slice(error_message_bytes).unwrap()
 }

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/AbstractDB.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/AbstractDB.java
@@ -1,9 +1,5 @@
 package org.github.tursodatabase.core;
 
-import org.github.tursodatabase.LimboErrorCode;
-import org.github.tursodatabase.NativeInvocation;
-import org.github.tursodatabase.exceptions.LimboException;
-
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -52,10 +48,10 @@ public abstract class AbstractDB {
      * @throws SQLException if a database access error occurs.
      */
     public final synchronized void open(int openFlags) throws SQLException {
-        _open(fileName, openFlags);
+        open0(fileName, openFlags);
     }
 
-    protected abstract void _open(String fileName, int openFlags) throws SQLException;
+    protected abstract void open0(String fileName, int openFlags) throws SQLException;
 
     /**
      * Closes a database connection and finalizes any remaining statements before the closing
@@ -100,14 +96,14 @@ public abstract class AbstractDB {
      * @return pointer to database instance
      * @throws SQLException if a database access error occurs.
      */
-    protected abstract long _open_utf8(byte[] fileName, int openFlags) throws SQLException;
+    protected abstract long openUtf8(byte[] fileName, int openFlags) throws SQLException;
 
     /**
      * Closes the SQLite interface to a database.
      *
      * @throws SQLException if a database access error occurs.
      */
-    protected abstract void _close() throws SQLException;
+    protected abstract void close0() throws SQLException;
 
     /**
      * Compiles, evaluates, executes and commits an SQL statement.
@@ -116,7 +112,7 @@ public abstract class AbstractDB {
      * @return Result code.
      * @throws SQLException if a database access error occurs.
      */
-    public abstract int _exec(String sql) throws SQLException;
+    public abstract int exec(String sql) throws SQLException;
 
     /**
      * Compiles an SQL statement.

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/AbstractDB.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/AbstractDB.java
@@ -172,35 +172,4 @@ public abstract class AbstractDB {
         // TODO: add implementation
         throw new SQLFeatureNotSupportedException();
     }
-
-    /**
-     * Throws SQL Exception with error code.
-     *
-     * @param errorCode Error code to be passed.
-     * @throws SQLException Formatted SQLException with error code
-     */
-    @NativeInvocation
-    private LimboException newSQLException(int errorCode, long errorMessagePointer) throws SQLException {
-        throw newSQLException(errorCode, getErrorMessage(errorMessagePointer));
-    }
-
-    /**
-     * Throws formatted SQLException with error code and message.
-     *
-     * @param errorCode    Error code to be passed.
-     * @param errorMessage throw newSQLException(errorCode);Error message to be passed.
-     * @return Formatted SQLException with error code and message.
-     */
-    public static LimboException newSQLException(int errorCode, String errorMessage) {
-        LimboErrorCode code = LimboErrorCode.getErrorCode(errorCode);
-        String msg;
-        if (code == LimboErrorCode.UNKNOWN_ERROR) {
-            msg = String.format("%s:%s (%s)", code, errorCode, errorMessage);
-        } else {
-            msg = String.format("%s (%s)", code, errorMessage);
-        }
-        return new LimboException(msg, code);
-    }
-
-    protected abstract String getErrorMessage(long errorMessagePointer);
 }

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/LimboDB.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/LimboDB.java
@@ -62,31 +62,31 @@ public final class LimboDB extends AbstractDB {
 
     // TODO: add support for JNI
     @Override
-    protected synchronized native long _open_utf8(byte[] file, int openFlags) throws SQLException;
+    protected synchronized native long openUtf8(byte[] file, int openFlags) throws SQLException;
 
     // TODO: add support for JNI
     @Override
-    protected synchronized native void _close() throws SQLException;
+    protected synchronized native void close0() throws SQLException;
 
     @Override
-    public synchronized int _exec(String sql) throws SQLException {
+    public synchronized int exec(String sql) throws SQLException {
         // TODO: add implementation
         throw new SQLFeatureNotSupportedException();
     }
 
     // TODO: add support for JNI
-    synchronized native int _exec_utf8(byte[] sqlUtf8) throws SQLException;
+    synchronized native int execUtf8(byte[] sqlUtf8) throws SQLException;
 
     // TODO: add support for JNI
     @Override
     public native void interrupt();
 
     @Override
-    protected void _open(String fileName, int openFlags) throws SQLException {
+    protected void open0(String fileName, int openFlags) throws SQLException {
         if (isOpen) {
             throwLimboException(LimboErrorCode.UNKNOWN_ERROR.code, "Already opened");
         }
-        dbPtr = _open_utf8(stringToUtf8ByteArray(fileName), openFlags);
+        dbPtr = openUtf8(stringToUtf8ByteArray(fileName), openFlags);
         isOpen = true;
     }
 


### PR DESCRIPTION
## Purpose of this PR 

- Set rules for java naming, maybe we can add tests to  automatically test rules in the future 
- For java methods, don't use underbar(IMO using camelcase for java methods seems to be the common convention) 
- If method names collide, append 0 at the back 