### PR TITLE
bindings/java Implement close() for `LimboStatement` and `LimboResultSet` 

### DIFF
--- a/bindings/java/rs_src/limbo_statement.rs
+++ b/bindings/java/rs_src/limbo_statement.rs
@@ -29,7 +29,6 @@ impl LimboStatement {
         Box::into_raw(Box::new(self)) as jlong
     }
 
-    #[allow(dead_code)]
     pub fn drop(ptr: jlong) {
         let _boxed = unsafe { Box::from_raw(ptr as *mut LimboStatement) };
     }

--- a/bindings/java/rs_src/limbo_statement.rs
+++ b/bindings/java/rs_src/limbo_statement.rs
@@ -88,6 +88,15 @@ pub extern "system" fn Java_org_github_tursodatabase_core_LimboStatement_step<'l
     }
 }
 
+#[no_mangle]
+pub extern "system" fn Java_org_github_tursodatabase_core_LimboStatement__1close<'local>(
+    _env: JNIEnv<'local>,
+    _obj: JObject<'local>,
+    stmt_ptr: jlong
+) {
+    LimboStatement::drop(stmt_ptr);
+}
+
 fn row_to_obj_array<'local>(
     env: &mut JNIEnv<'local>,
     row: &limbo_core::Row,

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/LimboResultSet.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/LimboResultSet.java
@@ -50,7 +50,11 @@ public class LimboResultSet {
    * cursor can only move forward.
    */
   public boolean next() throws SQLException {
-    if (!open || isEmptyResultSet || pastLastRow) {
+    if (!open) {
+      throw new SQLException("The resultSet is not open");
+    }
+
+    if (isEmptyResultSet || pastLastRow) {
       return false; // completed ResultSet
     }
 
@@ -95,6 +99,11 @@ public class LimboResultSet {
     if (!open) {
       throw new SQLException("ResultSet closed");
     }
+  }
+
+  public void close() throws SQLException {
+    this.statement.close();
+    this.open = false;
   }
 
   @Override

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/LimboResultSet.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/LimboResultSet.java
@@ -1,5 +1,6 @@
 package org.github.tursodatabase.core;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.github.tursodatabase.annotations.Nullable;
 import org.slf4j.Logger;
@@ -40,7 +41,8 @@ public class LimboResultSet {
   }
 
   /**
-   * Consumes all the rows in this result set until the {@link #next()} method returns `false`.
+   * Consumes all the rows in this {@link ResultSet} until the {@link #next()} method returns
+   * `false`.
    *
    * @throws SQLException if the result set is not open or if an error occurs while iterating.
    */

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/LimboResultSet.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/LimboResultSet.java
@@ -40,6 +40,19 @@ public class LimboResultSet {
   }
 
   /**
+   * Consumes all the rows in this result set until the {@link #next()} method returns `false`.
+   *
+   * @throws SQLException if the result set is not open or if an error occurs while iterating.
+   */
+  public void consumeAll() throws SQLException {
+    if (!open) {
+      throw new SQLException("The result set is not open");
+    }
+
+    while (next()) {}
+  }
+
+  /**
    * Moves the cursor forward one row from its current position. A {@link LimboResultSet} cursor is
    * initially positioned before the first fow; the first call to the method <code>next</code> makes
    * the first row the current row; the second call makes the second row the current row, and so on.
@@ -74,9 +87,6 @@ public class LimboResultSet {
     }
 
     pastLastRow = lastStepResult.isDone();
-    if (pastLastRow) {
-      open = false;
-    }
     return !pastLastRow;
   }
 

--- a/bindings/java/src/main/java/org/github/tursodatabase/core/LimboStatement.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/core/LimboStatement.java
@@ -67,6 +67,16 @@ public class LimboStatement {
     LimboExceptionUtils.throwLimboException(errorCode, errorMessageBytes);
   }
 
+  /**
+   * Closes the current statement and releases any resources associated with it. This method calls
+   * the native `_close` method to perform the actual closing operation.
+   */
+  public void close() {
+    _close(statementPointer);
+  }
+
+  private native void _close(long statementPointer);
+
   @Override
   public String toString() {
     return "LimboStatement{"

--- a/bindings/java/src/main/java/org/github/tursodatabase/jdbc4/JDBC4ResultSet.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/jdbc4/JDBC4ResultSet.java
@@ -25,7 +25,7 @@ public class JDBC4ResultSet implements ResultSet {
 
   @Override
   public void close() throws SQLException {
-    // TODO
+    resultSet.close();
   }
 
   @Override
@@ -866,8 +866,7 @@ public class JDBC4ResultSet implements ResultSet {
 
   @Override
   public boolean isClosed() throws SQLException {
-    // TODO
-    return false;
+    return !resultSet.isOpen();
   }
 
   @Override

--- a/bindings/java/src/main/java/org/github/tursodatabase/jdbc4/JDBC4Statement.java
+++ b/bindings/java/src/main/java/org/github/tursodatabase/jdbc4/JDBC4Statement.java
@@ -65,9 +65,7 @@ public class JDBC4Statement implements Statement {
 
     requireNonNull(statement, "statement should not be null after running execute method");
     final LimboResultSet resultSet = statement.getResultSet();
-    while (resultSet.isOpen()) {
-      resultSet.next();
-    }
+    resultSet.consumeAll();
 
     // TODO: return update count;
     return 0;

--- a/bindings/java/src/test/java/org/github/tursodatabase/jdbc4/JDBC4ResultSetTest.java
+++ b/bindings/java/src/test/java/org/github/tursodatabase/jdbc4/JDBC4ResultSetTest.java
@@ -61,7 +61,7 @@ class JDBC4ResultSetTest {
   }
 
   @Test
-  void resultSet_close_test() throws Exception {
+  void close_resultSet_test() throws Exception {
     stmt.executeUpdate("CREATE TABLE users (id INT PRIMARY KEY, username TEXT);");
     stmt.executeUpdate("INSERT INTO users VALUES (2, 'seonwoo');");
     stmt.executeQuery("SELECT * FROM users");

--- a/bindings/java/src/test/java/org/github/tursodatabase/jdbc4/JDBC4ResultSetTest.java
+++ b/bindings/java/src/test/java/org/github/tursodatabase/jdbc4/JDBC4ResultSetTest.java
@@ -1,9 +1,11 @@
 package org.github.tursodatabase.jdbc4;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 import org.github.tursodatabase.TestUtils;
@@ -79,6 +81,6 @@ class JDBC4ResultSetTest {
     resultSet.close();
     assertTrue(resultSet.isClosed());
 
-    resultSet.next();
+    assertThrows(SQLException.class, resultSet::next);
   }
 }

--- a/bindings/java/src/test/java/org/github/tursodatabase/jdbc4/JDBC4ResultSetTest.java
+++ b/bindings/java/src/test/java/org/github/tursodatabase/jdbc4/JDBC4ResultSetTest.java
@@ -57,4 +57,28 @@ class JDBC4ResultSetTest {
     // as well
     assertFalse(resultSet.next());
   }
+
+  @Test
+  void resultSet_close_test() throws Exception {
+    stmt.executeUpdate("CREATE TABLE users (id INT PRIMARY KEY, username TEXT);");
+    stmt.executeUpdate("INSERT INTO users VALUES (2, 'seonwoo');");
+    stmt.executeQuery("SELECT * FROM users");
+    ResultSet resultSet = stmt.getResultSet();
+
+    assertFalse(resultSet.isClosed());
+    resultSet.close();
+    assertTrue(resultSet.isClosed());
+  }
+
+  @Test
+  void calling_methods_on_closed_resultSet_should_throw_exception() throws Exception {
+    stmt.executeUpdate("CREATE TABLE users (id INT PRIMARY KEY, username TEXT);");
+    stmt.executeUpdate("INSERT INTO users VALUES (2, 'seonwoo');");
+    stmt.executeQuery("SELECT * FROM users");
+    ResultSet resultSet = stmt.getResultSet();
+    resultSet.close();
+    assertTrue(resultSet.isClosed());
+
+    resultSet.next();
+  }
 }


### PR DESCRIPTION
## Purpose of this PR 

- Implement `close()` method for `LimboStatement` and `LimboResultSet` 

## Changes 

- Because `LimboStatement` and `LimboResultSet` is 1:1 mapped, implementation of `close()` on both sides are related
- Add `consumeAll` method in `LimboResultSet`

## Reference 

- [Issue](https://github.com/tursodatabase/limbo/issues/615) 