### PR TITLE
Fix panic when double quoted strings are used for column names.

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1626,7 +1626,12 @@ pub fn translate_expr(
             }
         }
         ast::Expr::FunctionCallStar { .. } => todo!(),
-        ast::Expr::Id(_) => unreachable!("Id should be resolved to a Column before translation"),
+        ast::Expr::Id(id) => {
+            crate::bail_parse_error!(
+                "no such column: {} - should this be a string literal in single-quotes?",
+                id.0
+            )
+        }
         ast::Expr::Column {
             database: _,
             table,


### PR DESCRIPTION
Now:
```sql
limbo> create table t (a,b,c); insert into t (a,b,c) values ("hello", 234, 432);
thread 'main' panicked at core/translate/expr.rs:1621:29:
internal error: entered unreachable code: Id should be resolved to a Column before translation
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After fix:
```sql
limbo> create table t (a,b,c); insert into t (a,b,c) values ("hello", 234, 432);

  × Parse error: no such column: "hello" - should this be a string literal in single-quotes?

limbo>
```

Closes #800 