### PR TITLE
Fix MustBeInt opcode semantics

### DIFF
--- a/testing/insert.test
+++ b/testing/insert.test
@@ -7,3 +7,12 @@ do_execsql_test_on_specific_db {:memory:} basic-insert {
     insert into temp values (1);
     select * from temp;
 } {1}
+
+do_execsql_test_on_specific_db {:memory:} must-be-int-insert {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1),(2.0),('3'),('4.0');
+    select * from temp;
+} {1
+2
+3
+4}


### PR DESCRIPTION
In sqlite3 , we can create primary key with only integer column and during insert we can pass any value which can be parsed into integer as shown below. When I tried the same with limbo, it failed. The cause of this was due to MustBeInt opcode behaviour not aligned with sqlite. This PR aims to fix it.

Sqlite output
```
SQLite version 3.45.3
sqlite> create table temp (t1 integer, primary key (t1));
sqlite> insert into temp values (1),(2.0),('3'),('4.0');
sqlite> select * from temp;
1
2
3
4
```

Limbo output main branch
```
limbo>     create table temp (t1 integer, primary key (t1));
limbo>     insert into temp values (1),(2.0),('3'),('4.0');
Parse error: MustBeInt: the value in the register is not an integer
limbo>     select * from temp;
1
```

Limbo output with this PR
```
limbo> create table temp (t1 integer, primary key (t1));
limbo> insert into temp values (1),(2.0),('3'),('4.0');
limbo> select * from temp;
1
2
3
4
```
