### PR TITLE
Add load_extension function, resolve shared lib extensions

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -120,7 +120,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | like(X,Y,Z)                  | Yes    |         |
 | likelihood(X,Y)              | No     |         |
 | likely(X)                    | No     |         |
-| load_extension(X)            | No     |         |
+| load_extension(X)            | Yes    | sqlite3 extensions not yet supported |
 | load_extension(X,Y)          | No     |         |
 | lower(X)                     | Yes    |         |
 | ltrim(X)                     | Yes    |         |

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -325,7 +325,10 @@ impl Limbo {
 
     #[cfg(not(target_family = "wasm"))]
     fn handle_load_extension(&mut self, path: &str) -> Result<(), String> {
-        self.conn.load_extension(path).map_err(|e| e.to_string())
+        let ext_path = limbo_core::resolve_ext_path(path).map_err(|e| e.to_string())?;
+        self.conn
+            .load_extension(ext_path)
+            .map_err(|e| e.to_string())
     }
 
     fn display_in_memory(&mut self) -> std::io::Result<()> {

--- a/core/function.rs
+++ b/core/function.rs
@@ -136,6 +136,8 @@ pub enum ScalarFunc {
     ZeroBlob,
     LastInsertRowid,
     Replace,
+    #[cfg(not(target_family = "wasm"))]
+    LoadExtension,
 }
 
 impl Display for ScalarFunc {
@@ -185,6 +187,8 @@ impl Display for ScalarFunc {
             Self::LastInsertRowid => "last_insert_rowid".to_string(),
             Self::Replace => "replace".to_string(),
             Self::DateTime => "datetime".to_string(),
+            #[cfg(not(target_family = "wasm"))]
+            Self::LoadExtension => "load_extension".to_string(),
         };
         write!(f, "{}", str)
     }
@@ -426,6 +430,8 @@ impl Func {
             "tan" => Ok(Self::Math(MathFunc::Tan)),
             "tanh" => Ok(Self::Math(MathFunc::Tanh)),
             "trunc" => Ok(Self::Math(MathFunc::Trunc)),
+            #[cfg(not(target_family = "wasm"))]
+            "load_extension" => Ok(Self::Scalar(ScalarFunc::LoadExtension)),
             _ => Err(()),
         }
     }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1092,6 +1092,19 @@ pub fn translate_expr(
                             });
                             Ok(target_register)
                         }
+                        #[cfg(not(target_family = "wasm"))]
+                        ScalarFunc::LoadExtension => {
+                            let args = expect_arguments_exact!(args, 1, srf);
+                            let reg =
+                                translate_and_mark(program, referenced_tables, &args[0], resolver)?;
+                            program.emit_insn(Insn::Function {
+                                constant_mask: 0,
+                                start_reg: reg,
+                                dest: target_register,
+                                func: func_ctx,
+                            });
+                            Ok(target_register)
+                        }
                         ScalarFunc::Random => {
                             if args.is_some() {
                                 crate::bail_parse_error!(


### PR DESCRIPTION
This PR adds the `load_extension` function, and allows for platform agnostic arguments: e.g. `select load_extension('target/debug/liblimbo_uuid');` omitting the file extension.