### PR TITLE
Fix `SELECT -9223372036854775808` result differs from SQLite

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1773,7 +1773,7 @@ pub fn translate_expr(
                 } else {
                     1
                 };
-                
+
                 // Special case: if we're negating "9223372036854775808", this is exactly MIN_INT64
                 // If we don't do this -1 * 9223372036854775808 will overflow and parse will fail and trigger conversion to Real.
                 if multiplier == -1 && numeric_value == "9223372036854775808" {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1768,22 +1768,33 @@ pub fn translate_expr(
                 UnaryOperator::Negative | UnaryOperator::Positive,
                 ast::Expr::Literal(ast::Literal::Numeric(numeric_value)),
             ) => {
-                let maybe_int = numeric_value.parse::<i64>();
                 let multiplier = if let UnaryOperator::Negative = op {
                     -1
                 } else {
                     1
                 };
-                if let Ok(value) = maybe_int {
+                
+                // Special case: if we're negating "9223372036854775808", this is exactly MIN_INT64
+                // If we don't do this -1 * 9223372036854775808 will overflow and parse will fail and trigger conversion to Real.
+                if multiplier == -1 && numeric_value == "9223372036854775808" {
                     program.emit_insn(Insn::Integer {
-                        value: value * multiplier,
+                        value: i64::MIN,
                         dest: target_register,
                     });
                 } else {
-                    program.emit_insn(Insn::Real {
-                        value: multiplier as f64 * numeric_value.parse::<f64>()?,
-                        dest: target_register,
-                    });
+                    let maybe_int = numeric_value.parse::<i64>();
+                    if let Ok(value) = maybe_int {
+                        program.emit_insn(Insn::Integer {
+                            value: value * multiplier,
+                            dest: target_register,
+                        });
+                    } else {
+                        let value = numeric_value.parse::<f64>()?;
+                        program.emit_insn(Insn::Real {
+                            value: value * multiplier as f64,
+                            dest: target_register,
+                        });
+                    }
                 }
                 Ok(target_register)
             }


### PR DESCRIPTION
Closes #812 

`-9223372036854775808` is `MIN_INT64`. So when we extract out the minus and try to parse the remainder it becomes greater than MAX_INT64 (9223372036854775807) and will trigger overflow, which converts the literal into `Real`. So we have to handle it as a special case.