### PR TITLE
bindings/go: Avoid potentially expensive operations on prepare

### DIFF
--- a/bindings/go/rs_src/statement.rs
+++ b/bindings/go/rs_src/statement.rs
@@ -14,7 +14,7 @@ pub extern "C" fn db_prepare(ctx: *mut c_void, query: *const c_char) -> *mut c_v
 
     let db = LimboConn::from_ptr(ctx);
 
-    let stmt = db.conn.prepare(query_str.to_string());
+    let stmt = db.conn.prepare(query_str);
     match stmt {
         Ok(stmt) => LimboStatement::new(stmt, db).to_ptr(),
         Err(_) => std::ptr::null_mut(),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -255,10 +255,10 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub fn prepare(self: &Rc<Connection>, sql: impl Into<String>) -> Result<Statement> {
-        let sql = sql.into();
+    pub fn prepare(self: &Rc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
+        let sql = sql.as_ref();
         trace!("Preparing: {}", sql);
-        let db = self.db.clone();
+        let db = &self.db;
         let syms: &SymbolTable = &db.syms.borrow();
         let mut parser = Parser::new(sql.as_bytes());
         let cmd = parser.next()?;
@@ -283,8 +283,8 @@ impl Connection {
         }
     }
 
-    pub fn query(self: &Rc<Connection>, sql: impl Into<String>) -> Result<Option<Statement>> {
-        let sql = sql.into();
+    pub fn query(self: &Rc<Connection>, sql: impl AsRef<str>) -> Result<Option<Statement>> {
+        let sql = sql.as_ref();
         trace!("Querying: {}", sql);
         let mut parser = Parser::new(sql.as_bytes());
         let cmd = parser.next()?;
@@ -344,9 +344,9 @@ impl Connection {
         QueryRunner::new(self, sql)
     }
 
-    pub fn execute(self: &Rc<Connection>, sql: impl Into<String>) -> Result<()> {
-        let sql = sql.into();
-        let db = self.db.clone();
+    pub fn execute(self: &Rc<Connection>, sql: impl AsRef<str>) -> Result<()> {
+        let sql = sql.as_ref();
+        let db = &self.db;
         let syms: &SymbolTable = &db.syms.borrow();
         let mut parser = Parser::new(sql.as_bytes());
         let cmd = parser.next()?;


### PR DESCRIPTION
This simple patch makes sure we can operate with a reference to the string instead of being forced to transform it to a string, and makes sure that the Arc doesn't have to be cloned (which can be expensive in multi-core systems).

This doesn't really make a large difference in benchmarks, given how expensive Parse::new() is.