### PR TITLE
Fix memory leaks, make extension types more efficient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ name = "limbo_percentile"
 version = "0.0.13"
 dependencies = [
  "limbo_ext",
+ "mimalloc",
 ]
 
 [[package]]
@@ -1402,6 +1403,7 @@ version = "0.0.13"
 dependencies = [
  "limbo_ext",
  "log",
+ "mimalloc",
  "regex",
 ]
 
@@ -1437,7 +1439,7 @@ name = "limbo_uuid"
 version = "0.0.13"
 dependencies = [
  "limbo_ext",
- "log",
+ "mimalloc",
  "uuid",
 ]
 

--- a/core/types.rs
+++ b/core/types.rs
@@ -130,38 +130,41 @@ impl OwnedValue {
         }
     }
 
-    pub fn from_ffi(v: &ExtValue) -> Self {
+    pub fn from_ffi(v: &ExtValue) -> Result<Self> {
         match v.value_type() {
-            ExtValueType::Null => OwnedValue::Null,
+            ExtValueType::Null => Ok(OwnedValue::Null),
             ExtValueType::Integer => {
                 let Some(int) = v.to_integer() else {
-                    return OwnedValue::Null;
+                    return Ok(OwnedValue::Null);
                 };
-                OwnedValue::Integer(int)
+                Ok(OwnedValue::Integer(int))
             }
             ExtValueType::Float => {
                 let Some(float) = v.to_float() else {
-                    return OwnedValue::Null;
+                    return Ok(OwnedValue::Null);
                 };
-                OwnedValue::Float(float)
+                Ok(OwnedValue::Float(float))
             }
             ExtValueType::Text => {
                 let Some(text) = v.to_text() else {
-                    return OwnedValue::Null;
+                    return Ok(OwnedValue::Null);
                 };
-                OwnedValue::build_text(Rc::new(text))
+                Ok(OwnedValue::build_text(Rc::new(text.to_string())))
             }
             ExtValueType::Blob => {
                 let Some(blob) = v.to_blob() else {
-                    return OwnedValue::Null;
+                    return Ok(OwnedValue::Null);
                 };
-                OwnedValue::Blob(Rc::new(blob))
+                Ok(OwnedValue::Blob(Rc::new(blob)))
             }
             ExtValueType::Error => {
-                let Some(err) = v.to_error() else {
-                    return OwnedValue::Null;
+                let Some(err) = v.to_error_details() else {
+                    return Ok(OwnedValue::Null);
                 };
-                OwnedValue::Text(LimboText::new(Rc::new(err)))
+                match err {
+                    (_, Some(msg)) => Err(LimboError::ExtensionError(msg)),
+                    (code, None) => Err(LimboError::ExtensionError(code.to_string())),
+                }
             }
         }
     }
@@ -181,13 +184,15 @@ pub enum AggContext {
 const NULL: OwnedValue = OwnedValue::Null;
 
 impl AggContext {
-    pub fn compute_external(&mut self) {
+    pub fn compute_external(&mut self) -> Result<()> {
         if let Self::External(ext_state) = self {
             if ext_state.finalized_value.is_none() {
                 let final_value = unsafe { (ext_state.finalize_fn)(ext_state.state) };
-                ext_state.cache_final_value(OwnedValue::from_ffi(&final_value));
+                ext_state.cache_final_value(OwnedValue::from_ffi(&final_value)?);
+                unsafe { final_value.free() };
             }
         }
+        Ok(())
     }
 
     pub fn final_value(&self) -> &OwnedValue {

--- a/extensions/core/README.md
+++ b/extensions/core/README.md
@@ -19,13 +19,18 @@ Add the crate to your `Cargo.toml`:
 ```toml
 [dependencies]
 limbo_ext = { path = "path/to/limbo/extensions/core" } # temporary until crate is published
+
+# mimalloc is required if you intend on linking dynamically. It is imported for you by the register_extension
+# macro, so no configuration is needed. But it must be added to your Cargo.toml
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mimalloc = { version = "*", default-features = false }
 ```
 
-**NOTE** Crate must be of type `cdylib`
+**NOTE** Crate must be of type `cdylib` if you wish to link dynamically
 
 ```
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 ```
 
 `cargo build` will output a shared library that can be loaded with `.load target/debug/libyour_crate_name`

--- a/extensions/percentile/Cargo.toml
+++ b/extensions/percentile/Cargo.toml
@@ -14,3 +14,6 @@ static = ["limbo_ext/static"]
 
 [dependencies]
 limbo_ext = { path = "../core", features = ["static"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mimalloc = { version = "*", default-features = false }

--- a/extensions/regexp/Cargo.toml
+++ b/extensions/regexp/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [features]
 static = ["limbo_ext/static"]
+defaults = []
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -17,3 +18,6 @@ crate-type = ["cdylib", "lib"]
 limbo_ext = { path = "../core", features = ["static"] }
 regex = "1.11.1"
 log = "0.4.20"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mimalloc = { version = "*", default-features = false }

--- a/extensions/regexp/src/lib.rs
+++ b/extensions/regexp/src/lib.rs
@@ -19,11 +19,11 @@ fn regex(pattern: &Value, haystack: &Value) -> Value {
             let Some(haystack) = haystack.to_text() else {
                 return Value::null();
             };
-            let re = match Regex::new(&pattern) {
+            let re = match Regex::new(pattern) {
                 Ok(re) => re,
                 Err(_) => return Value::null(),
             };
-            Value::from_integer(re.is_match(&haystack) as i64)
+            Value::from_integer(re.is_match(haystack) as i64)
         }
         _ => Value::null(),
     }

--- a/extensions/uuid/Cargo.toml
+++ b/extensions/uuid/Cargo.toml
@@ -15,4 +15,6 @@ static= [ "limbo_ext/static" ]
 [dependencies]
 limbo_ext = { path = "../core", features = ["static"] }
 uuid = { version = "1.11.0", features = ["v4", "v7"] }
-log = "0.4.20"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mimalloc = { version = "*", default-features = false }


### PR DESCRIPTION
I was baffled previously, because any time that `free` was called on a type from an extension, it would hang even when I knew it wasn't in use any longer, and hadn't been double free'd.

After #737 was merged, I tried it again and noticed that it would no longer hang... but only for extensions that were staticly linked. 

Then I realized that we are using a global allocator, that likely wasn't getting used in the shared library that is built separately that won't inherit from our global allocator in core, causing some symbol mismatch and the subsequent hanging on calls to `free`. 

This PR adds the global allocator to extensions behind a feature flag in the macro that will prevent it from being used in `wasm` and staticly linked environments where it would conflict with limbos normal global allocator. This allows us to properly free the memory from returning extension functions over FFI.

This PR also changes the Extension type to a union field so we can store int + float values inline without boxing them. 

any additional tips or thoughts anyone else has on improving this would be appreciated :+1: 