### PR TITLE
core: Remove database header from BTreeCursor

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -157,7 +157,7 @@ pub struct Pager {
     /// I/O interface for input/output operations.
     pub io: Arc<dyn crate::io::IO>,
     dirty_pages: Rc<RefCell<HashSet<usize>>>,
-    db_header: Rc<RefCell<DatabaseHeader>>,
+    pub db_header: Rc<RefCell<DatabaseHeader>>,
 
     flush_info: RefCell<FlushInfo>,
     checkpoint_state: RefCell<CheckpointState>,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -772,8 +772,7 @@ impl Program {
                     root_page,
                 } => {
                     let (_, cursor_type) = self.cursor_ref.get(*cursor_id).unwrap();
-                    let cursor =
-                        BTreeCursor::new(pager.clone(), *root_page, self.database_header.clone());
+                    let cursor = BTreeCursor::new(pager.clone(), *root_page);
                     match cursor_type {
                         CursorType::BTreeTable(_) => {
                             cursors
@@ -2274,8 +2273,7 @@ impl Program {
                 } => {
                     let (_, cursor_type) = self.cursor_ref.get(*cursor_id).unwrap();
                     let is_index = cursor_type.is_index();
-                    let cursor =
-                        BTreeCursor::new(pager.clone(), *root_page, self.database_header.clone());
+                    let cursor = BTreeCursor::new(pager.clone(), *root_page);
                     if is_index {
                         cursors
                             .get_mut(*cursor_id)
@@ -2307,11 +2305,7 @@ impl Program {
                         // TODO: implement temp datbases
                         todo!("temp databases not implemented yet");
                     }
-                    let mut cursor = Box::new(BTreeCursor::new(
-                        pager.clone(),
-                        0,
-                        self.database_header.clone(),
-                    ));
+                    let mut cursor = Box::new(BTreeCursor::new(pager.clone(), 0));
 
                     let root_page = cursor.btree_create(*flags);
                     state.registers[*root] = OwnedValue::Integer(root_page as i64);


### PR DESCRIPTION
It's already in the pager so use it from there to reduce the size of the `BTreeCursor` struct.