### PR TITLE
cli: Improve `.schema` command output on errors

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -724,9 +724,9 @@ impl Limbo {
                 if !found {
                     if let Some(table_name) = table {
                         let _ = self
-                            .write_fmt(format_args!("Error: Table '{}' not found.", table_name));
+                            .write_fmt(format_args!("-- Error: Table '{}' not found.", table_name));
                     } else {
-                        let _ = self.writeln("No tables or indexes found in the database.");
+                        let _ = self.writeln("-- No tables or indexes found in the database.");
                     }
                 }
             }

--- a/testing/shelltests.py
+++ b/testing/shelltests.py
@@ -227,7 +227,7 @@ do_execshell_test(
     pipe,
     "test-can-switch-back-to-in-memory",
     ".schema users",
-    "Error: Table 'users' not found.",
+    "-- Error: Table 'users' not found.",
 )
 
 do_execshell_test(pipe, "test-verify-null-value", "select NULL;", "LIMBO")


### PR DESCRIPTION
Improve `.schema` output on errors by marking them as comments. This allows you to pipe any `.schema` output to another shell.