### PR TITLE
Store cursor types in program state and remove trait Cursor

### DIFF
--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -1,110 +1,19 @@
-use crate::{
-    types::{SeekKey, SeekOp},
-    Result,
-};
-use std::cell::{Ref, RefCell};
-
-use crate::types::{Cursor, CursorResult, OwnedRecord, OwnedValue};
+use crate::types::OwnedRecord;
 
 pub struct PseudoCursor {
-    current: RefCell<Option<OwnedRecord>>,
+    current: Option<OwnedRecord>,
 }
 
 impl PseudoCursor {
     pub fn new() -> Self {
-        Self {
-            current: RefCell::new(None),
-        }
-    }
-}
-
-impl Cursor for PseudoCursor {
-    fn is_empty(&self) -> bool {
-        self.current.borrow().is_none()
+        Self { current: None }
     }
 
-    fn root_page(&self) -> usize {
-        unreachable!()
+    pub fn record(&self) -> Option<&OwnedRecord> {
+        self.current.as_ref()
     }
 
-    fn rewind(&mut self) -> Result<CursorResult<()>> {
-        *self.current.borrow_mut() = None;
-        Ok(CursorResult::Ok(()))
-    }
-
-    fn next(&mut self) -> Result<CursorResult<()>> {
-        *self.current.borrow_mut() = None;
-        Ok(CursorResult::Ok(()))
-    }
-
-    fn wait_for_completion(&mut self) -> Result<()> {
-        Ok(())
-    }
-
-    fn rowid(&self) -> Result<Option<u64>> {
-        let x = self
-            .current
-            .borrow()
-            .as_ref()
-            .map(|record| match record.values[0] {
-                OwnedValue::Integer(rowid) => rowid as u64,
-                ref ov => {
-                    panic!("Expected integer value, got {:?}", ov);
-                }
-            });
-        Ok(x)
-    }
-
-    fn seek(&mut self, _: SeekKey<'_>, _: SeekOp) -> Result<CursorResult<bool>> {
-        unimplemented!();
-    }
-
-    fn seek_to_last(&mut self) -> Result<CursorResult<()>> {
-        unimplemented!();
-    }
-
-    fn record(&self) -> Result<Ref<Option<OwnedRecord>>> {
-        Ok(self.current.borrow())
-    }
-
-    fn insert(
-        &mut self,
-        key: &OwnedValue,
-        record: &OwnedRecord,
-        moved_before: bool,
-    ) -> Result<CursorResult<()>> {
-        let _ = key;
-        let _ = moved_before;
-        *self.current.borrow_mut() = Some(record.clone());
-        Ok(CursorResult::Ok(()))
-    }
-
-    fn delete(&mut self) -> Result<CursorResult<()>> {
-        unimplemented!()
-    }
-
-    fn get_null_flag(&self) -> bool {
-        false
-    }
-
-    fn set_null_flag(&mut self, _null_flag: bool) {
-        // Do nothing
-    }
-
-    fn exists(&mut self, key: &OwnedValue) -> Result<CursorResult<bool>> {
-        let _ = key;
-        todo!()
-    }
-
-    fn btree_create(&mut self, _flags: usize) -> u32 {
-        unreachable!("Please don't.")
-    }
-
-    fn last(&mut self) -> Result<CursorResult<()>> {
-        todo!()
-    }
-
-    fn prev(&mut self) -> Result<CursorResult<()>> {
-        todo!()
+    pub fn insert(&mut self, record: OwnedRecord) {
+        self.current = Some(record);
     }
 }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -135,6 +135,14 @@ impl Table {
             Self::Pseudo(_) => unimplemented!(),
         }
     }
+
+    pub fn btree(&self) -> Option<Rc<BTreeTable>> {
+        match self {
+            Self::BTree(table) => Some(table.clone()),
+            Self::Index(_) => None,
+            Self::Pseudo(_) => None,
+        }
+    }
 }
 
 impl PartialEq for Table {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -46,35 +46,13 @@ impl Schema {
 #[derive(Clone, Debug)]
 pub enum Table {
     BTree(Rc<BTreeTable>),
-    Index(Rc<Index>),
     Pseudo(Rc<PseudoTable>),
 }
 
 impl Table {
-    pub fn is_pseudo(&self) -> bool {
-        matches!(self, Table::Pseudo(_))
-    }
-
-    pub fn get_rowid_alias_column(&self) -> Option<(usize, &Column)> {
-        match self {
-            Self::BTree(table) => table.get_rowid_alias_column(),
-            Self::Index(_) => None,
-            Self::Pseudo(_) => None,
-        }
-    }
-
-    pub fn column_is_rowid_alias(&self, col: &Column) -> bool {
-        match self {
-            Table::BTree(table) => table.column_is_rowid_alias(col),
-            Self::Index(_) => false,
-            Self::Pseudo(_) => false,
-        }
-    }
-
     pub fn get_root_page(&self) -> usize {
         match self {
             Table::BTree(table) => table.root_page,
-            Table::Index(_) => unimplemented!(),
             Table::Pseudo(_) => unimplemented!(),
         }
     }
@@ -82,40 +60,13 @@ impl Table {
     pub fn get_name(&self) -> &str {
         match self {
             Self::BTree(table) => &table.name,
-            Self::Index(index) => &index.name,
             Self::Pseudo(_) => "",
-        }
-    }
-
-    pub fn column_index_to_name(&self, index: usize) -> Option<&str> {
-        match self {
-            Self::BTree(table) => match table.columns.get(index) {
-                Some(column) => Some(&column.name),
-                None => None,
-            },
-            Self::Index(i) => match i.columns.get(index) {
-                Some(column) => Some(&column.name),
-                None => None,
-            },
-            Self::Pseudo(table) => match table.columns.get(index) {
-                Some(_) => None,
-                None => None,
-            },
-        }
-    }
-
-    pub fn get_column(&self, name: &str) -> Option<(usize, &Column)> {
-        match self {
-            Self::BTree(table) => table.get_column(name),
-            Self::Index(_) => unimplemented!(),
-            Self::Pseudo(table) => table.get_column(name),
         }
     }
 
     pub fn get_column_at(&self, index: usize) -> &Column {
         match self {
             Self::BTree(table) => table.columns.get(index).unwrap(),
-            Self::Index(_) => unimplemented!(),
             Self::Pseudo(table) => table.columns.get(index).unwrap(),
         }
     }
@@ -123,23 +74,13 @@ impl Table {
     pub fn columns(&self) -> &Vec<Column> {
         match self {
             Self::BTree(table) => &table.columns,
-            Self::Index(_) => unimplemented!(),
             Self::Pseudo(table) => &table.columns,
-        }
-    }
-
-    pub fn has_rowid(&self) -> bool {
-        match self {
-            Self::BTree(table) => table.has_rowid,
-            Self::Index(_) => unimplemented!(),
-            Self::Pseudo(_) => unimplemented!(),
         }
     }
 
     pub fn btree(&self) -> Option<Rc<BTreeTable>> {
         match self {
             Self::BTree(table) => Some(table.clone()),
-            Self::Index(_) => None,
             Self::Pseudo(_) => None,
         }
     }

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -4,9 +4,13 @@ use sqlite3_parser::ast;
 
 use crate::{
     function::AggFunc,
-    schema::{Column, PseudoTable, Table},
+    schema::{Column, PseudoTable},
     types::{OwnedRecord, OwnedValue},
-    vdbe::{builder::ProgramBuilder, insn::Insn, BranchOffset},
+    vdbe::{
+        builder::{CursorType, ProgramBuilder},
+        insn::Insn,
+        BranchOffset,
+    },
     Result,
 };
 
@@ -50,7 +54,7 @@ pub fn init_group_by(
 ) -> Result<()> {
     let num_aggs = aggregates.len();
 
-    let sort_cursor = program.alloc_cursor_id(None, None);
+    let sort_cursor = program.alloc_cursor_id(None, CursorType::Sorter);
 
     let reg_abort_flag = program.alloc_register();
     let reg_group_exprs_cmp = program.alloc_registers(group_by.exprs.len());
@@ -175,7 +179,7 @@ pub fn emit_group_by<'a>(
         columns: pseudo_columns,
     });
 
-    let pseudo_cursor = program.alloc_cursor_id(None, Some(Table::Pseudo(pseudo_table.clone())));
+    let pseudo_cursor = program.alloc_cursor_id(None, CursorType::Pseudo(pseudo_table.clone()));
 
     program.emit_insn(Insn::OpenPseudo {
         cursor_id: pseudo_cursor,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -6,13 +6,18 @@ use sqlite3_parser::ast::{
 };
 
 use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
+use crate::schema::BTreeTable;
 use crate::util::normalize_ident;
 use crate::vdbe::BranchOffset;
 use crate::{
-    schema::{Column, Schema, Table},
+    schema::{Column, Schema},
     storage::sqlite3_ondisk::DatabaseHeader,
     translate::expr::translate_expr,
-    vdbe::{builder::ProgramBuilder, insn::Insn, Program},
+    vdbe::{
+        builder::{CursorType, ProgramBuilder},
+        insn::Insn,
+        Program,
+    },
     SymbolTable,
 };
 use crate::{Connection, Result};
@@ -53,20 +58,15 @@ pub fn translate_insert(
         Some(table) => table,
         None => crate::bail_corrupt_error!("Parse error: no such table: {}", table_name),
     };
-    let table = Rc::new(Table::BTree(table));
-    if !table.has_rowid() {
+    if !table.has_rowid {
         crate::bail_parse_error!("INSERT into WITHOUT ROWID table is not supported");
     }
 
     let cursor_id = program.alloc_cursor_id(
         Some(table_name.0.clone()),
-        Some(table.clone().deref().clone()),
+        CursorType::BTreeTable(table.clone()),
     );
-    let root_page = match table.as_ref() {
-        Table::BTree(btree) => btree.root_page,
-        Table::Index(index) => index.root_page,
-        Table::Pseudo(_) => todo!(),
-    };
+    let root_page = table.root_page;
     let values = match body {
         InsertBody::Select(select, None) => match &select.body.select.deref() {
             sqlite3_parser::ast::OneSelect::Values(values) => values,
@@ -77,9 +77,9 @@ pub fn translate_insert(
 
     let column_mappings = resolve_columns_for_insert(&table, columns, values)?;
     // Check if rowid was provided (through INTEGER PRIMARY KEY as a rowid alias)
-    let rowid_alias_index = table.columns().iter().position(|c| c.is_rowid_alias);
+    let rowid_alias_index = table.columns.iter().position(|c| c.is_rowid_alias);
     let has_user_provided_rowid = {
-        assert!(column_mappings.len() == table.columns().len());
+        assert!(column_mappings.len() == table.columns.len());
         if let Some(index) = rowid_alias_index {
             column_mappings[index].value_index.is_some()
         } else {
@@ -89,7 +89,7 @@ pub fn translate_insert(
 
     // allocate a register for each column in the table. if not provided by user, they will simply be set as null.
     // allocate an extra register for rowid regardless of whether user provided a rowid alias column.
-    let num_cols = table.columns().len();
+    let num_cols = table.columns.len();
     let rowid_reg = program.alloc_registers(num_cols + 1);
     let column_registers_start = rowid_reg + 1;
     let rowid_alias_reg = {
@@ -215,14 +215,14 @@ pub fn translate_insert(
             target_pc: make_record_label,
         });
         let rowid_column_name = if let Some(index) = rowid_alias_index {
-            table.column_index_to_name(index).unwrap()
+            &table.columns.get(index).unwrap().name
         } else {
             "rowid"
         };
 
         program.emit_insn(Insn::Halt {
             err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
-            description: format!("{}.{}", table.get_name(), rowid_column_name),
+            description: format!("{}.{}", table_name.0, rowid_column_name),
         });
 
         program.resolve_label(make_record_label, program.offset());
@@ -293,7 +293,7 @@ struct ColumnMapping<'a> {
 ///    - Named columns map to their corresponding value index
 ///    - Unspecified columns map to None
 fn resolve_columns_for_insert<'a>(
-    table: &'a Table,
+    table: &'a BTreeTable,
     columns: &Option<DistinctNames>,
     values: &[Vec<Expr>],
 ) -> Result<Vec<ColumnMapping<'a>>> {
@@ -301,7 +301,7 @@ fn resolve_columns_for_insert<'a>(
         crate::bail_parse_error!("no values to insert");
     }
 
-    let table_columns = table.columns();
+    let table_columns = &table.columns;
 
     // Case 1: No columns specified - map values to columns in order
     if columns.is_none() {
@@ -309,7 +309,7 @@ fn resolve_columns_for_insert<'a>(
         if num_values > table_columns.len() {
             crate::bail_parse_error!(
                 "table {} has {} columns but {} values were supplied",
-                table.get_name(),
+                &table.name,
                 table_columns.len(),
                 num_values
             );
@@ -350,11 +350,7 @@ fn resolve_columns_for_insert<'a>(
             .position(|c| c.name.eq_ignore_ascii_case(&column_name));
 
         if table_index.is_none() {
-            crate::bail_parse_error!(
-                "table {} has no column named {}",
-                table.get_name(),
-                column_name
-            );
+            crate::bail_parse_error!("table {} has no column named {}", &table.name, column_name);
         }
 
         mappings[table_index.unwrap()].value_index = Some(value_index);

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -27,6 +27,7 @@ use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::{DatabaseHeader, MIN_PAGE_CACHE_SIZE};
 use crate::translate::delete::translate_delete;
 use crate::util::PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX;
+use crate::vdbe::builder::CursorType;
 use crate::vdbe::{builder::ProgramBuilder, insn::Insn, Program};
 use crate::{bail_parse_error, Connection, LimboError, Result, SymbolTable};
 use insert::translate_insert;
@@ -463,9 +464,10 @@ fn translate_create_table(
 
     let table_id = "sqlite_schema".to_string();
     let table = schema.get_table(&table_id).unwrap();
-    let table = crate::schema::Table::BTree(table.clone());
-    let sqlite_schema_cursor_id =
-        program.alloc_cursor_id(Some(table_id.to_owned()), Some(table.to_owned()));
+    let sqlite_schema_cursor_id = program.alloc_cursor_id(
+        Some(table_id.to_owned()),
+        CursorType::BTreeTable(table.clone()),
+    );
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     function::AggFunc,
-    schema::{Column, Index, Table},
+    schema::{BTreeTable, Column, Index, Table},
     vdbe::BranchOffset,
     Result,
 };
@@ -255,6 +255,12 @@ pub struct TableReference {
 }
 
 impl TableReference {
+    pub fn btree(&self) -> Option<Rc<BTreeTable>> {
+        match self.reference_type {
+            TableReferenceType::BTreeTable => self.table.btree(),
+            TableReferenceType::Subquery { .. } => None,
+        }
+    }
     pub fn new_subquery(identifier: String, table_index: usize, plan: &SelectPlan) -> Self {
         Self {
             table: Table::Pseudo(Rc::new(PseudoTable::new_with_columns(

--- a/core/types.rs
+++ b/core/types.rs
@@ -1,5 +1,5 @@
 use std::fmt::Display;
-use std::{cell::Ref, rc::Rc};
+use std::rc::Rc;
 
 use crate::error::LimboError;
 use crate::Result;
@@ -522,31 +522,6 @@ pub enum SeekOp {
 pub enum SeekKey<'a> {
     TableRowId(u64),
     IndexKey(&'a OwnedRecord),
-}
-
-pub trait Cursor {
-    fn is_empty(&self) -> bool;
-    fn root_page(&self) -> usize;
-    fn rewind(&mut self) -> Result<CursorResult<()>>;
-    fn last(&mut self) -> Result<CursorResult<()>>;
-    fn next(&mut self) -> Result<CursorResult<()>>;
-    fn prev(&mut self) -> Result<CursorResult<()>>;
-    fn wait_for_completion(&mut self) -> Result<()>;
-    fn rowid(&self) -> Result<Option<u64>>;
-    fn seek(&mut self, key: SeekKey, op: SeekOp) -> Result<CursorResult<bool>>;
-    fn seek_to_last(&mut self) -> Result<CursorResult<()>>;
-    fn record(&self) -> Result<Ref<Option<OwnedRecord>>>;
-    fn insert(
-        &mut self,
-        key: &OwnedValue,
-        record: &OwnedRecord,
-        moved_before: bool, /* Tells inserter that it doesn't need to traverse in order to find leaf page */
-    ) -> Result<CursorResult<()>>; //
-    fn delete(&mut self) -> Result<CursorResult<()>>;
-    fn exists(&mut self, key: &OwnedValue) -> Result<CursorResult<bool>>;
-    fn set_null_flag(&mut self, flag: bool);
-    fn get_null_flag(&self) -> bool;
-    fn btree_create(&mut self, flags: usize) -> u32;
 }
 
 #[cfg(test)]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -211,7 +211,7 @@ impl ProgramState {
 pub struct Program {
     pub max_registers: usize,
     pub insns: Vec<Insn>,
-    pub cursor_ref: Vec<(Option<String>, Option<Table>)>,
+    pub cursor_ref: Vec<(Option<String>, CursorType)>,
     pub database_header: Rc<RefCell<DatabaseHeader>>,
     pub comments: HashMap<InsnReference, &'static str>,
     pub connection: Weak<Connection>,

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1,13 +1,9 @@
-use crate::{
-    types::{Cursor, CursorResult, OwnedRecord, OwnedValue, SeekKey, SeekOp},
-    Result,
-};
-use std::cell::{Ref, RefCell};
+use crate::types::OwnedRecord;
 use std::cmp::Ordering;
 
 pub struct Sorter {
     records: Vec<OwnedRecord>,
-    current: RefCell<Option<OwnedRecord>>,
+    current: Option<OwnedRecord>,
     order: Vec<bool>,
 }
 
@@ -15,23 +11,15 @@ impl Sorter {
     pub fn new(order: Vec<bool>) -> Self {
         Self {
             records: Vec::new(),
-            current: RefCell::new(None),
+            current: None,
             order,
         }
     }
-}
-
-impl Cursor for Sorter {
-    fn is_empty(&self) -> bool {
-        self.current.borrow().is_none()
+    pub fn is_empty(&self) -> bool {
+        self.current.is_none()
     }
-
-    fn root_page(&self) -> usize {
-        unreachable!()
-    }
-
     // We do the sorting here since this is what is called by the SorterSort instruction
-    fn rewind(&mut self) -> Result<CursorResult<()>> {
+    pub fn sort(&mut self) {
         self.records.sort_by(|a, b| {
             let cmp_by_idx = |idx: usize, ascending: bool| {
                 let a = &a.values[idx];
@@ -55,73 +43,14 @@ impl Cursor for Sorter {
         self.records.reverse();
         self.next()
     }
-
-    fn next(&mut self) -> Result<CursorResult<()>> {
-        let mut c = self.current.borrow_mut();
-        *c = self.records.pop();
-        Ok(CursorResult::Ok(()))
+    pub fn next(&mut self) {
+        self.current = self.records.pop();
+    }
+    pub fn record(&self) -> Option<&OwnedRecord> {
+        self.current.as_ref()
     }
 
-    fn wait_for_completion(&mut self) -> Result<()> {
-        Ok(())
-    }
-
-    fn rowid(&self) -> Result<Option<u64>> {
-        todo!();
-    }
-
-    fn seek(&mut self, _: SeekKey<'_>, _: SeekOp) -> Result<CursorResult<bool>> {
-        unimplemented!();
-    }
-
-    fn seek_to_last(&mut self) -> Result<CursorResult<()>> {
-        unimplemented!();
-    }
-
-    fn record(&self) -> Result<Ref<Option<OwnedRecord>>> {
-        let ret = self.current.borrow();
-        // log::trace!("returning {:?}", ret);
-        Ok(ret)
-    }
-
-    fn insert(
-        &mut self,
-        key: &OwnedValue,
-        record: &OwnedRecord,
-        moved_before: bool,
-    ) -> Result<CursorResult<()>> {
-        let _ = key;
-        let _ = moved_before;
+    pub fn insert(&mut self, record: &OwnedRecord) {
         self.records.push(OwnedRecord::new(record.values.to_vec()));
-        Ok(CursorResult::Ok(()))
-    }
-
-    fn delete(&mut self) -> Result<CursorResult<()>> {
-        unimplemented!()
-    }
-
-    fn set_null_flag(&mut self, _flag: bool) {
-        todo!();
-    }
-
-    fn get_null_flag(&self) -> bool {
-        false
-    }
-
-    fn exists(&mut self, key: &OwnedValue) -> Result<CursorResult<bool>> {
-        let _ = key;
-        todo!()
-    }
-
-    fn btree_create(&mut self, _flags: usize) -> u32 {
-        unreachable!("Why did you try to build a new tree with a sorter??? Stand up, open the door and take a walk for 30 min to come back with a better plan.");
-    }
-
-    fn last(&mut self) -> Result<CursorResult<()>> {
-        todo!()
-    }
-
-    fn prev(&mut self) -> Result<CursorResult<()>> {
-        todo!()
     }
 }


### PR DESCRIPTION
I was planning on starting work on index insertion, but realized we need to know whether our cursor refers to a table or an index etc., so it resulted in this refactoring work.

- `cursor_ref` now contains what _type_ of cursor it is (table, index, pseudo, sorter)
- `program.cursors` is now `program.btree_table_cursors`, `program.btree_index_cursors` etc and they are unboxed because dynamic dispatch is no longer necessary
- Cursor trait removed -- 95% of the shit was btree specific anyway, so I just moved them to `BTreeCursor`. In certain instructions in the VDBE we expect a btree cursor and in others we expect a pseudo/sorter etc, lets make that explicit.