### PR TITLE
core: Fix Statement::reset()

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -486,8 +486,7 @@ impl Statement {
     }
 
     pub fn reset(&mut self) {
-        let state = vdbe::ProgramState::new(self.program.max_registers);
-        self.state = state
+        self.state.reset();
     }
 }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -258,6 +258,19 @@ impl ProgramState {
     }
 
     pub fn reset(&mut self) {
+        self.pc = 0;
+        self.btree_table_cursors.borrow_mut().clear();
+        self.btree_index_cursors.borrow_mut().clear();
+        self.pseudo_cursors.borrow_mut().clear();
+        self.sorter_cursors.borrow_mut().clear();
+        let max_registers = self.registers.len();
+        self.registers.clear();
+        self.registers.resize(max_registers, OwnedValue::Null);
+        self.last_compare = None;
+        self.deferred_seek = None;
+        self.ended_coroutine.clear();
+        self.regex_cache.like.clear();
+        self.interrupted = false;
         self.parameters.clear();
     }
 }


### PR DESCRIPTION
The first rule of writing fast programs: don't use dynamic memory allocation!

Brings `SELECT 1` micro-benchmark back to 70 ns, which is a bit closer to what we had before.