### PR TITLE
Fix cli comments parsing

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -434,6 +434,9 @@ impl Limbo {
         line: &str,
         rl: &mut rustyline::DefaultEditor,
     ) -> anyhow::Result<()> {
+        if line.trim_start().starts_with("--") {
+            return Ok(());
+        }
         if self.input_buff.is_empty() {
             if line.is_empty() {
                 return Ok(());


### PR DESCRIPTION
#711 

I followed the patterns that sqlite has, so everything after `--` is treated as a comment. A bunch of spaces and a `--` is treated as a comment also.