### PR TITLE
Implement `Is` operator

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -592,6 +592,19 @@ pub fn translate_expr(
                         dest: target_register,
                     });
                 }
+                ast::Operator::Is => {
+                    let if_true_label = program.allocate_label();
+                    wrap_eval_jump_expr(
+                        program,
+                        Insn::Eq {
+                            lhs: e1_reg,
+                            rhs: e2_reg,
+                            target_pc: if_true_label,
+                        },
+                        target_register,
+                        if_true_label,
+                    );
+                }
                 #[cfg(feature = "json")]
                 op @ (ast::Operator::ArrowRight | ast::Operator::ArrowRightShift) => {
                     let json_func = match op {

--- a/testing/all.test
+++ b/testing/all.test
@@ -19,3 +19,4 @@ source $testdir/scalar-functions-datetime.test
 source $testdir/select.test
 source $testdir/subquery.test
 source $testdir/where.test
+source $testdir/compare.test

--- a/testing/compare.test
+++ b/testing/compare.test
@@ -140,3 +140,24 @@ foreach {testname lhs rhs ans} {
 } {
   do_execsql_test compare-lte-$testname "SELECT $lhs <= $rhs" $::ans
 }
+
+foreach {testname lhs rhs ans} {
+  int-int-1               8     1       0 
+  int-int-2               8     8       1
+} {
+  do_execsql_test compare-is-$testname "SELECT $lhs is $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  float-float-1             8.0     1.0     0
+  float-float-2             8.0     8.0     1
+} {
+  do_execsql_test compare-is-$testname "SELECT $lhs is $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+   text-text-1                'a'       'b'    0
+   text-text-2                'a'       'a'    1
+} {
+  do_execsql_test compare-is-$testname "SELECT $lhs is $rhs" $::ans
+}

--- a/testing/compare.test
+++ b/testing/compare.test
@@ -1,0 +1,142 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+foreach {testname lhs rhs ans} {
+  int-int-1               8     1       0 
+  int-int-2               8     8       1
+} {
+  do_execsql_test compare-eq-$testname "SELECT $lhs = $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  float-float-1             8.0     1.0     0
+  float-float-2             8.0     8.0     1
+} {
+  do_execsql_test compare-eq-$testname "SELECT $lhs = $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+   text-text-1                'a'       'b'    0
+   text-text-2                'a'       'a'    1
+} {
+  do_execsql_test compare-eq-$testname "SELECT $lhs = $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  int-int-1               8     1       1 
+  int-int-2               8     8       0
+} {
+  do_execsql_test compare-neq-$testname "SELECT $lhs <> $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  float-float-1             8.0     1.0     1
+  float-float-2             8.0     8.0     0
+} {
+  do_execsql_test compare-neq-$testname "SELECT $lhs <> $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+   text-text-1                'a'       'b'    1
+   text-text-2                'a'       'a'    0
+} {
+  do_execsql_test compare-neq-$testname "SELECT $lhs <> $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  int-int-1               1     8       0 
+  int-int-2               1     1       0
+  int-int-3               8     0       1
+} {
+  do_execsql_test compare-gt-$testname "SELECT $lhs > $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  float-float-1             1.0     2.0     0
+  float-float-2             1.0     1.0     0
+  float-float-3             7.0     6.0     1
+} {
+  do_execsql_test compare-gt-$testname "SELECT $lhs > $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+   text-text-1                'b'       'c'    0
+   text-text-2                'b'       'b'    0
+   text-text-3                'b'       'a'    1
+} {
+  do_execsql_test compare-gt-$testname "SELECT $lhs > $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  int-int-1               1     8       0 
+  int-int-2               1     1       1
+  int-int-3               8     0       1
+} {
+  do_execsql_test compare-gte-$testname "SELECT $lhs >= $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  float-float-1             1.0     2.0     0
+  float-float-2             1.0     1.0     1
+  float-float-3             7.0     6.0     1
+} {
+  do_execsql_test compare-gte-$testname "SELECT $lhs >= $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+   text-text-1                'b'       'c'    0
+   text-text-2                'b'       'b'    1
+   text-text-3                'b'       'a'    1
+} {
+  do_execsql_test compare-gte-$testname "SELECT $lhs >= $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  int-int-1               1     8       1 
+  int-int-2               1     1       0
+  int-int-3               8     0       0
+} {
+  do_execsql_test compare-lt-$testname "SELECT $lhs < $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  float-float-1             1.0     2.0     1
+  float-float-2             1.0     1.0     0
+  float-float-3             7.0     6.0     0
+} {
+  do_execsql_test compare-lt-$testname "SELECT $lhs < $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+   text-text-1                'b'       'c'    1
+   text-text-2                'b'       'b'    0
+   text-text-3                'b'       'a'    0
+} {
+  do_execsql_test compare-lt-$testname "SELECT $lhs < $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  int-int-1               1     8       1 
+  int-int-2               1     1       1
+  int-int-3               8     0       0
+} {
+  do_execsql_test compare-lte-$testname "SELECT $lhs <= $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  float-float-1             1.0     2.0     1
+  float-float-2             1.0     1.0     1
+  float-float-3             7.0     6.0     0
+} {
+  do_execsql_test compare-lte-$testname "SELECT $lhs <= $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+   text-text-1                'b'       'c'    1
+   text-text-2                'b'       'b'    1
+   text-text-3                'b'       'a'    0
+} {
+  do_execsql_test compare-lte-$testname "SELECT $lhs <= $rhs" $::ans
+}


### PR DESCRIPTION
This PR adds support for `Is` Operator which was not working as shown below. I have also added compare.test for all compare operations on which we can expand upon.

```
❯ .\target\debug\limbo.exe
Limbo v0.0.12
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database
limbo> select 1 is 2;
thread 'main' panicked at core\translate\expr.rs:613:40:
not yet implemented: Is
```