### PR TITLE
bindings/java: Fix failing tests 

### DIFF
--- a/bindings/java/rs_src/limbo_connection.rs
+++ b/bindings/java/rs_src/limbo_connection.rs
@@ -9,16 +9,19 @@ use jni::sys::jlong;
 use jni::JNIEnv;
 use limbo_core::Connection;
 use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Clone)]
 #[allow(dead_code)]
 pub struct LimboConnection {
+    // Because java's LimboConnection is 1:1 mapped to limbo connection, we can use Rc
     pub(crate) conn: Rc<Connection>,
-    pub(crate) io: Rc<dyn limbo_core::IO>,
+    // Because io is shared across multiple `LimboConnection`s, wrap it with Arc
+    pub(crate) io: Arc<dyn limbo_core::IO>,
 }
 
 impl LimboConnection {
-    pub fn new(conn: Rc<Connection>, io: Rc<dyn limbo_core::IO>) -> Self {
+    pub fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
         LimboConnection { conn, io }
     }
 

--- a/bindings/java/rs_src/limbo_connection.rs
+++ b/bindings/java/rs_src/limbo_connection.rs
@@ -69,7 +69,7 @@ pub extern "system" fn Java_org_github_tursodatabase_core_LimboConnection_prepar
     };
 
     match connection.conn.prepare(sql) {
-        Ok(stmt) => LimboStatement::new(stmt).to_ptr(),
+        Ok(stmt) => LimboStatement::new(stmt, connection.clone()).to_ptr(),
         Err(e) => {
             set_err_msg_and_throw_exception(
                 &mut env,

--- a/bindings/java/rs_src/limbo_statement.rs
+++ b/bindings/java/rs_src/limbo_statement.rs
@@ -7,6 +7,7 @@ use jni::JNIEnv;
 use limbo_core::{Statement, StepResult};
 
 pub const STEP_RESULT_ID_ROW: i32 = 10;
+#[allow(dead_code)]
 pub const STEP_RESULT_ID_IO: i32 = 20;
 pub const STEP_RESULT_ID_DONE: i32 = 30;
 pub const STEP_RESULT_ID_INTERRUPT: i32 = 40;
@@ -61,13 +62,19 @@ pub extern "system" fn Java_org_github_tursodatabase_core_LimboStatement_step<'l
                 Ok(row) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_ROW, Some(row)),
                 Err(e) => {
                     set_err_msg_and_throw_exception(&mut env, obj, LIMBO_ETC, e.to_string());
-                    return to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None)
+                    return to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None);
                 }
             },
-            Ok(StepResult::IO) => {},
-            Ok(StepResult::Done) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_DONE, None),
-            Ok(StepResult::Interrupt) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_INTERRUPT, None),
-            Ok(StepResult::Busy) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_BUSY, None),
+            Ok(StepResult::IO) => {}
+            Ok(StepResult::Done) => {
+                return to_limbo_step_result(&mut env, STEP_RESULT_ID_DONE, None)
+            }
+            Ok(StepResult::Interrupt) => {
+                return to_limbo_step_result(&mut env, STEP_RESULT_ID_INTERRUPT, None)
+            }
+            Ok(StepResult::Busy) => {
+                return to_limbo_step_result(&mut env, STEP_RESULT_ID_BUSY, None)
+            }
             _ => return to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None),
         }
     }

