### PR TITLE
Program state optimizations

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -372,7 +372,8 @@ impl Connection {
                         syms,
                     )?;
 
-                    let mut state = vdbe::ProgramState::new(program.max_registers);
+                    let mut state =
+                        vdbe::ProgramState::new(program.max_registers, program.cursor_ref.len());
                     program.step(&mut state, self.pager.clone())?;
                 }
             }
@@ -441,7 +442,7 @@ pub struct Statement {
 
 impl Statement {
     pub fn new(program: Rc<vdbe::Program>, pager: Rc<Pager>) -> Self {
-        let state = vdbe::ProgramState::new(program.max_registers);
+        let state = vdbe::ProgramState::new(program.max_registers, program.cursor_ref.len());
         Self {
             program,
             state,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -277,8 +277,7 @@ pub struct ProgramState {
 impl ProgramState {
     pub fn new(max_registers: usize) -> Self {
         let cursors: RefCell<BTreeMap<CursorID, Cursor>> = RefCell::new(BTreeMap::new());
-        let mut registers = Vec::with_capacity(max_registers);
-        registers.resize(max_registers, OwnedValue::Null);
+        let registers = vec![OwnedValue::Null; max_registers];
         Self {
             pc: 0,
             cursors,
@@ -319,9 +318,7 @@ impl ProgramState {
     pub fn reset(&mut self) {
         self.pc = 0;
         self.cursors.borrow_mut().clear();
-        let max_registers = self.registers.len();
-        self.registers.clear();
-        self.registers.resize(max_registers, OwnedValue::Null);
+        self.registers.iter_mut().for_each(|r| *r = OwnedValue::Null);
         self.last_compare = None;
         self.deferred_seek = None;
         self.ended_coroutine.0 = [0; 4];

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -16,8 +16,13 @@ impl Sorter {
         }
     }
     pub fn is_empty(&self) -> bool {
-        self.current.is_none()
+        self.records.is_empty()
     }
+
+    pub fn has_more(&self) -> bool {
+        self.current.is_some()
+    }
+
     // We do the sorting here since this is what is called by the SorterSort instruction
     pub fn sort(&mut self) {
         self.records.sort_by(|a, b| {


### PR DESCRIPTION
Current micro-optimizations:

- store single data structure for cursors in programstate, not one for every cursor type
- use vec for cursors instead of btreemap
- use knowledge of cursor amount to pre-allocate cursor vec capacity
- don't use resize in ::new() and ::reset(), instead populate directly and reset by iterating over each elem (somehow this is faster)
- use bitfield for ended_coroutine instead of hashmap
