### PR TITLE
BTree `delete` implementation

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -114,7 +114,7 @@ The current status of Limbo is:
 | PRAGMA foreign_key_check         | No         |                                                 |
 | PRAGMA foreign_key_list          | No         |                                                 |
 | PRAGMA foreign_keys              | No         |                                                 |
-| PRAGMA freelist_count            | No         |                                                 |
+| PRAGMA freelist_count            | Yes        |                                                 |
 | PRAGMA full_column_names         | Not Needed | deprecated in SQLite                            |
 | PRAGMA fullsync                  | No         |                                                 |
 | PRAGMA function_list             | No         |                                                 |

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -454,11 +454,11 @@ impl BTreeCursor {
                             SeekOp::GE => *cell_rowid >= rowid_key,
                             SeekOp::EQ => *cell_rowid == rowid_key,
                         };
-                        self.stack.advance();
                         if found {
                             let record = crate::storage::sqlite3_ondisk::read_record(payload)?;
                             return Ok(CursorResult::Ok((Some(*cell_rowid), Some(record))));
                         }
+                        self.stack.advance();
                     }
                     BTreeCell::IndexLeafCell(IndexLeafCell { payload, .. }) => {
                         let SeekKey::IndexKey(index_key) = key else {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -454,11 +454,11 @@ impl BTreeCursor {
                             SeekOp::GE => *cell_rowid >= rowid_key,
                             SeekOp::EQ => *cell_rowid == rowid_key,
                         };
+                        self.stack.advance();
                         if found {
                             let record = crate::storage::sqlite3_ondisk::read_record(payload)?;
                             return Ok(CursorResult::Ok((Some(*cell_rowid), Some(record))));
                         }
-                        self.stack.advance();
                     }
                     BTreeCell::IndexLeafCell(IndexLeafCell { payload, .. }) => {
                         let SeekKey::IndexKey(index_key) = key else {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1792,7 +1792,7 @@ impl BTreeCursor {
 
         let mut cell_idx = self.stack.current_cell_index() as usize;
 
-        // FIXME: This is HACK, seek() is returning next cell, so we need to go back one cell.
+        // FIXME: This is a HACK, seek() is returning next cell, so we need to go back one cell.
         cell_idx -= 1;
 
         let contents = page.get().contents.as_ref().unwrap();
@@ -1800,7 +1800,6 @@ impl BTreeCursor {
         println!("cell_idx: {}", cell_idx);
         println!("cell_count: {}", contents.cell_count());
         println!("cell_indices: {:?}", self.stack.cell_indices.borrow());
-        // cell_idx = 0; // for now hard code cell_idx to 0 for the test to pass.
         if cell_idx >= contents.cell_count() {
             return Err(LimboError::Corrupt(format!(
                 "Corrupted page: cell index {} is out of bounds for page with {} cells",

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1791,6 +1791,10 @@ impl BTreeCursor {
         return_if_locked!(page);
 
         let mut cell_idx = self.stack.current_cell_index() as usize;
+
+        // FIXME: This is HACK, seek() is returning next cell, so we need to go back one cell.
+        cell_idx -= 1;
+
         let contents = page.get().contents.as_ref().unwrap();
 
         println!("cell_idx: {}", cell_idx);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1806,7 +1806,7 @@ impl BTreeCursor {
         }
 
         // TODO: Clear overflow pages
-        
+
         page.set_dirty();
         self.pager.add_dirty(page.get().id);
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3,7 +3,7 @@ use crate::storage::buffer_pool::BufferPool;
 use crate::storage::database::DatabaseStorage;
 use crate::storage::sqlite3_ondisk::{self, DatabaseHeader, PageContent};
 use crate::storage::wal::Wal;
-use crate::{Buffer, Result};
+use crate::{Buffer, LimboError, Result};
 use log::trace;
 use std::cell::{RefCell, UnsafeCell};
 use std::collections::HashSet;
@@ -434,6 +434,68 @@ impl Pager {
         }
         // TODO: only clear cache of things that are really invalidated
         self.page_cache.write().unwrap().clear();
+    }
+
+    pub fn free_page(&self, page: Option<PageRef>, page_id: usize) -> Result<()> {
+        if page_id < 2 || page_id > self.db_header.borrow().database_size as usize {
+            return Err(LimboError::Corrupt(format!(
+                "Invalid page number {} for free operation",
+                page_id
+            )));
+        }
+
+        let page = match page {
+            Some(page) => {
+                assert_eq!(page.get().id, page_id, "Page id mismatch");
+                page
+            }
+            None => self.read_page(page_id)?,
+        };
+
+        let page_1 = self.read_page(1)?;
+        page_1.set_dirty();
+        self.add_dirty(1);
+
+        self.db_header.borrow_mut().freelist_pages += 1;
+
+        let trunk_page_id = self.db_header.borrow().freelist_trunk_page;
+
+        if trunk_page_id != 0 {
+            // Add as leaf to current trunk
+            let trunk_page = self.read_page(trunk_page_id as usize)?;
+            let trunk_page_contents = trunk_page.get().contents.as_ref().unwrap();
+            let number_of_leaf_pages = trunk_page_contents.read_u32(4);
+
+            let max_free_list_entries = (self.usable_size() / 4) - 8;
+
+            if number_of_leaf_pages < max_free_list_entries as u32 {
+                trunk_page.set_dirty();
+                self.add_dirty(trunk_page_id as usize);
+
+                trunk_page_contents.write_u32(4, number_of_leaf_pages + 1);
+                trunk_page_contents.write_u32(8, page_id as u32);
+                page.clear_uptodate();
+                page.clear_loaded();
+
+                return Ok(());
+            }
+        }
+
+        // If we get here, need to make this page a new trunk
+        page.set_dirty();
+        self.add_dirty(page_id);
+
+        let contents = page.get().contents.as_mut().unwrap();
+        // Point to previous trunk
+        contents.write_u32(0, trunk_page_id);
+        // Zero leaf count
+        contents.write_u32(4, 0);
+        // Update page 1 to point to new trunk
+        self.db_header.borrow_mut().freelist_trunk_page = page_id as u32;
+        // Clear flags
+        page.clear_uptodate();
+        page.clear_loaded();
+        Ok(())
     }
 
     /*

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -428,7 +428,7 @@ impl PageContent {
         }
     }
 
-    fn read_u8(&self, pos: usize) -> u8 {
+    pub fn read_u8(&self, pos: usize) -> u8 {
         let buf = self.as_ptr();
         buf[self.offset + pos]
     }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -332,7 +332,7 @@ pub fn begin_write_database_header(header: &DatabaseHeader, pager: &Pager) -> Re
     Ok(())
 }
 
-fn write_header_to_buf(buf: &mut [u8], header: &DatabaseHeader) {
+pub(crate) fn write_header_to_buf(buf: &mut [u8], header: &DatabaseHeader) {
     buf[0..16].copy_from_slice(&header.magic);
     buf[16..18].copy_from_slice(&header.page_size.to_be_bytes());
     buf[18] = header.write_version;

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -105,10 +105,10 @@ pub struct DatabaseHeader {
     pub database_size: u32,
 
     /// Page number of the first freelist trunk page.
-    freelist_trunk_page: u32,
+    pub freelist_trunk_page: u32,
 
     /// Total number of freelist pages.
-    freelist_pages: u32,
+    pub freelist_pages: u32,
 
     /// The schema cookie. Incremented when the database schema changes.
     schema_cookie: u32,
@@ -438,7 +438,7 @@ impl PageContent {
         u16::from_be_bytes([buf[self.offset + pos], buf[self.offset + pos + 1]])
     }
 
-    fn read_u32(&self, pos: usize) -> u32 {
+    pub fn read_u32(&self, pos: usize) -> u32 {
         let buf = self.as_ptr();
         u32::from_be_bytes([
             buf[self.offset + pos],

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,0 +1,610 @@
+use limbo_core::Database;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+#[allow(dead_code)]
+struct TempDatabase {
+    pub path: PathBuf,
+    pub io: Arc<dyn limbo_core::IO>,
+}
+
+#[allow(dead_code, clippy::arc_with_non_send_sync)]
+impl TempDatabase {
+    pub fn new(table_sql: &str) -> Self {
+        let mut path = TempDir::new().unwrap().into_path();
+        path.push("test.db");
+        {
+            let connection = rusqlite::Connection::open(&path).unwrap();
+            connection
+                .pragma_update(None, "journal_mode", "wal")
+                .unwrap();
+            connection.execute(table_sql, ()).unwrap();
+        }
+        let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::PlatformIO::new().unwrap());
+
+        Self { path, io }
+    }
+
+    pub fn connect_limbo(&self) -> Rc<limbo_core::Connection> {
+        log::debug!("conneting to limbo");
+        let db = Database::open_file(self.io.clone(), self.path.to_str().unwrap()).unwrap();
+
+        let conn = db.connect();
+        log::debug!("connected to limbo");
+        conn
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use limbo_core::{CheckpointStatus, Connection, StepResult, Value};
+    use log::debug;
+
+    #[ignore]
+    #[test]
+    fn test_sequential_write() -> anyhow::Result<()> {
+        let _ = env_logger::try_init();
+
+        let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+        let conn = tmp_db.connect_limbo();
+
+        let list_query = "SELECT * FROM test";
+        let max_iterations = 10000;
+        for i in 0..max_iterations {
+            debug!("inserting {} ", i);
+            if (i % 100) == 0 {
+                let progress = (i as f64 / max_iterations as f64) * 100.0;
+                println!("progress {:.1}%", progress);
+            }
+            let insert_query = format!("INSERT INTO test VALUES ({})", i);
+            match conn.query(insert_query) {
+                Ok(Some(ref mut rows)) => loop {
+                    match rows.next_row()? {
+                        StepResult::IO => {
+                            tmp_db.io.run_once()?;
+                        }
+                        StepResult::Done => break,
+                        _ => unreachable!(),
+                    }
+                },
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("{}", err);
+                }
+            };
+
+            let mut current_read_index = 0;
+            match conn.query(list_query) {
+                Ok(Some(ref mut rows)) => loop {
+                    match rows.next_row()? {
+                        StepResult::Row(row) => {
+                            let first_value = row.values.first().expect("missing id");
+                            let id = match first_value {
+                                Value::Integer(i) => *i as i32,
+                                Value::Float(f) => *f as i32,
+                                _ => unreachable!(),
+                            };
+                            assert_eq!(current_read_index, id);
+                            current_read_index += 1;
+                        }
+                        StepResult::IO => {
+                            tmp_db.io.run_once()?;
+                        }
+                        StepResult::Interrupt => break,
+                        StepResult::Done => break,
+                        StepResult::Busy => {
+                            panic!("Database is busy");
+                        }
+                    }
+                },
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("{}", err);
+                }
+            }
+            do_flush(&conn, &tmp_db)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_simple_overflow_page() -> anyhow::Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);");
+        let conn = tmp_db.connect_limbo();
+
+        let mut huge_text = String::new();
+        for i in 0..8192 {
+            huge_text.push((b'A' + (i % 24) as u8) as char);
+        }
+
+        let list_query = "SELECT * FROM test LIMIT 1";
+        let insert_query = format!("INSERT INTO test VALUES (1, '{}')", huge_text.as_str());
+
+        match conn.query(insert_query) {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Done => break,
+                    _ => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("{}", err);
+            }
+        };
+
+        // this flush helped to review hex of test.db
+        do_flush(&conn, &tmp_db)?;
+
+        match conn.query(list_query) {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::Row(row) => {
+                        let first_value = &row.values[0];
+                        let text = &row.values[1];
+                        let id = match first_value {
+                            Value::Integer(i) => *i as i32,
+                            Value::Float(f) => *f as i32,
+                            _ => unreachable!(),
+                        };
+                        let text = match text {
+                            Value::Text(t) => *t,
+                            _ => unreachable!(),
+                        };
+                        assert_eq!(1, id);
+                        compare_string(&huge_text, text);
+                    }
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("{}", err);
+            }
+        }
+        do_flush(&conn, &tmp_db)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_sequential_overflow_page() -> anyhow::Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);");
+        let conn = tmp_db.connect_limbo();
+        let iterations = 10_usize;
+
+        let mut huge_texts = Vec::new();
+        for i in 0..iterations {
+            let mut huge_text = String::new();
+            for _j in 0..8192 {
+                huge_text.push((b'A' + i as u8) as char);
+            }
+            huge_texts.push(huge_text);
+        }
+
+        for i in 0..iterations {
+            let huge_text = &huge_texts[i];
+            let insert_query = format!("INSERT INTO test VALUES ({}, '{}')", i, huge_text.as_str());
+            match conn.query(insert_query) {
+                Ok(Some(ref mut rows)) => loop {
+                    match rows.next_row()? {
+                        StepResult::IO => {
+                            tmp_db.io.run_once()?;
+                        }
+                        StepResult::Done => break,
+                        _ => unreachable!(),
+                    }
+                },
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("{}", err);
+                }
+            };
+        }
+
+        let list_query = "SELECT * FROM test LIMIT 1";
+        let mut current_index = 0;
+        match conn.query(list_query) {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::Row(row) => {
+                        let first_value = &row.values[0];
+                        let text = &row.values[1];
+                        let id = match first_value {
+                            Value::Integer(i) => *i as i32,
+                            Value::Float(f) => *f as i32,
+                            _ => unreachable!(),
+                        };
+                        let text = match text {
+                            Value::Text(t) => *t,
+                            _ => unreachable!(),
+                        };
+                        let huge_text = &huge_texts[current_index];
+                        assert_eq!(current_index, id as usize);
+                        compare_string(huge_text, text);
+                        current_index += 1;
+                    }
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("{}", err);
+            }
+        }
+        do_flush(&conn, &tmp_db)?;
+        Ok(())
+    }
+
+    #[test]
+    #[ignore]
+    fn test_wal_checkpoint() -> anyhow::Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+        // threshold is 1000 by default
+        let iterations = 1001_usize;
+        let conn = tmp_db.connect_limbo();
+
+        for i in 0..iterations {
+            let insert_query = format!("INSERT INTO test VALUES ({})", i);
+            do_flush(&conn, &tmp_db)?;
+            conn.checkpoint().unwrap();
+            match conn.query(insert_query) {
+                Ok(Some(ref mut rows)) => loop {
+                    match rows.next_row()? {
+                        StepResult::IO => {
+                            tmp_db.io.run_once()?;
+                        }
+                        StepResult::Done => break,
+                        _ => unreachable!(),
+                    }
+                },
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("{}", err);
+                }
+            };
+        }
+
+        do_flush(&conn, &tmp_db)?;
+        conn.clear_page_cache().unwrap();
+        let list_query = "SELECT * FROM test LIMIT 1";
+        let mut current_index = 0;
+        match conn.query(list_query) {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::Row(row) => {
+                        let first_value = &row.values[0];
+                        let id = match first_value {
+                            Value::Integer(i) => *i as i32,
+                            Value::Float(f) => *f as i32,
+                            _ => unreachable!(),
+                        };
+                        assert_eq!(current_index, id as usize);
+                        current_index += 1;
+                    }
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("{}", err);
+            }
+        }
+        do_flush(&conn, &tmp_db)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_wal_restart() -> anyhow::Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+        // threshold is 1000 by default
+
+        fn insert(i: usize, conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
+            log::debug!("inserting {}", i);
+            let insert_query = format!("INSERT INTO test VALUES ({})", i);
+            match conn.query(insert_query) {
+                Ok(Some(ref mut rows)) => loop {
+                    match rows.next_row()? {
+                        StepResult::IO => {
+                            tmp_db.io.run_once()?;
+                        }
+                        StepResult::Done => break,
+                        _ => unreachable!(),
+                    }
+                },
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("{}", err);
+                }
+            };
+            log::debug!("inserted {}", i);
+            tmp_db.io.run_once()?;
+            Ok(())
+        }
+
+        fn count(conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<usize> {
+            log::debug!("counting");
+            let list_query = "SELECT count(x) FROM test";
+            loop {
+                if let Some(ref mut rows) = conn.query(list_query).unwrap() {
+                    loop {
+                        match rows.next_row()? {
+                            StepResult::Row(row) => {
+                                let first_value = &row.values[0];
+                                let count = match first_value {
+                                    Value::Integer(i) => *i as i32,
+                                    _ => unreachable!(),
+                                };
+                                log::debug!("counted {}", count);
+                                return Ok(count as usize);
+                            }
+                            StepResult::IO => {
+                                tmp_db.io.run_once()?;
+                            }
+                            StepResult::Interrupt => break,
+                            StepResult::Done => break,
+                            StepResult::Busy => panic!("Database is busy"),
+                        }
+                    }
+                }
+            }
+        }
+
+        {
+            let conn = tmp_db.connect_limbo();
+            insert(1, &conn, &tmp_db).unwrap();
+            assert_eq!(count(&conn, &tmp_db).unwrap(), 1);
+            conn.close()?;
+        }
+        {
+            let conn = tmp_db.connect_limbo();
+            assert_eq!(
+                count(&conn, &tmp_db).unwrap(),
+                1,
+                "failed to read from wal from another connection"
+            );
+            conn.close()?;
+        }
+        Ok(())
+    }
+
+    fn compare_string(a: &String, b: &String) {
+        assert_eq!(a.len(), b.len(), "Strings are not equal in size!");
+        let a = a.as_bytes();
+        let b = b.as_bytes();
+
+        let len = a.len();
+        for i in 0..len {
+            if a[i] != b[i] {
+                println!(
+                    "Bytes differ \n\t at index: dec -> {} hex -> {:#02x} \n\t values dec -> {}!={} hex -> {:#02x}!={:#02x}",
+                    i, i, a[i], b[i], a[i], b[i]
+                );
+                break;
+            }
+        }
+    }
+
+    fn do_flush(conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
+        loop {
+            match conn.cacheflush()? {
+                CheckpointStatus::Done => {
+                    break;
+                }
+                CheckpointStatus::IO => {
+                    tmp_db.io.run_once()?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_db =
+            TempDatabase::new("CREATE TABLE test_rowid (id INTEGER PRIMARY KEY, val TEXT);");
+        let conn = tmp_db.connect_limbo();
+
+        // Simple insert
+        let mut insert_query =
+            conn.query("INSERT INTO test_rowid (id, val) VALUES (NULL, 'test1')")?;
+        if let Some(ref mut rows) = insert_query {
+            loop {
+                match rows.next_row()? {
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Done => break,
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        // Check last_insert_rowid separately
+        let mut select_query = conn.query("SELECT last_insert_rowid()")?;
+        if let Some(ref mut rows) = select_query {
+            loop {
+                match rows.next_row()? {
+                    StepResult::Row(row) => {
+                        if let Value::Integer(id) = row.values[0] {
+                            assert_eq!(id, 1, "First insert should have rowid 1");
+                        }
+                    }
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => panic!("Database is busy"),
+                }
+            }
+        }
+
+        // Test explicit rowid
+        match conn.query("INSERT INTO test_rowid (id, val) VALUES (5, 'test2')") {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Done => break,
+                    _ => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => eprintln!("{}", err),
+        };
+
+        // Check last_insert_rowid after explicit id
+        let mut last_id = 0;
+        match conn.query("SELECT last_insert_rowid()") {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::Row(row) => {
+                        if let Value::Integer(id) = row.values[0] {
+                            last_id = id;
+                        }
+                    }
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => panic!("Database is busy"),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => eprintln!("{}", err),
+        };
+        assert_eq!(last_id, 5, "Explicit insert should have rowid 5");
+        do_flush(&conn, &tmp_db)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_simple_delete() -> anyhow::Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+        let conn = tmp_db.connect_limbo();
+
+        let insert_query = "INSERT INTO test VALUES (1)";
+        match conn.query(insert_query) {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Done => break,
+                    _ => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("{}", err);
+            }
+        };
+
+        let insert_query = "INSERT INTO test VALUES (2)";
+        match conn.query(insert_query) {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Done => break,
+                    _ => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("{}", err);
+            }
+        };
+
+        let delete_query = "DELETE FROM test WHERE x = 1;";
+        match conn.query(delete_query) {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Done => break,
+                    _ => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("{}", err);
+            }
+        };
+
+        let delete_query = "DELETE FROM test WHERE x = 2;";
+        match conn.query(delete_query) {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Done => break,
+                    _ => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("{}", err);
+            }
+        };
+
+        let count_query = "SELECT COUNT(*) FROM test;";
+        match conn.query(count_query) {
+            Ok(Some(ref mut rows)) => loop {
+                match rows.next_row()? {
+                    StepResult::Row(row) => {
+                        let count = match row.values[0] {
+                            Value::Integer(i) => i,
+                            _ => unreachable!(),
+                        };
+                        assert_eq!(count, 0, "Table should be empty after delete");
+                    }
+                    StepResult::IO => {
+                        tmp_db.io.run_once()?;
+                    }
+                    StepResult::Done => break,
+                    _ => unreachable!(),
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("{}", err);
+            }
+        };
+
+        do_flush(&conn, &tmp_db)?;
+        Ok(())
+    }
+}

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1593,6 +1593,8 @@ pub enum PragmaName {
     JournalMode,
     /// trigger a checkpoint to run on database(s) if WAL is enabled
     WalCheckpoint,
+    /// `freelist_count` pragma - number of free pages in the database file
+    FreelistCount,
 }
 
 impl FromStr for PragmaName {
@@ -1603,6 +1605,7 @@ impl FromStr for PragmaName {
             "cache_size" => Ok(PragmaName::CacheSize),
             "wal_checkpoint" => Ok(PragmaName::WalCheckpoint),
             "journal_mode" => Ok(PragmaName::JournalMode),
+            "freelist_count" => Ok(PragmaName::FreelistCount),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
Get `cell_idx` from stack and drops the page

Currently the `cell_idx` we are getting is wrong (`1` instead of `0` for a 1 page Btree). I suspect the problem is with `seek` which is advancing the stack's cell_indices[0] before `delete` is called. Check `test/src/lib.rs::test_simple_delete()` unit test.

- If I move this [`self.stack.advance`](https://github.com/tursodatabase/limbo/blob/main/core/storage/btree.rs#L457) to after `if found` block then delete works and test passes.

@pereman2 need some guidance on this. 

----------------------------------------------------
**Core delete tasks**:
- [x] Implement free page functionality
- [x] Clear overflow pages if any before deleting their cells using free page.
- [x] Implement delete for leaf page
- [ ] Balance after delete properly

**Auxiliary tasks to make delete work properly**:

- [x] Implement block coalescing in `free_cell_range` to reduce fragmentation.
- [x] Track page fragmentation in `free_cell_range`.
- [x] Update page offsets in `drop_cell` and update cell pointer array after dropping a cell. 