--- a/bindings/java/rs_src/limbo_statement.rs
+++ b/bindings/java/rs_src/limbo_statement.rs
@@ -53,18 +53,17 @@ pub extern "system" fn Java_org_github_tursodatabase_core_LimboStatement_step<'l
         Ok(stmt) => stmt,
         Err(e) => {
             set_err_msg_and_throw_exception(&mut env, obj, LIMBO_ETC, e.to_string());
-
-            return JObject::null();
+            return to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None);
         }
     };
 
     loop {
-        match stmt
-            .stmt
-            .step()
-            .map_err(|_e| to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None))
-            .unwrap()
-        {
+        let step_result = match stmt.stmt.step() {
+            Ok(result) => result,
+            Err(_) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None),
+        };
+
+        match step_result {
             StepResult::Row(row) => {
                 return match row_to_obj_array(&mut env, &row) {
                     Ok(row) => to_limbo_step_result(&mut env, STEP_RESULT_ID_ROW, Some(row)),

--- a/bindings/java/rs_src/limbo_statement.rs
+++ b/bindings/java/rs_src/limbo_statement.rs
@@ -59,27 +59,32 @@ pub extern "system" fn Java_org_github_tursodatabase_core_LimboStatement_step<'l
     };
 
     loop {
-        match stmt.stmt.step() {
-            Ok(StepResult::Row(row)) => match row_to_obj_array(&mut env, &row) {
-                Ok(row) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_ROW, Some(row)),
-                Err(e) => {
+        match stmt
+            .stmt
+            .step()
+            .map_err(|_e| to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None))
+            .unwrap()
+        {
+            StepResult::Row(row) => {
+                return match row_to_obj_array(&mut env, &row) {
+                    Ok(row) => to_limbo_step_result(&mut env, STEP_RESULT_ID_ROW, Some(row)),
+                    Err(e) => {
+                        set_err_msg_and_throw_exception(&mut env, obj, LIMBO_ETC, e.to_string());
+                        to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None)
+                    }
+                }
+            }
+            StepResult::IO => {
+                if let Err(e) = stmt.connection.io.run_once() {
                     set_err_msg_and_throw_exception(&mut env, obj, LIMBO_ETC, e.to_string());
                     return to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None);
                 }
-            },
-            Ok(StepResult::IO) => {
-                stmt.connection.io.run_once().unwrap();
             }
-            Ok(StepResult::Done) => {
-                return to_limbo_step_result(&mut env, STEP_RESULT_ID_DONE, None)
-            }
-            Ok(StepResult::Interrupt) => {
+            StepResult::Done => return to_limbo_step_result(&mut env, STEP_RESULT_ID_DONE, None),
+            StepResult::Interrupt => {
                 return to_limbo_step_result(&mut env, STEP_RESULT_ID_INTERRUPT, None)
             }
-            Ok(StepResult::Busy) => {
-                return to_limbo_step_result(&mut env, STEP_RESULT_ID_BUSY, None)
-            }
-            _ => return to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None),
+            StepResult::Busy => return to_limbo_step_result(&mut env, STEP_RESULT_ID_BUSY, None),
         }
     }
 }

--- a/bindings/java/rs_src/limbo_statement.rs
+++ b/bindings/java/rs_src/limbo_statement.rs
@@ -55,25 +55,21 @@ pub extern "system" fn Java_org_github_tursodatabase_core_LimboStatement_step<'l
         }
     };
 
-    match stmt.stmt.step() {
-        Ok(StepResult::Row(row)) => match row_to_obj_array(&mut env, &row) {
-            Ok(row) => to_limbo_step_result(&mut env, STEP_RESULT_ID_ROW, Some(row)),
-            Err(e) => {
-                set_err_msg_and_throw_exception(&mut env, obj, LIMBO_ETC, e.to_string());
-                to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None)
-            }
-        },
-        Ok(StepResult::IO) => match env.new_object_array(0, "java/lang/Object", JObject::null()) {
-            Ok(row) => to_limbo_step_result(&mut env, STEP_RESULT_ID_IO, Some(row.into())),
-            Err(e) => {
-                set_err_msg_and_throw_exception(&mut env, obj, LIMBO_ETC, e.to_string());
-                to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None)
-            }
-        },
-        Ok(StepResult::Done) => to_limbo_step_result(&mut env, STEP_RESULT_ID_DONE, None),
-        Ok(StepResult::Interrupt) => to_limbo_step_result(&mut env, STEP_RESULT_ID_INTERRUPT, None),
-        Ok(StepResult::Busy) => to_limbo_step_result(&mut env, STEP_RESULT_ID_BUSY, None),
-        _ => to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None),
+    loop {
+        match stmt.stmt.step() {
+            Ok(StepResult::Row(row)) => match row_to_obj_array(&mut env, &row) {
+                Ok(row) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_ROW, Some(row)),
+                Err(e) => {
+                    set_err_msg_and_throw_exception(&mut env, obj, LIMBO_ETC, e.to_string());
+                    return to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None)
+                }
+            },
+            Ok(StepResult::IO) => {},
+            Ok(StepResult::Done) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_DONE, None),
+            Ok(StepResult::Interrupt) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_INTERRUPT, None),
+            Ok(StepResult::Busy) => return to_limbo_step_result(&mut env, STEP_RESULT_ID_BUSY, None),
+            _ => return to_limbo_step_result(&mut env, STEP_RESULT_ID_ERROR, None),
+        }
     }
 }
 

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/LimboResultSet.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/LimboResultSet.java
@@ -64,6 +64,11 @@ public class LimboResultSet {
             row++;
         }
 
