### PR TITLE
Fix `SELECT ABS(-9223372036854775808)` causes limbo to panic. 

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -45,6 +45,8 @@ pub enum LimboError {
     ExtensionError(String),
     #[error("Unbound parameter at index {0}")]
     Unbound(NonZero<usize>),
+    #[error("Runtime error: {0}")]
+    RuntimeError(String),
 }
 
 #[macro_export]

--- a/core/error.rs
+++ b/core/error.rs
@@ -45,8 +45,8 @@ pub enum LimboError {
     ExtensionError(String),
     #[error("Unbound parameter at index {0}")]
     Unbound(NonZero<usize>),
-    #[error("Runtime error: {0}")]
-    RuntimeError(String),
+    #[error("Runtime error: integer overflow")]
+    IntegerOverflow,
 }
 
 #[macro_export]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2708,15 +2708,11 @@ pub fn exec_soundex(reg: &OwnedValue) -> OwnedValue {
 fn exec_abs(reg: &OwnedValue) -> Result<OwnedValue> {
     match reg {
         OwnedValue::Integer(x) => {
-            if *x == i64::MIN {
+            match i64::checked_abs(*x) {
+                Some(y) => Ok(OwnedValue::Integer(y)),
                 // Special case: if we do the abs of "-9223372036854775808", it causes overflow.
-                // return RuntimeError
-                return Err(LimboError::RuntimeError("integer overflow".to_string()));
-            }
-            if x < &0 {
-                Ok(OwnedValue::Integer(-x))
-            } else {
-                Ok(OwnedValue::Integer(*x))
+                // return IntegerOverflow error
+                None => Err(LimboError::IntegerOverflow),
             }
         }
         OwnedValue::Float(x) => {


### PR DESCRIPTION
Now we return `RuntimeError`.  Matches SQLite behavior.

SQLite:
```sql
sqlite> SELECT ABS(-9223372036854775808);
Runtime error: integer overflow
```

Limbo after this fix:

```sql
limbo> SELECT ABS(-9223372036854775808);
Runtime error: integer overflow
```

Closes https://github.com/tursodatabase/limbo/issues/815