### PR TITLE
Reduce `liblimbo_sqlite3.a` size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ dist = false
 github-attestations = true
 
 [profile.release]
+debug = "line-tables-only"
 codegen-units = 1
 panic = "abort"
 lto = "off"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ github-attestations = true
 [profile.release]
 codegen-units = 1
 panic = "abort"
-lto = true
+lto = "off"
 
 [profile.bench-profile]
 inherits = "release"
@@ -62,4 +62,3 @@ debug = true
 
 [profile.dist]
 inherits = "release"
-lto = "thin"


### PR DESCRIPTION
This reduces `liblimbo_sqlite3.a` size from 37M to 15M.

Refs #714