### PR TITLE
Fix `select X'1';` causes limbo to go in infinite loop

### DIFF
--- a/vendored/sqlite3-parser/src/dialect/token.rs
+++ b/vendored/sqlite3-parser/src/dialect/token.rs
@@ -177,4 +177,5 @@ pub enum TokenType {
     TK_WINDOW = 165,
     TK_OVER = 166,
     TK_FILTER = 167,
+    TK_ILLEGAL = 185,
 }

--- a/vendored/sqlite3-parser/src/lexer/sql/mod.rs
+++ b/vendored/sqlite3-parser/src/lexer/sql/mod.rs
@@ -489,9 +489,19 @@ impl Splitter for Tokenizer {
                     Ok(self.identifierish(data))
                 }
             }
-            _ => Err(Error::UnrecognizedToken(None, None)),
+            // Return TK_ILLEGAL
+            _ => handle_unrecognized(data),
         }
     }
+}
+
+fn handle_unrecognized(data: &[u8]) -> Result<(Option<Token<'_>>, usize), Error> {
+    let mut end = 1;
+    while end < data.len() && !data[end].is_ascii_whitespace() {
+        end += 1;
+    }
+
+    Ok((Some((&data[..end], TokenType::TK_ILLEGAL)), end))
 }
 
 fn literal(data: &[u8], quote: u8) -> Result<(Option<Token<'_>>, usize), Error> {

--- a/vendored/sqlite3-parser/src/lexer/sql/mod.rs
+++ b/vendored/sqlite3-parser/src/lexer/sql/mod.rs
@@ -193,7 +193,7 @@ impl FallibleIterator for Parser<'_> {
                 self.parser.sqlite3ParserFinalize();
                 return Err(Error::UnrecognizedToken(
                     Some((self.scanner.line(), self.scanner.column())),
-                    Some(start.into())
+                    Some(start.into()),
                 ));
             }
 
@@ -528,7 +528,7 @@ fn literal(data: &[u8], quote: u8) -> Result<(Option<Token<'_>>, usize), Error> 
 fn blob_literal(data: &[u8]) -> Result<(Option<Token<'_>>, usize), Error> {
     debug_assert!(data[0] == b'x' || data[0] == b'X');
     debug_assert_eq!(data[1], b'\'');
-    
+
     let mut end = 2;
     let mut valid = true;
     while end < data.len() && data[end] != b'\'' {
@@ -537,13 +537,13 @@ fn blob_literal(data: &[u8]) -> Result<(Option<Token<'_>>, usize), Error> {
         }
         end += 1;
     }
-    
+
     let total_len = if end < data.len() { end + 1 } else { end };
-    
+
     if !valid || (end - 2) % 2 != 0 || end >= data.len() {
         return Ok((Some((&data[..total_len], TokenType::TK_ILLEGAL)), total_len));
     }
-    
+
     Ok((Some((&data[2..end], TokenType::TK_BLOB)), total_len))
 }
 


### PR DESCRIPTION
Closes https://github.com/tursodatabase/limbo/issues/730.

Fixed `blog_literal` function to make it return `TK_ILLEGAL` token which in turn now causes parser to stop and return `UnrecognizedTokenError`.

Added `TK_ILLEGAL` to `TokenType` Enum.

Behavior now:

```sql
SELECT X'1';  -- Odd number of hex digits -> TK_ILLEGAL -> unrecognized token error

  × unrecognized token at (1, 12)
   ╭────
 1 │ SELECT X'1';
   ·        ▲
   ·        ╰── here
   ╰────

SELECT X'AB'; -- Valid blob -> TK_BLOB -> parses successfully
�
SELECT X'G1'; -- Invalid hex digit -> TK_ILLEGAL -> unrecognized token error

  × unrecognized token at (1, 13)
   ╭────
 1 │ SELECT X'G1';
   ·        ▲
   ·        ╰── here
   ╰────

```