### PR TITLE
WIP: Initial virtual table implementation + generate_series() demo extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "limbo_series"
+version = "0.0.13"
+dependencies = [
+ "limbo_ext",
+ "log",
+]
+
+[[package]]
 name = "limbo_sim"
 version = "0.0.13"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "simulator",
     "sqlite3",
     "test", "extensions/percentile",
+    "extensions/series",
 ]
 exclude = ["perf/latency/limbo"]
 

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -1,6 +1,15 @@
-use crate::{function::ExternalFunc, Database};
-use limbo_ext::{ExtensionApi, InitAggFunction, ResultCode, ScalarFunction};
+use crate::{
+    function::ExternalFunc,
+    schema::{Column, Type},
+    Database, VirtualTable,
+};
+use fallible_iterator::FallibleIterator;
+use limbo_ext::{ExtensionApi, InitAggFunction, ResultCode, ScalarFunction, VTabModuleImpl};
 pub use limbo_ext::{FinalizeFunction, StepFunction, Value as ExtValue, ValueType as ExtValueType};
+use sqlite3_parser::{
+    ast::{Cmd, CreateTableBody, Stmt},
+    lexer::sql::Parser,
+};
 use std::{
     ffi::{c_char, c_void, CStr},
     rc::Rc,
@@ -13,6 +22,7 @@ unsafe extern "C" fn register_scalar_function(
     func: ScalarFunction,
 ) -> ResultCode {
     let c_str = unsafe { CStr::from_ptr(name) };
+    println!("Scalar??");
     let name_str = match c_str.to_str() {
         Ok(s) => s.to_string(),
         Err(_) => return ResultCode::InvalidArgs,
@@ -32,6 +42,7 @@ unsafe extern "C" fn register_aggregate_function(
     step_func: StepFunction,
     finalize_func: FinalizeFunction,
 ) -> ResultCode {
+    println!("Aggregate??");
     let c_str = unsafe { CStr::from_ptr(name) };
     let name_str = match c_str.to_str() {
         Ok(s) => s.to_string(),
@@ -42,6 +53,48 @@ unsafe extern "C" fn register_aggregate_function(
     }
     let db = unsafe { &*(ctx as *const Database) };
     db.register_aggregate_function_impl(&name_str, args, (init_func, step_func, finalize_func))
+}
+
+unsafe extern "C" fn register_module(
+    ctx: *mut c_void,
+    name: *const c_char,
+    module: VTabModuleImpl,
+) -> ResultCode {
+    let c_str = unsafe { CStr::from_ptr(name) };
+    let name_str = match c_str.to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return ResultCode::Error,
+    };
+    if ctx.is_null() {
+        return ResultCode::Error;
+    }
+    let db = unsafe { &*(ctx as *const Database) };
+
+    db.register_module_impl(&name_str, module)
+}
+
+unsafe extern "C" fn declare_vtab(
+    ctx: *mut c_void,
+    name: *const c_char,
+    sql: *const c_char,
+) -> ResultCode {
+    let c_str = unsafe { CStr::from_ptr(name) };
+    let name_str = match c_str.to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return ResultCode::Error,
+    };
+
+    let c_str = unsafe { CStr::from_ptr(sql) };
+    let sql_str = match c_str.to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return ResultCode::Error,
+    };
+
+    if ctx.is_null() {
+        return ResultCode::Error;
+    }
+    let db = unsafe { &*(ctx as *const Database) };
+    db.declare_vtab_impl(&name_str, &sql_str)
 }
 
 impl Database {
@@ -66,11 +119,93 @@ impl Database {
         ResultCode::OK
     }
 
+    fn register_module_impl(&self, name: &str, module: VTabModuleImpl) -> ResultCode {
+        self.vtab_modules
+            .borrow_mut()
+            .insert(name.to_string(), Rc::new(module));
+        ResultCode::OK
+    }
+
+    fn declare_vtab_impl(&self, name: &str, sql: &str) -> ResultCode {
+        let mut parser = Parser::new(sql.as_bytes());
+        let cmd = parser.next().unwrap().unwrap();
+        let Cmd::Stmt(stmt) = cmd else {
+            return ResultCode::Error;
+        };
+        let Stmt::CreateTable { body, .. } = stmt else {
+            return ResultCode::Error;
+        };
+        let CreateTableBody::ColumnsAndConstraints { columns, .. } = body else {
+            return ResultCode::Error;
+        };
+
+        let columns = columns
+            .into_iter()
+            .filter_map(|(name, column_def)| {
+                // if column_def.col_type includes HIDDEN, omit it for now
+                if let Some(data_type) = column_def.col_type.as_ref() {
+                    if data_type.name.as_str().contains("HIDDEN") {
+                        return None;
+                    }
+                }
+                let column = Column {
+                    name: name.0.clone(),
+                    // TODO extract to util, we use this elsewhere too.
+                    ty: match column_def.col_type {
+                        Some(data_type) => {
+                            // https://www.sqlite.org/datatype3.html
+                            let type_name = data_type.name.as_str().to_uppercase();
+                            if type_name.contains("INT") {
+                                Type::Integer
+                            } else if type_name.contains("CHAR")
+                                || type_name.contains("CLOB")
+                                || type_name.contains("TEXT")
+                            {
+                                Type::Text
+                            } else if type_name.contains("BLOB") || type_name.is_empty() {
+                                Type::Blob
+                            } else if type_name.contains("REAL")
+                                || type_name.contains("FLOA")
+                                || type_name.contains("DOUB")
+                            {
+                                Type::Real
+                            } else {
+                                Type::Numeric
+                            }
+                        }
+                        None => Type::Null,
+                    },
+                    primary_key: column_def.constraints.iter().any(|c| {
+                        matches!(
+                            c.constraint,
+                            sqlite3_parser::ast::ColumnConstraint::PrimaryKey { .. }
+                        )
+                    }),
+                    is_rowid_alias: false,
+                };
+                Some(column)
+            })
+            .collect::<Vec<_>>();
+        let vtab_module = self.vtab_modules.borrow().get(name).unwrap().clone();
+        let vtab = VirtualTable {
+            name: name.to_string(),
+            implementation: vtab_module,
+            columns,
+        };
+        self.syms
+            .borrow_mut()
+            .vtabs
+            .insert(name.to_string(), Rc::new(vtab));
+        ResultCode::OK
+    }
+
     pub fn build_limbo_ext(&self) -> ExtensionApi {
         ExtensionApi {
             ctx: self as *const _ as *mut c_void,
             register_scalar_function,
             register_aggregate_function,
+            register_module,
+            declare_vtab,
         }
     }
 }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,3 +1,4 @@
+use crate::VirtualTable;
 use crate::{util::normalize_ident, Result};
 use core::fmt;
 use fallible_iterator::FallibleIterator;
@@ -47,6 +48,7 @@ impl Schema {
 pub enum Table {
     BTree(Rc<BTreeTable>),
     Pseudo(Rc<PseudoTable>),
+    Virtual(Rc<VirtualTable>),
 }
 
 impl Table {
@@ -54,6 +56,7 @@ impl Table {
         match self {
             Table::BTree(table) => table.root_page,
             Table::Pseudo(_) => unimplemented!(),
+            Table::Virtual(_) => unimplemented!(),
         }
     }
 
@@ -61,6 +64,7 @@ impl Table {
         match self {
             Self::BTree(table) => &table.name,
             Self::Pseudo(_) => "",
+            Self::Virtual(table) => &table.name,
         }
     }
 
@@ -68,6 +72,7 @@ impl Table {
         match self {
             Self::BTree(table) => table.columns.get(index).unwrap(),
             Self::Pseudo(table) => table.columns.get(index).unwrap(),
+            Self::Virtual(_) => unimplemented!(),
         }
     }
 
@@ -75,6 +80,7 @@ impl Table {
         match self {
             Self::BTree(table) => &table.columns,
             Self::Pseudo(table) => &table.columns,
+            Self::Virtual(table) => &table.columns,
         }
     }
 
@@ -82,6 +88,13 @@ impl Table {
         match self {
             Self::BTree(table) => Some(table.clone()),
             Self::Pseudo(_) => None,
+            Self::Virtual(_) => None,
+        }
+    }
+    pub fn virtual_table(&self) -> Option<Rc<VirtualTable>> {
+        match self {
+            Self::Virtual(table) => Some(table.clone()),
+            _ => None,
         }
     }
 }
@@ -91,6 +104,7 @@ impl PartialEq for Table {
         match (self, other) {
             (Self::BTree(a), Self::BTree(b)) => Rc::ptr_eq(a, b),
             (Self::Pseudo(a), Self::Pseudo(b)) => Rc::ptr_eq(a, b),
+            (Self::Virtual(a), Self::Virtual(b)) => Rc::ptr_eq(a, b),
             _ => false,
         }
     }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1575,6 +1575,15 @@ pub fn translate_expr(
                     });
                     Ok(target_register)
                 }
