### PR TITLE
Change VALID_URL_PREFIX to use sqlite instead

### DIFF
--- a/bindings/java/src/main/java/org/github/tursodatabase/JDBC.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/JDBC.java
@@ -7,7 +7,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 
 public class JDBC implements Driver {
-    private static final String VALID_URL_PREFIX = "jdbc:limbo:";
+    private static final String VALID_URL_PREFIX = "jdbc:sqlite:";
 
     static {
         try {

--- a/bindings/java/src/test/java/org/github/tursodatabase/JDBCTest.java
+++ b/bindings/java/src/test/java/org/github/tursodatabase/JDBCTest.java
@@ -20,13 +20,13 @@ class JDBCTest {
     @Test
     void non_null_connection_is_returned_when_valid_url_is_passed() throws Exception {
         String fileUrl = TestUtils.createTempFile();
-        LimboConnection connection = JDBC.createConnection("jdbc:limbo:" + fileUrl, new Properties());
+        LimboConnection connection = JDBC.createConnection("jdbc:sqlite:" + fileUrl, new Properties());
         assertThat(connection).isNotNull();
     }
 
     @Test
     void connection_can_be_retrieved_from_DriverManager() throws SQLException {
-        try (Connection connection = DriverManager.getConnection("jdbc:limbo:sample.db")) {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:sample.db")) {
             assertThat(connection).isNotNull();
         }
     }


### PR DESCRIPTION
To maximize compatibility between limbo and sqlite, update `VALID_URL_PREFIX`

## Reference 

- [Issue](https://github.com/tursodatabase/limbo/issues/615)