+        if (lastStepResult.isInInvalidState()) {
+            open = false;
+            throw new SQLException("step() returned invalid result: " + lastStepResult);
+        }
+
         pastLastRow = lastStepResult.isDone();
         if (pastLastRow) {
             open = false;

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/LimboStepResult.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/LimboStepResult.java
@@ -13,6 +13,7 @@ public class LimboStepResult {
     private static final int STEP_RESULT_ID_IO = 20;
     private static final int STEP_RESULT_ID_DONE = 30;
     private static final int STEP_RESULT_ID_INTERRUPT = 40;
+    // Indicates that the database file could not be written because of concurrent activity by some other connection
     private static final int STEP_RESULT_ID_BUSY = 50;
     private static final int STEP_RESULT_ID_ERROR = 60;
 
@@ -39,6 +40,14 @@ public class LimboStepResult {
 
     public boolean isDone() {
         return stepResultId == STEP_RESULT_ID_DONE;
+    }
+
+    public boolean isInInvalidState() {
+        // current implementation doesn't allow STEP_RESULT_ID_IO to be returned
+        return stepResultId == STEP_RESULT_ID_IO ||
+               stepResultId == STEP_RESULT_ID_INTERRUPT ||
+               stepResultId == STEP_RESULT_ID_BUSY ||
+               stepResultId == STEP_RESULT_ID_ERROR;
     }
 
     @Override

--- a/bindings/java/src/test/java/org/github/tursodatabase/jdbc4/JDBC4ResultSetTest.java
+++ b/bindings/java/src/test/java/org/github/tursodatabase/jdbc4/JDBC4ResultSetTest.java
@@ -9,7 +9,6 @@ import java.util.Properties;
 
 import org.github.tursodatabase.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class JDBC4ResultSetTest {
@@ -27,7 +26,6 @@ class JDBC4ResultSetTest {
     }
 
     @Test
-    @Disabled("https://github.com/tursodatabase/limbo/pull/743#issuecomment-2600746904")
     void invoking_next_before_the_last_row_should_return_true() throws Exception {
         stmt.executeUpdate("CREATE TABLE users (id INT PRIMARY KEY, username TEXT);");
         stmt.executeUpdate("INSERT INTO users VALUES (1, 'sinwoo');");
@@ -41,7 +39,6 @@ class JDBC4ResultSetTest {
     }
 
     @Test
-    @Disabled("https://github.com/tursodatabase/limbo/pull/743#issuecomment-2600746904")
     void invoking_next_after_the_last_row_should_return_false() throws Exception {
         stmt.executeUpdate("CREATE TABLE users (id INT PRIMARY KEY, username TEXT);");
         stmt.executeUpdate("INSERT INTO users VALUES (1, 'sinwoo');");


### PR DESCRIPTION
## The purpose of this PR 

- Do not create a new `io` and instead use `io` which is used when creating `LimboDatabase`. 
- Run the loop of `step` function on the rust side(better for performance as we don't have to switch between java <-> rust) 

## Changes 

- Java 
  - handle invalid cases 
  - remove @Disabled annotation from tests 
- Rust 
  - add loops in the step function 

## Reference 

- https://github.com/tursodatabase/limbo/issues/615