### PR TITLE
Add github workflow labeler to automatically add labels 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+bindings/java:
+  - 'bindings/java/**'
+
+bindings/go:
+  - 'bindings/go/**'
+
+bindings/python:
+  - 'bindings/python/**'
+
+bindings/rust:
+  - 'bindings/rust/**'
+
+bindings/wasm:
+  - 'bindings/wasm/**'
+
+core:
+  - 'core/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Labeler
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
## Purpose of this PR 

- Automatically add labels to PRs for easy classification 
- We can add useful rules as needed 

## Changes 

- Add 2 files to configure labeler 
- For now, changes under certain directory will add labels 

## ETC 

- Adding colors to labels would be much useful, but I think the `labeler` doesn't yet support those feature 
  - [Related issue](https://github.com/actions/labeler/pull/685)