### PR TITLE
Implement IsNot operator

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -605,6 +605,19 @@ pub fn translate_expr(
                         if_true_label,
                     );
                 }
+                ast::Operator::IsNot => {
+                    let if_true_label = program.allocate_label();
+                    wrap_eval_jump_expr(
+                        program,
+                        Insn::Ne {
+                            lhs: e1_reg,
+                            rhs: e2_reg,
+                            target_pc: if_true_label,
+                        },
+                        target_register,
+                        if_true_label,
+                    );
+                }
                 #[cfg(feature = "json")]
                 op @ (ast::Operator::ArrowRight | ast::Operator::ArrowRightShift) => {
                     let json_func = match op {

--- a/testing/compare.test
+++ b/testing/compare.test
@@ -161,3 +161,24 @@ foreach {testname lhs rhs ans} {
 } {
   do_execsql_test compare-is-$testname "SELECT $lhs is $rhs" $::ans
 }
+
+foreach {testname lhs rhs ans} {
+  int-int-1               8     1       1 
+  int-int-2               8     8       0
+} {
+  do_execsql_test compare-is-not-$testname "SELECT $lhs is not $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  float-float-1             8.0     1.0     1
+  float-float-2             8.0     8.0     0
+} {
+  do_execsql_test compare-is-not-$testname "SELECT $lhs is not $rhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+   text-text-1                'a'       'b'    1
+   text-text-2                'a'       'a'    0
+} {
+  do_execsql_test compare-is-not-$testname "SELECT $lhs is not $rhs" $::ans
+}


### PR DESCRIPTION
This PR adds support for IsNot Operator which was not working as shown below.

```
❯ ./target/debug/limbo
Limbo v0.0.12
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database
limbo> select 1 is not 0;
thread 'main' panicked at core\translate\expr.rs:626:40:
not yet implemented: IsNot
stack backtrace:
```