### PR TITLE
Initial support for wal_checkpoint pragma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +211,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -392,6 +419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "comma"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +637,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downcast"
@@ -746,6 +791,15 @@ dependencies = [
  "lazy_static",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1182,6 +1236,7 @@ name = "limbo"
 version = "0.0.13"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "cli-table",
  "csv",
@@ -1190,6 +1245,8 @@ dependencies = [
  "env_logger 0.10.2",
  "limbo_core",
  "miette",
+ "predicates",
+ "rexpect",
  "rustyline",
 ]
 
@@ -1481,6 +1538,17 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -1500,6 +1568,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-format"
@@ -1775,7 +1849,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -2010,6 +2088,19 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rexpect"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c020234fb542618dc3e3d43724e9d93f87e1db74040a76a8c4e830220fb9b20d"
+dependencies = [
+ "comma",
+ "nix 0.27.1",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "rgb"
@@ -2578,6 +2669,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,15 +794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,7 +1236,6 @@ dependencies = [
  "env_logger 0.10.2",
  "limbo_core",
  "miette",
- "predicates",
  "rexpect",
  "rustyline",
 ]
@@ -1570,12 +1560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,10 +1834,7 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
- "float-cmp",
- "normalize-line-endings",
  "predicates-core",
- "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,7 +1532,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "libc",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,10 +33,7 @@ miette = { version = "7.4.0", features = ["fancy"] }
 [features]
 io_uring = ["limbo_core/io_uring"]
 
-[dev-dependencies]
+# not testing the cli on windows as rexpect does not support it.
+[target.'cfg(not(windows))'.dev-dependencies]
 assert_cmd = "^2"
-predicates = "^3"
-
-# rexpect does not support windows https://github.com/rust-cli/rexpect/issues/11
-#[target.'cfg(not(windows))'.dev-dependencies]
 rexpect = "0.6.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,3 +32,11 @@ miette = { version = "7.4.0", features = ["fancy"] }
 
 [features]
 io_uring = ["limbo_core/io_uring"]
+
+[dev-dependencies]
+assert_cmd = "^2"
+predicates = "^3"
+
+# rexpect does not support windows https://github.com/rust-cli/rexpect/issues/11
+#[target.'cfg(not(windows))'.dev-dependencies]
+rexpect = "0.6.0"

--- a/cli/tests/test_journal.rs
+++ b/cli/tests/test_journal.rs
@@ -1,0 +1,35 @@
+use assert_cmd::cargo::cargo_bin;
+use rexpect::error::*;
+use rexpect::session::spawn_command;
+use std::process;
+
+#[test]
+fn test_pragma_journal_mode_wal() -> Result<(), Error> {
+    let mut child = spawn_command(run_cli(), Some(1000))?;
+    child.exp_regex("limbo>")?; // skip everything until limbo cursor appear
+    child.exp_regex(".?")?;
+    child.send_line("pragma journal_mode;")?;
+    child.exp_string("wal")?;
+    child.send_line(".quit")?;
+    child.exp_eof()?;
+    Ok(())
+}
+
+#[ignore = "wal checkpoint not yet implemented"]
+#[test]
+fn test_pragma_wal_checkpoint() -> Result<(), Error> {
+    let mut child = spawn_command(run_cli(), Some(1000))?;
+    child.exp_regex("limbo>")?; // skip everything until limbo cursor appear
+    child.exp_regex(".?")?;
+    child.send_line("pragma wal_checkpoint;")?;
+    child.exp_string("0|0|0")?;
+    child.send_line(".quit")?;
+    child.exp_eof()?;
+    Ok(())
+}
+
+fn run_cli() -> process::Command {
+    let bin_path = cargo_bin("limbo");
+    let mut cmd = process::Command::new(bin_path);
+    cmd
+}

--- a/cli/tests/test_journal.rs
+++ b/cli/tests/test_journal.rs
@@ -4,7 +4,7 @@
 mod tests {
     use assert_cmd::cargo::cargo_bin;
     use rexpect::error::*;
-    use rexpect::session::spawn_command;
+    use rexpect::session::{spawn_command, PtySession};
     use std::process;
 
     #[test]
@@ -14,9 +14,7 @@ mod tests {
         child.exp_regex(".?")?;
         child.send_line("pragma journal_mode;")?;
         child.exp_string("wal")?;
-        child.send_line(".quit")?;
-        child.exp_eof()?;
-        Ok(())
+        quit(&mut child)
     }
 
     #[test]
@@ -26,6 +24,10 @@ mod tests {
         child.exp_regex(".?")?;
         child.send_line("pragma wal_checkpoint;")?;
         child.exp_string("0|0|0")?;
+        quit(&mut child)
+    }
+
+    fn quit(child: &mut PtySession) -> Result<(), Error> {
         child.send_line(".quit")?;
         child.exp_eof()?;
         Ok(())
@@ -33,7 +35,7 @@ mod tests {
 
     fn run_cli() -> process::Command {
         let bin_path = cargo_bin("limbo");
-        let mut cmd = process::Command::new(bin_path);
+        let cmd = process::Command::new(bin_path);
         cmd
     }
 }

--- a/cli/tests/test_journal.rs
+++ b/cli/tests/test_journal.rs
@@ -1,35 +1,40 @@
-use assert_cmd::cargo::cargo_bin;
-use rexpect::error::*;
-use rexpect::session::spawn_command;
-use std::process;
+/// rexpect does not work on Windows.
+/// https://github.com/rust-cli/rexpect/issues/11
+#[cfg(not(target_os = "windows"))]
+mod tests {
+    use assert_cmd::cargo::cargo_bin;
+    use rexpect::error::*;
+    use rexpect::session::spawn_command;
+    use std::process;
 
-#[test]
-fn test_pragma_journal_mode_wal() -> Result<(), Error> {
-    let mut child = spawn_command(run_cli(), Some(1000))?;
-    child.exp_regex("limbo>")?; // skip everything until limbo cursor appear
-    child.exp_regex(".?")?;
-    child.send_line("pragma journal_mode;")?;
-    child.exp_string("wal")?;
-    child.send_line(".quit")?;
-    child.exp_eof()?;
-    Ok(())
-}
+    #[test]
+    fn test_pragma_journal_mode_wal() -> Result<(), Error> {
+        let mut child = spawn_command(run_cli(), Some(1000))?;
+        child.exp_regex("limbo>")?; // skip everything until limbo cursor appear
+        child.exp_regex(".?")?;
+        child.send_line("pragma journal_mode;")?;
+        child.exp_string("wal")?;
+        child.send_line(".quit")?;
+        child.exp_eof()?;
+        Ok(())
+    }
 
-#[ignore = "wal checkpoint not yet implemented"]
-#[test]
-fn test_pragma_wal_checkpoint() -> Result<(), Error> {
-    let mut child = spawn_command(run_cli(), Some(1000))?;
-    child.exp_regex("limbo>")?; // skip everything until limbo cursor appear
-    child.exp_regex(".?")?;
-    child.send_line("pragma wal_checkpoint;")?;
-    child.exp_string("0|0|0")?;
-    child.send_line(".quit")?;
-    child.exp_eof()?;
-    Ok(())
-}
+    #[ignore = "wal checkpoint not yet implemented"]
+    #[test]
+    fn test_pragma_wal_checkpoint() -> Result<(), Error> {
+        let mut child = spawn_command(run_cli(), Some(1000))?;
+        child.exp_regex("limbo>")?; // skip everything until limbo cursor appear
+        child.exp_regex(".?")?;
+        child.send_line("pragma wal_checkpoint;")?;
+        child.exp_string("0|0|0")?;
+        child.send_line(".quit")?;
+        child.exp_eof()?;
+        Ok(())
+    }
 
-fn run_cli() -> process::Command {
-    let bin_path = cargo_bin("limbo");
-    let mut cmd = process::Command::new(bin_path);
-    cmd
+    fn run_cli() -> process::Command {
+        let bin_path = cargo_bin("limbo");
+        let mut cmd = process::Command::new(bin_path);
+        cmd
+    }
 }

--- a/cli/tests/test_journal.rs
+++ b/cli/tests/test_journal.rs
@@ -19,7 +19,6 @@ mod tests {
         Ok(())
     }
 
-    #[ignore = "wal checkpoint not yet implemented"]
     #[test]
     fn test_pragma_wal_checkpoint() -> Result<(), Error> {
         let mut child = spawn_command(run_cli(), Some(1000))?;

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -25,6 +25,7 @@ pub const NO_LOCK: u32 = 0;
 pub const SHARED_LOCK: u32 = 1;
 pub const WRITE_LOCK: u32 = 2;
 
+#[derive(Debug)]
 pub enum CheckpointMode {
     Passive,
     Full,

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod subquery;
 use crate::schema::Schema;
 use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::{DatabaseHeader, MIN_PAGE_CACHE_SIZE};
+use crate::storage::wal::CheckpointMode;
 use crate::translate::delete::translate_delete;
 use crate::util::PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX;
 use crate::vdbe::builder::CursorType;
@@ -37,7 +38,6 @@ use std::cell::RefCell;
 use std::fmt::Display;
 use std::rc::{Rc, Weak};
 use std::str::FromStr;
-use crate::storage::wal::CheckpointMode;
 
 /// Translate SQL statement into bytecode program.
 pub fn translate(
@@ -594,7 +594,7 @@ fn update_pragma(
             Ok(())
         }
         PragmaName::WalCheckpoint => {
-            // TODO
+            query_pragma("wal_checkpoint", header, program)?;
             Ok(())
         }
     }
@@ -616,26 +616,38 @@ fn query_pragma(
                 value: database_header.borrow().default_page_cache_size.into(),
                 dest: register,
             });
+            program.emit_insn(Insn::ResultRow {
+                start_reg: register,
+                count: 1,
+            });
         }
         PragmaName::JournalMode => {
             program.emit_insn(Insn::String8 {
                 value: "wal".into(),
                 dest: register,
             });
+            program.emit_insn(Insn::ResultRow {
+                start_reg: register,
+                count: 1,
+            });
         }
         PragmaName::WalCheckpoint => {
+            // Checkpoint uses 3 registers: P1, P2, P3. Ref Insn::Checkpoint for more info.
+            // Allocate two more here as one was allocated at the top.
+            program.alloc_register();
+            program.alloc_register();
             program.emit_insn(Insn::Checkpoint {
                 database: 0,
                 checkpoint_mode: CheckpointMode::Passive,
                 dest: register,
             });
+            program.emit_insn(Insn::ResultRow {
+                start_reg: register,
+                count: 3,
+            });
         }
     }
 
-    program.emit_insn(Insn::ResultRow {
-        start_reg: register,
-        count: 1,
-    });
     Ok(())
 }
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -592,6 +592,10 @@ fn update_pragma(
             query_pragma("journal_mode", header, program)?;
             Ok(())
         }
+        PragmaName::WalCheckpoint => {
+            // TODO
+            Ok(())
+        }
     }
 }
 
@@ -615,6 +619,12 @@ fn query_pragma(
         PragmaName::JournalMode => {
             program.emit_insn(Insn::String8 {
                 value: "wal".into(),
+                dest: register,
+            });
+        }
+        PragmaName::WalCheckpoint => {
+            program.emit_insn(Insn::Checkpoint {
+                reg: 12, // TODO fix hard-coded
                 dest: register,
             });
         }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -37,6 +37,7 @@ use std::cell::RefCell;
 use std::fmt::Display;
 use std::rc::{Rc, Weak};
 use std::str::FromStr;
+use crate::storage::wal::CheckpointMode;
 
 /// Translate SQL statement into bytecode program.
 pub fn translate(
@@ -624,7 +625,8 @@ fn query_pragma(
         }
         PragmaName::WalCheckpoint => {
             program.emit_insn(Insn::Checkpoint {
-                reg: 12, // TODO fix hard-coded
+                database: 0,
+                checkpoint_mode: CheckpointMode::Passive,
                 dest: register,
             });
         }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -84,6 +84,15 @@ pub fn insn_to_str(
                 0,
                 format!("r[{}]=~r[{}]", dest, reg),
             ),
+            Insn::Checkpoint { reg, dest } => (
+                "Checkpoint",
+                *reg as i32,
+                *dest as i32,
+                0,
+                OwnedValue::build_text(Rc::new("".to_string())),
+                0,
+                format!("r[{}]=~r[{}]", dest, reg),
+            ),
             Insn::Remainder { lhs, rhs, dest } => (
                 "Remainder",
                 *lhs as i32,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -2,7 +2,6 @@ use crate::vdbe::builder::CursorType;
 
 use super::{Insn, InsnReference, OwnedValue, Program};
 use std::rc::Rc;
-use crate::storage::wal::CheckpointMode;
 
 pub fn insn_to_str(
     program: &Program,
@@ -85,7 +84,11 @@ pub fn insn_to_str(
                 0,
                 format!("r[{}]=~r[{}]", dest, reg),
             ),
-            Insn::Checkpoint { database, checkpoint_mode: _, dest } => (
+            Insn::Checkpoint {
+                database,
+                checkpoint_mode: _,
+                dest,
+            } => (
                 "Checkpoint",
                 *database as i32,
                 *dest as i32,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -2,6 +2,7 @@ use crate::vdbe::builder::CursorType;
 
 use super::{Insn, InsnReference, OwnedValue, Program};
 use std::rc::Rc;
+use crate::storage::wal::CheckpointMode;
 
 pub fn insn_to_str(
     program: &Program,
@@ -84,14 +85,14 @@ pub fn insn_to_str(
                 0,
                 format!("r[{}]=~r[{}]", dest, reg),
             ),
-            Insn::Checkpoint { reg, dest } => (
+            Insn::Checkpoint { database, checkpoint_mode: _, dest } => (
                 "Checkpoint",
-                *reg as i32,
+                *database as i32,
                 *dest as i32,
                 0,
                 OwnedValue::build_text(Rc::new("".to_string())),
                 0,
-                format!("r[{}]=~r[{}]", dest, reg),
+                format!("r[{}]=~r[{}]", dest, database),
             ),
             Insn::Remainder { lhs, rhs, dest } => (
                 "Remainder",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -66,6 +66,12 @@ pub enum Insn {
         reg: usize,
         dest: usize,
     },
+    // Checkpoint the database (applying wal file content to database file).
+    Checkpoint {
+        // TODO support registers as in sqlite
+        reg: usize,
+        dest: usize,
+    },
     // Divide lhs by rhs and place the remainder in dest register.
     Remainder {
         lhs: usize,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1,9 +1,9 @@
 use std::num::NonZero;
 
 use super::{AggFunc, BranchOffset, CursorID, FuncCtx, PageIdx};
+use crate::storage::wal::CheckpointMode;
 use crate::types::{OwnedRecord, OwnedValue};
 use limbo_macros::Description;
-use crate::storage::wal::CheckpointMode;
 
 #[derive(Description, Debug)]
 pub enum Insn {
@@ -69,9 +69,9 @@ pub enum Insn {
     },
     // Checkpoint the database (applying wal file content to database file).
     Checkpoint {
-        database: usize, // checkpoint database P1
+        database: usize,                 // checkpoint database P1
         checkpoint_mode: CheckpointMode, // P2 checkpoint mode
-        dest: usize, // P3 checkpoint result
+        dest: usize,                     // P3 checkpoint result
     },
     // Divide lhs by rhs and place the remainder in dest register.
     Remainder {

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -3,6 +3,7 @@ use std::num::NonZero;
 use super::{AggFunc, BranchOffset, CursorID, FuncCtx, PageIdx};
 use crate::types::{OwnedRecord, OwnedValue};
 use limbo_macros::Description;
+use crate::storage::wal::CheckpointMode;
 
 #[derive(Description, Debug)]
 pub enum Insn {
@@ -68,9 +69,9 @@ pub enum Insn {
     },
     // Checkpoint the database (applying wal file content to database file).
     Checkpoint {
-        // TODO support registers as in sqlite
-        reg: usize,
-        dest: usize,
+        database: usize, // checkpoint database P1
+        checkpoint_mode: CheckpointMode, // P2 checkpoint mode
+        dest: usize, // P3 checkpoint result
     },
     // Divide lhs by rhs and place the remainder in dest register.
     Remainder {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -362,6 +362,12 @@ impl Program {
                     state.registers[*dest] = exec_bit_not(&state.registers[*reg]);
                     state.pc += 1;
                 }
+                Insn::Checkpoint { reg: _, dest } => {
+                    // Write 1 (checkpoint SQLITE_BUSY) or 0 (not busy).
+                    // fixme currently hard coded not implemented
+                    state.registers[*dest] = OwnedValue::Integer(0);
+                    state.pc += 1;
+                }
                 Insn::Null { dest, dest_end } => {
                     if let Some(dest_end) = dest_end {
                         for i in *dest..=*dest_end {

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1591,6 +1591,8 @@ pub enum PragmaName {
     CacheSize,
     /// `journal_mode` pragma
     JournalMode,
+    /// trigger a checkpoint to run on database(s) if WAL is enabled
+    WalCheckpoint,
 }
 
 impl FromStr for PragmaName {
@@ -1599,6 +1601,7 @@ impl FromStr for PragmaName {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         match input {
             "cache_size" => Ok(PragmaName::CacheSize),
+            "wal_checkpoint" => Ok(PragmaName::WalCheckpoint),
             "journal_mode" => Ok(PragmaName::JournalMode),
             _ => Err(()),
         }


### PR DESCRIPTION
Wire pragma wal_checkpoint to checkpoint infra
- add basic support for parsing and instruction emitting `pragma wal_checkpoint;`
- checkpoint opcode for instruction
- checkpoint execution in `virtual machine`
- cli test 

Part of #696.

Before
```
limbo> pragma wal_checkpoint;

  × Parse error: Not a valid pragma name
```

After
```
Enter ".help" for usage hints.
limbo> pragma wal_checkpoint;
0|0|0
```

```