### PR TITLE
Improve changes() and total_changes() functions and add tests

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -112,7 +112,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | Function                     | Status | Comment |
 |------------------------------|--------|---------|
 | abs(X)                       | Yes    |         |
-| changes()                    | No     |         |
+| changes()                    | Partial| Still need to support update statements and triggers |
 | char(X1,X2,...,XN)           | Yes    |         |
 | coalesce(X,Y,...)            | Yes    |         |
 | concat(X,...)                | Yes    |         |
@@ -158,7 +158,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | substr(X,Y)                  | Yes    |         |
 | substring(X,Y,Z)             | Yes    |         |
 | substring(X,Y)               | Yes    |         |
-| total_changes()              | No     |         |
+| total_changes()              | Partial| Still need to support update statements and triggers |
 | trim(X)                      | Yes    |         |
 | trim(X,Y)                    | Yes    |         |
 | typeof(X)                    | Yes    |         |

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -422,6 +422,12 @@ impl Connection {
     fn update_last_rowid(&self, rowid: u64) {
         self.last_insert_rowid.set(rowid);
     }
+
+    pub fn set_changes(&self, nchange: i64) {
+        self.last_change.set(nchange);
+        let prev_total_changes = self.total_changes.get();
+        self.total_changes.set(prev_total_changes + nchange);
+    }
 }
 
 pub struct Statement {

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -48,6 +48,7 @@ pub fn translate(
     syms: &SymbolTable,
 ) -> Result<Program> {
     let mut program = ProgramBuilder::new();
+    let mut change_cnt_on = false;
 
     match stmt {
         ast::Stmt::AlterTable(_, _) => bail_parse_error!("ALTER TABLE not supported yet"),
@@ -79,6 +80,7 @@ pub fn translate(
             limit,
             ..
         } => {
+            change_cnt_on = true;
             translate_delete(&mut program, schema, &tbl_name, where_clause, limit, syms)?;
         }
         ast::Stmt::Detach(_) => bail_parse_error!("DETACH not supported yet"),
@@ -106,6 +108,7 @@ pub fn translate(
             body,
             returning,
         } => {
+            change_cnt_on = true;
             translate_insert(
                 &mut program,
                 schema,
@@ -120,7 +123,7 @@ pub fn translate(
         }
     }
 
-    Ok(program.build(database_header, connection))
+    Ok(program.build(database_header, connection, change_cnt_on))
 }
 
 /* Example:

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::HashMap,
     rc::{Rc, Weak},
 };
@@ -327,6 +327,7 @@ impl ProgramBuilder {
         mut self,
         database_header: Rc<RefCell<DatabaseHeader>>,
         connection: Weak<Connection>,
+        change_cnt_on: bool,
     ) -> Program {
         self.resolve_labels();
         assert!(
@@ -343,6 +344,8 @@ impl ProgramBuilder {
             connection,
             auto_commit: true,
             parameters: self.parameters,
+            n_change: Cell::new(0),
+            change_cnt_on,
         }
     }
 }

--- a/testing/all.test
+++ b/testing/all.test
@@ -20,3 +20,5 @@ source $testdir/select.test
 source $testdir/subquery.test
 source $testdir/where.test
 source $testdir/compare.test
+source $testdir/changes.test
+source $testdir/total-changes.test

--- a/testing/changes.test
+++ b/testing/changes.test
@@ -1,0 +1,23 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test_on_specific_db {:memory:} changes-on-basic-insert {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1);
+    select changes();
+} {1}
+
+do_execsql_test_on_specific_db {:memory:} changes-on-multiple-row-insert {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1), (2), (3);
+    select changes();
+} {3}
+
+do_execsql_test_on_specific_db {:memory:} changes-shows-most-recent {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1), (2), (3);
+    insert into temp values (4), (5), (6), (7);
+    select changes();
+} {4}

--- a/testing/total-changes.test
+++ b/testing/total-changes.test
@@ -1,0 +1,23 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test_on_specific_db {:memory:} total-changes-on-basic-insert {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1);
+    select total_changes();
+} {1}
+
+do_execsql_test_on_specific_db {:memory:} total-changes-on-multiple-row-insert {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1), (2), (3);
+    select total_changes();
+} {3}
+
+do_execsql_test_on_specific_db {:memory:} total-changes-on-multiple-inserts {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1), (2), (3);
+    insert into temp values (4), (5), (6), (7);
+    select total_changes();
+} {7}


### PR DESCRIPTION
#144 

- The previous `changes()` function returns 1 no matter what
- Modified `changes()` and `total_changes()` to be closer to the sqlite implementation
    - Store local `n_change` counter in the `Program` struct 
    - Update `last_change` and `total_changes` values in `Connection` struct on halt
    - Add `change_cnt_on` flag to `Program` struct that is `true` for insert and delete (also need later on for update)
- Added TCL tests