### PR TITLE
fix: flaky test in datetime because compare pre-init now.

### DIFF
--- a/core/vdbe/datetime.rs
+++ b/core/vdbe/datetime.rs
@@ -884,8 +884,6 @@ mod tests {
 
     #[test]
     fn test_valid_get_time_from_datetime_value() {
-        let now = chrono::Local::now().to_utc().format("%H:%M:%S").to_string();
-
         let test_time_str = "22:30:45";
         let prev_time_str = "20:30:45";
         let next_time_str = "03:30:45";
@@ -1049,8 +1047,6 @@ mod tests {
                 OwnedValue::build_text(Rc::new("22:30:45.123Z".to_string())),
                 test_time_str,
             ),
-            // Test Format 11: 'now'
-            (OwnedValue::build_text(Rc::new("now".to_string())), &now),
             // Format 12: DDDDDDDDDD (Julian date as float or integer)
             (OwnedValue::Float(2460082.1), "14:24:00"),
             (OwnedValue::Integer(2460082), "12:00:00"),


### PR DESCRIPTION
Removed flaky test that happens sometimes when the CI runner is a bit slow e.g. in https://github.com/tursodatabase/limbo/actions/runs/12706265753/job/35418879041?pr=643 

'now' is covered in other test so it should be fine. it is a problem in time test, for date not so much.

for example it is covered in:

https://github.com/tursodatabase/limbo/blob/bcc85c37a0febdf5c3f29127029fe10c9906867d/core/vdbe/datetime.rs#L1434C5-L1446C6