### PR TITLE
Fix parser panic when duplicate column names are given to `CREATE TABLE`

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -596,7 +596,10 @@ impl Iterator for QueryRunner<'_> {
         match self.parser.next() {
             Ok(Some(cmd)) => Some(self.conn.run_cmd(cmd)),
             Ok(None) => None,
-            Err(err) => Some(Err(LimboError::from(err))),
+            Err(err) => {
+                self.parser.finalize();
+                Some(Result::Err(LimboError::from(err)))
+            }
         }
     }
 }

--- a/vendored/sqlite3-parser/src/lexer/sql/mod.rs
+++ b/vendored/sqlite3-parser/src/lexer/sql/mod.rs
@@ -28,6 +28,7 @@ pub use error::Error;
 pub struct Parser<'input> {
     input: &'input [u8],
     scanner: Scanner<Tokenizer>,
+    /// lemon parser
     parser: yyParser<'input>,
 }
 
@@ -61,6 +62,11 @@ impl<'input> Parser<'input> {
     /// Current byte offset in input
     pub fn offset(&self) -> usize {
         self.scanner.offset()
+    }
+
+    /// Public API for sqlite3ParserFinalize()
+    pub fn finalize(&mut self) {
+        self.parser.sqlite3ParserFinalize();
     }
 }
 


### PR DESCRIPTION
Currently, we are using the same `Parser` instance across multiple queries (9cc9577c91edb1ab807f6c5fb6c2deb826abfcd1).  But during this error the parser is not finalized, so parser stack is not reset, thereby triggering the assertion at https://github.com/tursodatabase/limbo/blob/15f7928551435458e2991dde3a76ce71e8a32057/vendored/sqlite3-parser/third_party/lemon/lempar.rs#L663

This PR fixes the panic by calling `sqlite3ParserFinalize()` in the case of error.

Closes https://github.com/tursodatabase/limbo/issues/742

-----------

`git bisect` FTW