### PR TITLE
chore: update repository link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.0.11"
 authors = ["the Limbo authors"]
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/penberg/limbo"
+repository = "https://github.com/tursodatabase/limbo"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]


### PR DESCRIPTION
only doc change: Just update the repo link in `Cargo.toml` to be the latest.