### PR TITLE
bindings/java: Fix naming rules

### DIFF
--- a/bindings/java/rs_src/limbo_db.rs
+++ b/bindings/java/rs_src/limbo_db.rs
@@ -8,7 +8,7 @@ const ERROR_CODE_ETC: i32 = 9999;
 
 #[no_mangle]
 #[allow(clippy::arc_with_non_send_sync)]
-pub extern "system" fn Java_org_github_tursodatabase_core_LimboDB__1open_1utf8<'local>(
+pub extern "system" fn Java_org_github_tursodatabase_core_LimboDB_openUtf8<'local>(
     mut env: JNIEnv<'local>,
     obj: JObject<'local>,
     file_name_byte_arr: JByteArray<'local>,

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/AbstractDB.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/AbstractDB.java
@@ -1,9 +1,5 @@
 package org.github.tursodatabase.core;
 
-import org.github.tursodatabase.LimboErrorCode;
-import org.github.tursodatabase.NativeInvocation;
-import org.github.tursodatabase.exceptions.LimboException;
-
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -19,7 +15,7 @@ public abstract class AbstractDB {
     private final String fileName;
     private final AtomicBoolean closed = new AtomicBoolean(true);
 
-    public AbstractDB(String url, String filaName) throws SQLException {
+    public AbstractDB(String url, String filaName) {
         this.url = url;
         this.fileName = filaName;
     }
@@ -52,10 +48,10 @@ public abstract class AbstractDB {
      * @throws SQLException if a database access error occurs.
      */
     public final synchronized void open(int openFlags) throws SQLException {
-        _open(fileName, openFlags);
+        open0(fileName, openFlags);
     }
 
-    protected abstract void _open(String fileName, int openFlags) throws SQLException;
+    protected abstract void open0(String fileName, int openFlags) throws SQLException;
 
     /**
      * Closes a database connection and finalizes any remaining statements before the closing
@@ -100,14 +96,14 @@ public abstract class AbstractDB {
      * @return pointer to database instance
      * @throws SQLException if a database access error occurs.
      */
-    protected abstract long _open_utf8(byte[] fileName, int openFlags) throws SQLException;
+    protected abstract long openUtf8(byte[] fileName, int openFlags) throws SQLException;
 
     /**
      * Closes the SQLite interface to a database.
      *
      * @throws SQLException if a database access error occurs.
      */
-    protected abstract void _close() throws SQLException;
+    protected abstract void close0() throws SQLException;
 
     /**
      * Compiles, evaluates, executes and commits an SQL statement.
@@ -116,7 +112,7 @@ public abstract class AbstractDB {
      * @return Result code.
      * @throws SQLException if a database access error occurs.
      */
-    public abstract int _exec(String sql) throws SQLException;
+    public abstract int exec(String sql) throws SQLException;
 
     /**
      * Compiles an SQL statement.

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/LimboDB.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/LimboDB.java
@@ -30,8 +30,6 @@ public final class LimboDB extends AbstractDB {
         }
     }
 
-    // url example: "jdbc:sqlite:{fileName}
-
     /**
      * @param url      e.g. "jdbc:sqlite:fileName
      * @param fileName e.g. path to file
@@ -41,7 +39,7 @@ public final class LimboDB extends AbstractDB {
     }
 
     // TODO: receive config as argument
-    private LimboDB(String url, String fileName) throws SQLException {
+    private LimboDB(String url, String fileName) {
         super(url, fileName);
     }
 
@@ -53,7 +51,6 @@ public final class LimboDB extends AbstractDB {
 
         try {
             System.loadLibrary("_limbo_java");
-
         } finally {
             isLoaded = true;
         }
@@ -63,31 +60,31 @@ public final class LimboDB extends AbstractDB {
 
     // TODO: add support for JNI
     @Override
-    protected synchronized native long _open_utf8(byte[] file, int openFlags) throws SQLException;
+    protected synchronized native long openUtf8(byte[] file, int openFlags) throws SQLException;
 
     // TODO: add support for JNI
     @Override
-    protected synchronized native void _close() throws SQLException;
+    protected synchronized native void close0() throws SQLException;
 
     @Override
-    public synchronized int _exec(String sql) throws SQLException {
+    public synchronized int exec(String sql) throws SQLException {
         // TODO: add implementation
         throw new SQLFeatureNotSupportedException();
     }
 
     // TODO: add support for JNI
-    synchronized native int _exec_utf8(byte[] sqlUtf8) throws SQLException;
+    synchronized native int execUtf8(byte[] sqlUtf8) throws SQLException;
 
     // TODO: add support for JNI
     @Override
     public native void interrupt();
 
     @Override
-    protected void _open(String fileName, int openFlags) throws SQLException {
+    protected void open0(String fileName, int openFlags) throws SQLException {
         if (isOpen) {
             throwLimboException(LimboErrorCode.UNKNOWN_ERROR.code, "Already opened");
         }
-        dbPtr = _open_utf8(stringToUtf8ByteArray(fileName), openFlags);
+        dbPtr = openUtf8(stringToUtf8ByteArray(fileName), openFlags);
         isOpen = true;
     }
 


### PR DESCRIPTION
## Purpose of this PR 

- Set rules for java naming, maybe we can add tests to  automatically test rules in the future 
- For java methods, don't use underbar(IMO using camelcase for java methods seems to be the common convention) 
- If method names collide, append 0 at the back 

## Reference 

https://github.com/tursodatabase/limbo/issues/615