### PR TITLE
Support returning column names from prepared statement

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -295,7 +295,6 @@ impl Connection {
     pub(crate) fn run_cmd(self: &Rc<Connection>, cmd: Cmd) -> Result<Option<Rows>> {
         let db = self.db.clone();
         let syms: &SymbolTable = &db.syms.borrow();
-
         match cmd {
             Cmd::Stmt(stmt) => {
                 let program = Rc::new(translate::translate(
@@ -466,6 +465,10 @@ impl Statement {
         Ok(Rows::new(stmt))
     }
 
+    pub fn columns(&self) -> &[String] {
+        &self.program.columns
+    }
+
     pub fn parameters(&self) -> &parameters::Parameters {
         &self.program.parameters
     }
@@ -512,6 +515,10 @@ impl Rows {
 
     pub fn next_row(&mut self) -> Result<StepResult<'_>> {
         self.stmt.step()
+    }
+
+    pub fn columns(&self) -> &[String] {
+        self.stmt.columns()
     }
 }
 

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -175,7 +175,11 @@ fn emit_program_for_select(
 
     // Finalize program
     epilogue(program, init_label, start_offset)?;
-
+    program.columns = plan
+        .result_columns
+        .iter()
+        .map(|rc| rc.name.clone())
+        .collect::<Vec<_>>();
     Ok(())
 }
 
@@ -286,7 +290,11 @@ fn emit_program_for_delete(
 
     // Finalize program
     epilogue(program, init_label, start_offset)?;
-
+    program.columns = plan
+        .result_columns
+        .iter()
+        .map(|rc| rc.name.clone())
+        .collect::<Vec<_>>();
     Ok(())
 }
 

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -30,6 +30,7 @@ pub struct ProgramBuilder {
     // map of instruction index to manual comment (used in EXPLAIN)
     comments: HashMap<InsnReference, &'static str>,
     pub parameters: Parameters,
+    pub columns: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -60,6 +61,7 @@ impl ProgramBuilder {
             seekrowid_emitted_bitmask: 0,
             comments: HashMap::new(),
             parameters: Parameters::new(),
+            columns: Vec::new(),
         }
     }
 
@@ -352,6 +354,7 @@ impl ProgramBuilder {
             parameters: self.parameters,
             n_change: Cell::new(0),
             change_cnt_on,
+            columns: self.columns,
         }
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -284,6 +284,7 @@ pub struct Program {
     pub auto_commit: bool,
     pub n_change: Cell<i64>,
     pub change_cnt_on: bool,
+    pub columns: Vec<String>,
 }
 
 impl Program {


### PR DESCRIPTION
Closes #764 

Go driver needs support for fetching the column names after `prepare`