### PR TITLE
Changes to json serialization/deserialization

### DIFF
--- a/core/json/de.rs
+++ b/core/json/de.rs
@@ -519,6 +519,9 @@ pub mod ordered_object {
         use serde::ser::SerializeMap;
         let mut map = serializer.serialize_map(Some(pairs.len()))?;
         for (k, v) in pairs {
+            if let Val::Removed = v {
+                continue;
+            }
             map.serialize_entry(k, v)?;
         }
         map.end()

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -6,6 +6,7 @@ mod ser;
 use std::rc::Rc;
 
 pub use crate::json::de::from_str;
+use crate::json::de::ordered_object;
 use crate::json::error::Error as JsonError;
 use crate::json::json_path::{json_path, JsonPath, PathElement};
 pub use crate::json::ser::to_string;
@@ -23,7 +24,8 @@ pub enum Val {
     Float(f64),
     String(String),
     Array(Vec<Val>),
-    Object(IndexMap<String, Val>),
+    #[serde(with = "ordered_object")]
+    Object(Vec<(String, Val)>),
 }
 
 pub fn get_json(json_value: &OwnedValue) -> crate::Result<OwnedValue> {
@@ -367,7 +369,7 @@ fn json_extract_single<'a>(
 
                 match current_element {
                     Val::Object(map) => {
-                        if let Some(value) = map.get(key) {
+                        if let Some((_, value)) = map.iter().find(|(k, _)| k == key) {
                             current_element = value;
                         } else {
                             return Ok(None);

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -24,6 +24,7 @@ pub enum Val {
     Float(f64),
     String(String),
     Array(Vec<Val>),
+    Removed,
     #[serde(with = "ordered_object")]
     Object(Vec<(String, Val)>),
 }
@@ -313,6 +314,7 @@ pub fn json_type(value: &OwnedValue, path: Option<&OwnedValue>) -> crate::Result
         Val::String(_) => "text",
         Val::Array(_) => "array",
         Val::Object(_) => "object",
+        Val::Removed => unreachable!(),
     };
 
     Ok(OwnedValue::Text(LimboText::json(Rc::new(val.to_string()))))


### PR DESCRIPTION
Change JSON deserialization to enable json_patch implementation with SQLite-compatible behavior:
* Preserves duplicate keys in JSON objects
* Applies patches only to the first occurrence of each key
* Trade-off: Changes key lookup from O(1) to O(n) to support duplicate keys
* Have to be merged before json_patch() function