### PR TITLE
add missing components to flake.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake #default

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ dist/
 
 # Javascript
 **/node_modules/
+
+# direnv
+.direnv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
     "bindings/python",
     "bindings/rust",
     "bindings/wasm",
-	"bindings/go",
+    "bindings/go",
     "cli",
     "core",
     "extensions/core",

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,11 @@
     devShells = forAllSystems (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
-        rustStable = fenix.packages.${system}.stable.toolchain;
+        rust-stable = fenix.packages.${system}.stable;
+        rust-toolchain = rust-stable.toolchain;
+        rustfmt = rust-stable.rustfmt;
+        rust-src = rust-stable.rust-src;
+        rust-analyzer = rust-stable.rust-analyzer;
         wasmTarget = fenix.packages.${system}.targets.wasm32-wasi.latest.rust-std;
         extraDarwinInputs =
           if pkgs.stdenv.isDarwin
@@ -36,9 +40,13 @@
                 sqlite
                 gnumake
                 rustup # not used to install the toolchain, but the makefile uses it
-                rustStable
+                rust-toolchain
+                rust-src
+                rust-analyzer
+                rustfmt
                 wasmTarget
                 tcl
+                python3
               ]
               ++ extraDarwinInputs;
           };


### PR DESCRIPTION
- add missing rustfm, rust-src, and rust-analyzer
- add direnv for convenient while using nix shell(let me in your review if it's not suitable for this project!)
- to running `cargo test` I needed `python3`, so added.
- fix an indention in `Cargo.toml` file(let me know if it's out of scope)