### PR TITLE
explored basic sqlite jsonb support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,12 +714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fast-float2"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,22 +1096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonb"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd7dc2490b13d09367f5dc4bf202a5d70958dd5b9b2758e2708ee062752a824"
-dependencies = [
- "byteorder",
- "fast-float2",
- "itoa",
- "nom",
- "ordered-float",
- "rand",
- "ryu",
- "serde_json",
-]
-
-[[package]]
 name = "julian_day_converter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,7 +1198,6 @@ dependencies = [
  "hex",
  "indexmap",
  "io-uring",
- "jsonb",
  "julian_day_converter",
  "libc",
  "libloading",
@@ -1241,6 +1218,7 @@ dependencies = [
  "rusqlite",
  "rustix",
  "serde",
+ "serde_sqlite_jsonb",
  "sieve-cache",
  "sqlite3-parser",
  "tempfile",
@@ -1394,12 +1372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,16 +1450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,15 +1494,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "owo-colors"
@@ -2159,11 +2112,31 @@ version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_json5"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a6b754515e1a7bd79fc2edeaecee526fc80cb3a918607e5ca149225a3a9586"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
+name = "serde_sqlite_jsonb"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28eb962d30138aa087a29ea05a791232bac2987c854d9b06c91de0dc61e69e7c"
+dependencies = [
+ "serde",
+ "serde_json5",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,11 +16,7 @@ path = "lib.rs"
 [features]
 default = ["fs", "json", "uuid", "io_uring"]
 fs = []
-json = [
-    "dep:jsonb",
-    "dep:pest",
-    "dep:pest_derive",
-]
+json = ["dep:serde_sqlite_jsonb", "dep:pest", "dep:pest_derive"]
 uuid = ["dep:uuid"]
 io_uring = ["dep:io-uring", "rustix/io_uring"]
 
@@ -46,10 +42,15 @@ sqlite3-parser = { path = "../vendored/sqlite3-parser" }
 thiserror = "1.0.61"
 getrandom = { version = "0.2.15", features = ["js"] }
 regex = "1.11.1"
-regex-syntax = { version = "0.8.5", default-features = false, features = ["unicode"] }
+regex-syntax = { version = "0.8.5", default-features = false, features = [
+    "unicode",
+] }
 chrono = "0.4.38"
 julian_day_converter = "0.3.2"
-jsonb = { version = "0.4.4", optional = true }
+# pull implementation directly into limbo?
+serde_sqlite_jsonb = { version = "0.1", features = [
+    "serde_json5",
+], default-features = false, optional = true }
 indexmap = { version = "2.2.6", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 pest = { version = "2.0", optional = true }

--- a/core/function.rs
+++ b/core/function.rs
@@ -34,6 +34,7 @@ impl Display for ExternalFunc {
 #[derive(Debug, Clone, PartialEq)]
 pub enum JsonFunc {
     Json,
+    Jsonb,
     JsonArray,
     JsonArrayLength,
     JsonArrowExtract,
@@ -51,6 +52,7 @@ impl Display for JsonFunc {
             "{}",
             match self {
                 Self::Json => "json".to_string(),
+                Self::Jsonb => "jsonb".to_string(),
                 Self::JsonArray => "json_array".to_string(),
                 Self::JsonExtract => "json_extract".to_string(),
                 Self::JsonArrayLength => "json_array_length".to_string(),
@@ -385,6 +387,8 @@ impl Func {
             "replace" => Ok(Self::Scalar(ScalarFunc::Replace)),
             #[cfg(feature = "json")]
             "json" => Ok(Self::Json(JsonFunc::Json)),
+            #[cfg(feature = "json")]
+            "jsonb" => Ok(Self::Json(JsonFunc::Jsonb)),
             #[cfg(feature = "json")]
             "json_array_length" => Ok(Self::Json(JsonFunc::JsonArrayLength)),
             #[cfg(feature = "json")]

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -762,7 +762,7 @@ pub fn translate_expr(
                 }
                 #[cfg(feature = "json")]
                 Func::Json(j) => match j {
-                    JsonFunc::Json => {
+                    JsonFunc::Json | JsonFunc::Jsonb => {
                         let args = expect_arguments_exact!(args, 1, j);
 
                         translate_function(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -27,6 +27,7 @@ pub mod sorter;
 use crate::error::{LimboError, SQLITE_CONSTRAINT_PRIMARYKEY};
 use crate::ext::ExtValue;
 use crate::function::{AggFunc, FuncCtx, MathFunc, MathFuncArity, ScalarFunc};
+use crate::json::get_jsonb;
 use crate::pseudo::PseudoCursor;
 use crate::result::LimboResult;
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
@@ -1507,6 +1508,14 @@ impl Program {
                                 let json_str = get_json(json_value);
                                 match json_str {
                                     Ok(json) => state.registers[*dest] = json,
+                                    Err(e) => return Err(e),
+                                }
+                            }
+                            JsonFunc::Jsonb => {
+                                let json_value = &state.registers[*start_reg];
+                                let json_blob = get_jsonb(json_value);
+                                match json_blob {
+                                    Ok(json_blob) => state.registers[*dest] = json_blob,
                                     Err(e) => return Err(e),
                                 }
                             }

--- a/flake.nix
+++ b/flake.nix
@@ -9,40 +9,45 @@
     };
   };
 
-  outputs = {
-    nixpkgs,
-    fenix,
-    ...
-  }: let
-    systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
-    forAllSystems = nixpkgs.lib.genAttrs systems;
-  in {
-    devShells = forAllSystems (
-      system: let
-        pkgs = nixpkgs.legacyPackages.${system};
-        rustStable = fenix.packages.${system}.stable.toolchain;
-        wasmTarget = fenix.packages.${system}.targets.wasm32-wasi.latest.rust-std;
-        extraDarwinInputs =
-          if pkgs.stdenv.isDarwin
-          then [pkgs.darwin.apple_sdk.frameworks.CoreFoundation]
-          else [];
-      in {
-        default = with pkgs;
-          mkShell {
-            buildInputs =
-              [
-                clang
-                libiconv
-                sqlite
-                gnumake
-                rustup # not used to install the toolchain, but the makefile uses it
-                rustStable
-                wasmTarget
-                tcl
-              ]
-              ++ extraDarwinInputs;
-          };
-      }
-    );
-  };
+  outputs =
+    { nixpkgs
+    , fenix
+    , ...
+    }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          rustStable = fenix.packages.${system}.stable.toolchain;
+          wasmTarget = fenix.packages.${system}.targets.wasm32-wasi.latest.rust-std;
+          extraDarwinInputs =
+            if pkgs.stdenv.isDarwin
+            then [ pkgs.darwin.apple_sdk.frameworks.CoreFoundation ]
+            else [ ];
+        in
+        {
+          default = with pkgs;
+            mkShell {
+              buildInputs =
+                [
+                  clang
+                  libiconv
+                  sqlite
+                  gnumake
+                  rustup # not used to install the toolchain, but the makefile uses it
+                  rustStable
+                  wasmTarget
+                  tcl
+                  python39
+                ]
+                ++ extraDarwinInputs;
+            };
+        }
+      );
+    };
 }


### PR DESCRIPTION
i took a shot at supporting sqlite's JSONB format in the simplest manner possible: replace the databendlabs JSONB crate with [a different crate that appeared to implement SQLITE's JSONB format](https://github.com/lovasoa/serde-sqlite-jsonb).

i also wrote the small amount of scaffolding needed to implement and start testing sqlite's `jsonb` function.

turns out, this only kind of works. the tests i wrote revealed a deviation from sqlite: sqlite uses the "TEXT" type for the test input's key, but the crate being used uses the "TEXTRAW" type.

since @madejejej is also working on JSONB in #710 (unfortunately only discovered after writing this) and resolving this deviation would not be trivial for me right now, i don't think any of this will get merged.

however, in the interest of documenting approaches and providing some very basic tests, i wanted to put this up and have it closed. hopefully it will be somewhat useful without being much of a nuisance.