### PR TITLE
github: Switch to upload-artifact v4

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -121,9 +121,9 @@ jobs:
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: linux-wheels
           path: bindings/python/dist
 
   macos-x86_64:
@@ -150,9 +150,9 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: macos-x86-wheels
           path: bindings/python/dist
 
   macos-arm64:
@@ -179,9 +179,9 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: macos-arm64-wheels
           path: bindings/python/dist
 
   sdist:
@@ -198,9 +198,9 @@ jobs:
           command: sdist
           args: --out dist
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: sdist-wheels
           path: bindings/python/dist
 
   release:


### PR DESCRIPTION
The current version is getting deprecated:

https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/