### PR TITLE
Add direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.envrc
+++ b/.envrc
@@ -2,3 +2,4 @@ if has nix; then
   watch_file rust-toolchain.toml
   use flake
 fi
+layout python3

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,4 @@
-use flake
+if has nix; then
+  watch_file rust-toolchain.toml
+  use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ dist/
 
 # Javascript
 **/node_modules/
+
+# Direnv
+.direnv

--- a/bindings/python/.envrc
+++ b/bindings/python/.envrc
@@ -1,2 +1,0 @@
-source_env ../../.envrc
-layout python3

--- a/bindings/python/.envrc
+++ b/bindings/python/.envrc
@@ -1,0 +1,2 @@
+source_env ../../.envrc
+layout python3


### PR DESCRIPTION
Add `use flake` configuration for direnv. For Nix users, being able to hop into a directory and loading the environment automatically is very convenient.