### PR TITLE
Implement AddImm opcode

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -4,16 +4,24 @@ This document describes the compatibility of Limbo with SQLite.
 
 ## Table of contents:
 
-- [Features](#features)
-- [SQLite query language](#sqlite-query-language)
+- [Compatibility with SQLite](#compatibility-with-sqlite)
+  - [Table of contents:](#table-of-contents)
+  - [Features](#features)
+  - [SQLite query language](#sqlite-query-language)
     - [Statements](#statements)
-      - [PRAGMA Statements](#pragma)
+      - [PRAGMA](#pragma)
     - [Expressions](#expressions)
-    - [Functions](#functions)
-- [SQLite C API](#sqlite-c-api)
-- [SQLite VDBE opcodes](#sqlite-vdbe-opcodes)
-- [Extensions](#extensions)
+    - [SQL functions](#sql-functions)
+      - [Scalar functions](#scalar-functions)
+      - [Mathematical functions](#mathematical-functions)
+      - [Aggregate functions](#aggregate-functions)
+      - [Date and time functions](#date-and-time-functions)
+      - [JSON functions](#json-functions)
+  - [SQLite C API](#sqlite-c-api)
+  - [SQLite VDBE opcodes](#sqlite-vdbe-opcodes)
+  - [Extensions](#extensions)
     - [UUID](#uuid)
+    - [regexp](#regexp)
 
 ## Features
 
@@ -395,7 +403,7 @@ Modifiers:
 | Opcode         | Status |
 |----------------|--------|
 | Add            | Yes    |
-| AddImm         | No     |
+| AddImm         | Yes    |
 | Affinity       | No     |
 | AggFinal       | Yes    |
 | AggStep        | Yes    |

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1138,6 +1138,15 @@ pub fn insn_to_str(
                 0,
                 format!("r[{}]=(r[{}] || r[{}])", dest, lhs, rhs),
             ),
+            Insn::AddImm { lhs, rhs } => (
+                "AddImm",
+                *lhs as i32,
+                *rhs as i32,
+                0,
+                OwnedValue::build_text(Rc::new("".to_string())),
+                0,
+                format!("r[{}]=r[{}]+r[{}]", lhs, lhs, rhs),
+            ),
         };
     format!(
         "{:<4}  {:<17}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -46,9 +46,9 @@ use crate::{
 use crate::{resolve_ext_path, Connection, Result, Rows, TransactionState, DATABASE_VERSION};
 use datetime::{exec_date, exec_datetime_full, exec_julianday, exec_time, exec_unixepoch};
 use insn::{
-    exec_add, exec_and, exec_bit_and, exec_bit_not, exec_bit_or, exec_boolean_not, exec_concat,
-    exec_divide, exec_multiply, exec_or, exec_remainder, exec_shift_left, exec_shift_right,
-    exec_subtract,
+    exec_add, exec_add_imm, exec_and, exec_bit_and, exec_bit_not, exec_bit_or, exec_boolean_not,
+    exec_concat, exec_divide, exec_multiply, exec_or, exec_remainder, exec_shift_left,
+    exec_shift_right, exec_subtract,
 };
 use likeop::{construct_like_escape_arg, exec_glob, exec_like_with_escape};
 use rand::distributions::{Distribution, Uniform};
@@ -330,6 +330,11 @@ impl Program {
                 Insn::Add { lhs, rhs, dest } => {
                     state.registers[*dest] =
                         exec_add(&state.registers[*lhs], &state.registers[*rhs]);
+                    state.pc += 1;
+                }
+                Insn::AddImm { lhs, rhs } => {
+                    state.registers[*lhs] =
+                        exec_add_imm(&state.registers[*lhs], &state.registers[*rhs]);
                     state.pc += 1;
                 }
                 Insn::Subtract { lhs, rhs, dest } => {


### PR DESCRIPTION
This PR implements the AddImm opcode. Unfortunately, there aren't tests in the sqlite source code for the AddImm bytecode that I could use to test the implementation for compatibility. Maybe the simulation testing may help with making sure the bytecode works as intended.