+                TableReferenceType::VirtualTable { .. } => {
+                    let cursor_id = program.resolve_cursor_id(&tbl_ref.table_identifier);
+                    program.emit_insn(Insn::VColumn {
+                        cursor_id: cursor_id,
+                        column: *column,
+                        dest: target_register,
+                    });
+                    Ok(target_register)
+                }
             }
         }
         ast::Expr::RowId { database: _, table } => {

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -509,7 +509,11 @@ fn push_predicate(
                 .iter()
                 .position(|t| {
                     t.table_identifier == table_reference.table_identifier
-                        && t.reference_type == TableReferenceType::BTreeTable
+                        && matches!(
+                            t.reference_type,
+                            TableReferenceType::BTreeTable { .. }
+                                | TableReferenceType::VirtualTable { .. }
+                        )
                 })
                 .unwrap();
 

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     parameters::Parameters,
     schema::{BTreeTable, Index, PseudoTable},
     storage::sqlite3_ondisk::DatabaseHeader,
-    Connection,
+    Connection, VirtualTable,
 };
 
 use super::{BranchOffset, CursorID, Insn, InsnReference, Program};
@@ -38,6 +38,7 @@ pub enum CursorType {
     BTreeIndex(Rc<Index>),
     Pseudo(Rc<PseudoTable>),
     Sorter,
+    VirtualTable(Rc<VirtualTable>),
 }
 
 impl CursorType {
@@ -304,6 +305,9 @@ impl ProgramBuilder {
                 }
                 Insn::IsNull { src: _, target_pc } => {
                     resolve(target_pc, "IsNull");
+                }
+                Insn::VNext { pc_if_next, .. } => {
+                    resolve(pc_if_next, "VNext");
                 }
                 _ => continue,
             }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -344,6 +344,62 @@ pub fn insn_to_str(
                 0,
                 "".to_string(),
             ),
+            Insn::VOpenAsync { cursor_id } => (
+                "VOpenAsync",
+                *cursor_id as i32,
+                0,
+                0,
+                OwnedValue::build_text(Rc::new("".to_string())),
+                0,
+                "".to_string(),
+            ),
+            Insn::VOpenAwait => (
+                "VOpenAwait",
+                0,
+                0,
+                0,
+                OwnedValue::build_text(Rc::new("".to_string())),
+                0,
+                "".to_string(),
+            ),
+            Insn::VFilter {
+                cursor_id,
+                arg_count,
+                args_reg,
+            } => (
+                "VFilter",
+                *cursor_id as i32,
+                *arg_count as i32,
+                *args_reg as i32,
+                OwnedValue::build_text(Rc::new("".to_string())),
+                0,
+                "".to_string(),
+            ),
+            Insn::VColumn {
+                cursor_id,
+                column,
+                dest,
+            } => (
+                "VColumn",
+                *cursor_id as i32,
+                *column as i32,
+                *dest as i32,
+                OwnedValue::build_text(Rc::new("".to_string())),
+                0,
+                "".to_string(),
+            ),
+            Insn::VNext {
+                cursor_id,
+                pc_if_next,
+            } => (
+                "VNext",
+                *cursor_id as i32,
+                pc_if_next.to_debug_int(),
+                0,
+                OwnedValue::build_text(Rc::new("".to_string())),
+                0,
+                "".to_string(),
+            ),
             Insn::OpenPseudo {
                 cursor_id,
                 content_reg,
@@ -401,6 +457,7 @@ pub fn insn_to_str(
                         Some(&pseudo_table.columns.get(*column).unwrap().name)
                     }
                     CursorType::Sorter => None,
+                    CursorType::VirtualTable(v) => Some(&v.columns.get(*column).unwrap().name),
                 };
                 (
                     "Column",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -154,6 +154,35 @@ pub enum Insn {
     // Await for the completion of open cursor.
     OpenReadAwait,
 
+    /// Open a cursor for a virtual table.
+    VOpenAsync {
+        cursor_id: CursorID,
+    },
+
+    /// Await for the completion of open cursor for a virtual table.
+    VOpenAwait,
+
+    /// Initialize the position of the virtual table cursor.
+    VFilter {
+        cursor_id: CursorID,
+        arg_count: usize,
+        args_reg: usize,
+    },
+
+    /// Read a column from the current row of the virtual table cursor.
+    VColumn {
+        cursor_id: CursorID,
+        column: usize,
+        dest: usize,
+    },
+
+    /// Advance the virtual table cursor to the next row.
+    /// TODO: async
+    VNext {
+        cursor_id: CursorID,
+        pc_if_next: BranchOffset,
+    },
+
     // Open a cursor for a pseudo-table that contains a single row.
     OpenPseudo {
         cursor_id: CursorID,

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -1,5 +1,5 @@
 mod types;
-pub use limbo_macros::{register_extension, scalar, AggregateDerive};
+pub use limbo_macros::{register_extension, scalar, AggregateDerive, VTabModuleDerive};
 use std::os::raw::{c_char, c_void};
 pub use types::{ResultCode, Value, ValueType};
 
@@ -21,6 +21,30 @@ pub struct ExtensionApi {
         step_func: StepFunction,
         finalize_func: FinalizeFunction,
     ) -> ResultCode,
+
+    pub register_module: unsafe extern "C" fn(
+        ctx: *mut c_void,
+        name: *const c_char,
+        module: VTabModuleImpl,
+    ) -> ResultCode,
+
+    pub declare_vtab: unsafe extern "C" fn(
+        ctx: *mut c_void,
+        name: *const c_char,
+        sql: *const c_char,
+    ) -> ResultCode,
+}
+
+impl ExtensionApi {
+    pub fn declare_virtual_table(&self, name: &str, sql: &str) -> ResultCode {
+        let Ok(name) = std::ffi::CString::new(name) else {
+            return ResultCode::Error;
+        };
+        let Ok(sql) = std::ffi::CString::new(sql) else {
+            return ResultCode::Error;
+        };
+        unsafe { (self.declare_vtab)(self.ctx, name.as_ptr(), sql.as_ptr()) }
+    }
 }
 
 pub type ExtensionEntryPoint = unsafe extern "C" fn(api: *const ExtensionApi) -> ResultCode;
@@ -46,4 +70,53 @@ pub trait AggFunc {
 
     fn step(state: &mut Self::State, args: &[Value]);
     fn finalize(state: Self::State) -> Value;
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub struct VTabModuleImpl {
+    pub name: *const c_char,
+    pub connect: VtabFnConnect,
+    pub open: VtabFnOpen,
+    pub filter: VtabFnFilter,
+    pub column: VtabFnColumn,
+    pub next: VtabFnNext,
+    pub eof: VtabFnEof,
+}
+
+pub type VtabFnConnect = unsafe extern "C" fn(api: *const c_void) -> ResultCode;
+
+pub type VtabFnOpen = unsafe extern "C" fn() -> *mut c_void;
+
+pub type VtabFnFilter =
+    unsafe extern "C" fn(cursor: *mut c_void, argc: i32, argv: *const Value) -> ResultCode;
+
+pub type VtabFnColumn = unsafe extern "C" fn(cursor: *mut c_void, idx: u32) -> Value;
+
+pub type VtabFnNext = unsafe extern "C" fn(cursor: *mut c_void) -> ResultCode;
+
+pub type VtabFnEof = unsafe extern "C" fn(cursor: *mut c_void) -> bool;
+
+pub trait VTabModule: 'static {
+    type VCursor: VTabCursor;
+
+    fn name() -> &'static str;
+    fn connect(api: &ExtensionApi) -> ResultCode;
+    fn open() -> Self::VCursor;
+    fn filter(cursor: &mut Self::VCursor, arg_count: i32, args: &[Value]) -> ResultCode;
+    fn column(cursor: &Self::VCursor, idx: u32) -> Value;
+    fn next(cursor: &mut Self::VCursor) -> ResultCode;
+    fn eof(cursor: &Self::VCursor) -> bool;
+}
+
+pub trait VTabCursor: Sized {
+    fn rowid(&self) -> i64;
+    fn column(&self, idx: u32) -> Value;
+    fn eof(&self) -> bool;
+    fn next(&mut self) -> ResultCode;
+}
+
+#[repr(C)]
+pub struct VTabImpl {
+    pub module: VTabModuleImpl,
 }

--- a/extensions/core/src/types.rs
+++ b/extensions/core/src/types.rs
@@ -3,6 +3,7 @@ use std::{fmt::Display, os::raw::c_void};
 /// Error type is of type ExtError which can be
 /// either a user defined error or an error code
 #[repr(C)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ResultCode {
     OK = 0,
     Error = 1,
@@ -18,6 +19,7 @@ pub enum ResultCode {
     Unimplemented = 11,
     Internal = 12,
     Unavailable = 13,
+    EOF = 14,
 }
 
 impl ResultCode {
@@ -43,6 +45,7 @@ impl Display for ResultCode {
             ResultCode::Unimplemented => write!(f, "Unimplemented"),
             ResultCode::Internal => write!(f, "Internal Error"),
             ResultCode::Unavailable => write!(f, "Unavailable"),
+            ResultCode::EOF => write!(f, "EOF"),
         }
     }
 }
@@ -60,7 +63,7 @@ pub enum ValueType {
 
 #[repr(C)]
 pub struct Value {
-    value_type: ValueType,
+    pub value_type: ValueType,
     value: *mut c_void,
 }
 

--- a/extensions/series/Cargo.toml
+++ b/extensions/series/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "limbo_series"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+
+[dependencies]
+limbo_ext = { path = "../core"}
+log = "0.4.20"

--- a/extensions/series/src/lib.rs
+++ b/extensions/series/src/lib.rs
@@ -1,0 +1,136 @@
+use limbo_ext::{
+    register_extension, ExtensionApi, ResultCode, VTabCursor, VTabModule, VTabModuleDerive, Value,
+    ValueType,
+};
+
+register_extension! {
+    vtabs: { GenerateSeriesVTab }
+}
+
+/// A virtual table that generates a sequence of integers
+#[derive(Debug, VTabModuleDerive)]
+struct GenerateSeriesVTab;
+
+impl VTabModule for GenerateSeriesVTab {
+    type VCursor = GenerateSeriesCursor;
+    fn name() -> &'static str {
+        "generate_series"
+    }
+
+    fn connect(api: &ExtensionApi) -> ResultCode {
+        // Create table schema
+        let sql = "CREATE TABLE generate_series(
+            value INTEGER,
+            start INTEGER HIDDEN,
+            stop INTEGER HIDDEN,
+            step INTEGER HIDDEN
+        )";
+        let name = Self::name();
+        api.declare_virtual_table(name, sql)
+    }
+
+    fn open() -> Self::VCursor {
+        GenerateSeriesCursor {
+            start: 0,
+            stop: 0,
+            step: 0,
+            current: 0,
+        }
+    }
+
+    fn filter(cursor: &mut Self::VCursor, arg_count: i32, args: &[Value]) -> ResultCode {
+        // args are the start, stop, and step
+        if arg_count == 0 || arg_count > 3 {
+            return ResultCode::InvalidArgs;
+        }
+        let start = {
+            if args[0].value_type() == ValueType::Integer {
+                args[0].to_integer().unwrap()
+            } else {
+                return ResultCode::InvalidArgs;
+            }
+        };
+        let stop = if args.len() == 1 {
+            i64::MAX
+        } else {
+            if args[1].value_type() == ValueType::Integer {
+                args[1].to_integer().unwrap()
+            } else {
+                return ResultCode::InvalidArgs;
+            }
+        };
+        let step = if args.len() <= 2 {
+            1
+        } else {
+            if args[2].value_type() == ValueType::Integer {
+                args[2].to_integer().unwrap()
+            } else {
+                return ResultCode::InvalidArgs;
+            }
+        };
+        cursor.start = start;
+        cursor.current = start;
+        cursor.stop = stop;
+        cursor.step = step;
+        ResultCode::OK
+    }
+
+    fn column(cursor: &Self::VCursor, idx: u32) -> Value {
+        cursor.column(idx)
+    }
+
+    fn next(cursor: &mut Self::VCursor) -> ResultCode {
+        GenerateSeriesCursor::next(cursor)
+    }
+
+    fn eof(cursor: &Self::VCursor) -> bool {
+        cursor.eof()
+    }
+}
+
+/// The cursor for iterating over the generated sequence
+#[derive(Debug)]
+struct GenerateSeriesCursor {
+    start: i64,
+    stop: i64,
+    step: i64,
+    current: i64,
+}
+
+impl GenerateSeriesCursor {
+    fn next(&mut self) -> ResultCode {
+        let current = self.current;
+
+        // Check if we've reached the end
+        if (self.step > 0 && current >= self.stop) || (self.step < 0 && current <= self.stop) {
+            return ResultCode::EOF;
+        }
+
+        self.current = current.saturating_add(self.step);
+        ResultCode::OK
+    }
+}
+
+impl VTabCursor for GenerateSeriesCursor {
+    fn next(&mut self) -> ResultCode {
+        GenerateSeriesCursor::next(self)
+    }
+
+    fn eof(&self) -> bool {
+        (self.step > 0 && self.current > self.stop) || (self.step < 0 && self.current < self.stop)
+    }
+
+    fn column(&self, idx: u32) -> Value {
+        match idx {
+            0 => Value::from_integer(self.current),
+            1 => Value::from_integer(self.start),
+            2 => Value::from_integer(self.stop),
+            3 => Value::from_integer(self.step),
+            _ => Value::null(),
+        }
+    }
+
+    fn rowid(&self) -> i64 {
+        ((self.current - self.start) / self.step) + 1
+    }
+}

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -6,13 +6,14 @@ use syn::{Ident, LitStr, Token};
 pub(crate) struct RegisterExtensionInput {
     pub aggregates: Vec<Ident>,
     pub scalars: Vec<Ident>,
+    pub vtabs: Vec<Ident>,
 }
 
 impl syn::parse::Parse for RegisterExtensionInput {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut aggregates = Vec::new();
         let mut scalars = Vec::new();
-
+        let mut vtabs = Vec::new();
         while !input.is_empty() {
             if input.peek(syn::Ident) && input.peek2(Token![:]) {
                 let section_name: Ident = input.parse()?;
@@ -28,11 +29,15 @@ impl syn::parse::Parse for RegisterExtensionInput {
                     scalars = Punctuated::<Ident, Token![,]>::parse_terminated(&content)?
                         .into_iter()
                         .collect();
+                } else if section_name == "vtabs" {
+                    vtabs = Punctuated::<Ident, Token![,]>::parse_terminated(&content)?
+                        .into_iter()
+                        .collect();
                 } else {
                     return Err(syn::Error::new(section_name.span(), "Unknown section"));
                 }
             } else {
-                return Err(input.error("Expected aggregates: or scalars: section"));
+                return Err(input.error("Expected aggregates:, scalars:, or vtabs: section"));
             }
 
             if input.peek(Token![,]) {
@@ -43,6 +48,7 @@ impl syn::parse::Parse for RegisterExtensionInput {
         Ok(Self {
             aggregates,
             scalars,
+            vtabs,
         })
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -324,6 +324,103 @@ pub fn derive_agg_func(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
+#[proc_macro_derive(VTabModuleDerive)]
+pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let struct_name = &ast.ident;
+
+    let register_fn_name = format_ident!("register_{}", struct_name);
+    let connect_fn_name = format_ident!("connect_{}", struct_name);
+    let open_fn_name = format_ident!("open_{}", struct_name);
+    let filter_fn_name = format_ident!("filter_{}", struct_name);
+    let column_fn_name = format_ident!("column_{}", struct_name);
+    let next_fn_name = format_ident!("next_{}", struct_name);
+    let eof_fn_name = format_ident!("eof_{}", struct_name);
+
+    let expanded = quote! {
+        impl #struct_name {
+            #[no_mangle]
+            unsafe extern "C" fn #connect_fn_name(
+                db: *const ::std::ffi::c_void,
+            ) -> ::limbo_ext::ResultCode {
+                let api = unsafe { &*(db as *const ExtensionApi) };
+                <#struct_name as ::limbo_ext::VTabModule>::connect(api)
+            }
+
+            #[no_mangle]
+            unsafe extern "C" fn #open_fn_name(
+            ) -> *mut ::std::ffi::c_void {
+                let cursor = <#struct_name as ::limbo_ext::VTabModule>::open();
+                Box::into_raw(Box::new(cursor)) as *mut ::std::ffi::c_void
+            }
+
+            #[no_mangle]
+            unsafe extern "C" fn #filter_fn_name(
+                cursor: *mut ::std::ffi::c_void,
+                argc: i32,
+                argv: *const ::limbo_ext::Value,
+            ) -> ::limbo_ext::ResultCode {
+                let cursor = unsafe { &mut *(cursor as *mut <#struct_name as ::limbo_ext::VTabModule>::VCursor) };
+                let args = std::slice::from_raw_parts(argv, argc as usize);
+                <#struct_name as ::limbo_ext::VTabModule>::filter(cursor, argc, args)
+            }
+
+            #[no_mangle]
+            unsafe extern "C" fn #column_fn_name(
+                cursor: *mut ::std::ffi::c_void,
+                idx: u32,
+            ) -> ::limbo_ext::Value {
+                let cursor = unsafe { &mut *(cursor as *mut <#struct_name as ::limbo_ext::VTabModule>::VCursor) };
+                <#struct_name as ::limbo_ext::VTabModule>::column(cursor, idx)
+            }
+
+            #[no_mangle]
+            unsafe extern "C" fn #next_fn_name(
+                cursor: *mut ::std::ffi::c_void,
+            ) -> ::limbo_ext::ResultCode {
+                let cursor = unsafe { &mut *(cursor as *mut <#struct_name as ::limbo_ext::VTabModule>::VCursor) };
+                <#struct_name as ::limbo_ext::VTabModule>::next(cursor)
+            }
+
+            #[no_mangle]
+            unsafe extern "C" fn #eof_fn_name(
+                cursor: *mut ::std::ffi::c_void,
+            ) -> bool {
+                let cursor = unsafe { &mut *(cursor as *mut <#struct_name as ::limbo_ext::VTabModule>::VCursor) };
+                <#struct_name as ::limbo_ext::VTabModule>::eof(cursor)
+            }
+
+            #[no_mangle]
+            pub unsafe extern "C" fn #register_fn_name(
+                api: *const ::limbo_ext::ExtensionApi
+            ) -> ::limbo_ext::ResultCode {
+                if api.is_null() {
+                    return ::limbo_ext::ResultCode::Error;
+                }
+
+                let api = &*api;
+                let name = <#struct_name as ::limbo_ext::VTabModule>::name();
+                // name needs to be a c str FFI compatible, NOT CString
+                let name_c = std::ffi::CString::new(name).unwrap();
+
+                let module = ::limbo_ext::VTabModuleImpl {
+                    name: name_c.as_ptr(),
+                    connect: Self::#connect_fn_name,
+                    open: Self::#open_fn_name,
+                    filter: Self::#filter_fn_name,
+                    column: Self::#column_fn_name,
+                    next: Self::#next_fn_name,
+                    eof: Self::#eof_fn_name,
+                };
+
+                (api.register_module)(api.ctx, name_c.as_ptr(), module)
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
 /// Register your extension with 'core' by providing the relevant functions
 ///```ignore
 ///use limbo_ext::{register_extension, scalar, Value, AggregateDerive, AggFunc};
@@ -363,6 +460,7 @@ pub fn register_extension(input: TokenStream) -> TokenStream {
     let RegisterExtensionInput {
         aggregates,
         scalars,
+        vtabs,
     } = input_ast;
 
     let scalar_calls = scalars.iter().map(|scalar_ident| {
@@ -390,6 +488,21 @@ pub fn register_extension(input: TokenStream) -> TokenStream {
         }
     });
 
+    let vtab_calls = vtabs.iter().map(|vtab_ident| {
+        let register_fn = syn::Ident::new(&format!("register_{}", vtab_ident), vtab_ident.span());
+        quote! {
+            {
+                let result = unsafe{ #vtab_ident::#register_fn(api)};
+                if result == ::limbo_ext::ResultCode::OK {
+                    let result = <#vtab_ident as ::limbo_ext::VTabModule>::connect(api);
+                    return result;
+                } else {
+                    return result;
+                }
+            }
+        }
+    });
+
     let expanded = quote! {
         #[no_mangle]
         pub extern "C" fn register_extension(api: &::limbo_ext::ExtensionApi) -> ::limbo_ext::ResultCode {
@@ -397,6 +510,8 @@ pub fn register_extension(input: TokenStream) -> TokenStream {
             #(#scalar_calls)*
 
             #(#aggregate_calls)*
+
+            #(#vtab_calls)*
 
             ::limbo_ext::ResultCode::OK
         }


### PR DESCRIPTION
TODO:

- heavy documentation of approach, esp. things where it diverges from sqlite / is hacky / is shit
- fix generate_series() implementation edge cases

Feats:

- adds ability to load virtual table modules from extensions
- adds generate_series() as a demo implementation:

```
Limbo v0.0.13
Enter ".help" for usage hints.
limbo> .load target/debug/liblimbo_series.dylib
limbo> select u.id, u.first_name from users u join generate_series(1, 9, 2) g ON u.id = g.value;
1|Jamie
3|Tommy
5|Edward
7|Aimee
9|Matthew
```

generate_series() is sort of a bad example because it is a so-called "eponymous virtual table" i.e. you don't construct it like `CREATE VIRTUAL TABLE generate_series USING series(foo)` but it is always loaded into the schema when the module is loaded.

i will try to implement another demo impl that actually uses CREATE VIRTUAL TABLE ... , although that might bloat the PR. but it would also validate the direction the current FFI interface is going in.