### PR TITLE
json_patch() function implementation

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -80,6 +80,7 @@ pub enum JsonFunc {
     JsonType,
     JsonErrorPosition,
     JsonValid,
+    JsonPatch,
 }
 
 #[cfg(feature = "json")]
@@ -99,6 +100,7 @@ impl Display for JsonFunc {
                 Self::JsonType => "json_type".to_string(),
                 Self::JsonErrorPosition => "json_error_position".to_string(),
                 Self::JsonValid => "json_valid".to_string(),
+                Self::JsonPatch => "json_patch".to_string(),
             }
         )
     }
@@ -523,6 +525,8 @@ impl Func {
             "json_error_position" => Ok(Self::Json(JsonFunc::JsonErrorPosition)),
             #[cfg(feature = "json")]
             "json_valid" => Ok(Self::Json(JsonFunc::JsonValid)),
+            #[cfg(feature = "json")]
+            "json_patch" => Ok(Self::Json(JsonFunc::JsonPatch)),
             "unixepoch" => Ok(Self::Scalar(ScalarFunc::UnixEpoch)),
             "julianday" => Ok(Self::Scalar(ScalarFunc::JulianDay)),
             "hex" => Ok(Self::Scalar(ScalarFunc::Hex)),

--- a/core/json/de.rs
+++ b/core/json/de.rs
@@ -519,6 +519,9 @@ pub mod ordered_object {
         use serde::ser::SerializeMap;
         let mut map = serializer.serialize_map(Some(pairs.len()))?;
         for (k, v) in pairs {
+            if let Val::Removed = v {
+                continue;
+            }
             map.serialize_entry(k, v)?;
         }
         map.end()

--- a/core/json/json_operations.rs
+++ b/core/json/json_operations.rs
@@ -1,0 +1,103 @@
+use std::collections::VecDeque;
+
+use crate::types::OwnedValue;
+
+use super::{convert_json_to_db_type, get_json_value, Val};
+
+/// Represents a single patch operation in the merge queue.
+///
+/// Used internally by the `merge_patch` function to track the path and value
+/// for each pending merge operation.
+#[derive(Debug, Clone)]
+struct PatchOperation {
+    path: Vec<usize>,
+    patch: Val,
+}
+
+/// The function follows RFC 7386 JSON Merge Patch semantics:
+/// * If the patch is null, the target is replaced with null
+/// * If the patch contains a scalar value, the target is replaced with that value
+/// * If both target and patch are objects, the patch is recursively applied
+/// * null values in the patch result in property removal from the target
+pub fn json_patch(target: &OwnedValue, patch: &OwnedValue) -> crate::Result<OwnedValue> {
+    match (target, patch) {
+        (OwnedValue::Blob(_), _) | (_, OwnedValue::Blob(_)) => {
+            crate::bail_constraint_error!("blob is not supported!");
+        }
+        _ => (),
+    }
+
+    let mut parsed_target = get_json_value(target)?;
+    let parsed_patch = get_json_value(patch)?;
+
+    merge_patch(&mut parsed_target, parsed_patch);
+
+    convert_json_to_db_type(&parsed_target, false)
+}
+
+/// # Implementation Notes
+///
+/// * Processes patches in breadth-first order
+/// * Maintains path information for nested updates
+/// * Handles object merging with proper null value semantics
+/// * Preserves existing values not mentioned in the patch
+///
+/// Following RFC 7386 rules:
+/// * null values remove properties
+/// * Objects are merged recursively
+/// * Non-object values replace the target completely
+fn merge_patch(target: &mut Val, patch: Val) {
+    let mut queue = VecDeque::with_capacity(8);
+
+    queue.push_back(PatchOperation {
+        path: Vec::new(),
+        patch,
+    });
+    while let Some(PatchOperation { path, patch }) = queue.pop_front() {
+        let mut current: &mut Val = target;
+
+        for (depth, key) in path.iter().enumerate() {
+            if let Val::Object(ref mut obj) = current {
+                current = &mut obj
+                    .get_mut(*key)
+                    .unwrap_or_else(|| {
+                        panic!("Invalid path at depth {}: key '{}' not found", depth, key)
+                    })
+                    .1;
+            }
+        }
+
+        match (current, patch) {
+            (curr, Val::Null) => {
+                *curr = Val::Null;
+            }
+            (Val::Object(target_map), Val::Object(patch_map)) => {
+                for (key, patch_val) in patch_map {
+                    if let Some(pos) = target_map
+                        .iter()
+                        .position(|(target_key, _)| target_key == &key)
+                    {
+                        match patch_val {
+                            Val::Null => {
+                                target_map.remove(pos);
+                            }
+                            val => {
+                                let mut new_path = path.clone();
+                                new_path.push(pos);
+                                queue.push_back(PatchOperation {
+                                    path: new_path,
+                                    patch: val,
+                                });
+                            }
+                        };
+                    } else {
+                        target_map.push((key, patch_val));
+                    };
+                }
+            }
+            (curr, patch_val) => {
+                *curr = patch_val;
+            }
+        }
+    }
+}

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -6,6 +6,7 @@ mod ser;
 use std::rc::Rc;
 
 pub use crate::json::de::from_str;
+use crate::json::de::ordered_object;
 use crate::json::error::Error as JsonError;
 use crate::json::json_path::{json_path, JsonPath, PathElement};
 pub use crate::json::ser::to_string;
@@ -23,7 +24,8 @@ pub enum Val {
     Float(f64),
     String(String),
     Array(Vec<Val>),
-    Object(IndexMap<String, Val>),
+    #[serde(with = "ordered_object")]
+    Object(Vec<(String, Val)>),
 }
 
 pub fn get_json(json_value: &OwnedValue) -> crate::Result<OwnedValue> {
@@ -367,7 +369,7 @@ fn json_extract_single<'a>(
 
                 match current_element {
                     Val::Object(map) => {
-                        if let Some(value) = map.get(key) {
+                        if let Some((_, value)) = map.iter().find(|(k, _)| k == key) {
                             current_element = value;
                         } else {
                             return Ok(None);

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -1,5 +1,6 @@
 mod de;
 mod error;
+mod json_operations;
 mod json_path;
 mod ser;
 
@@ -8,6 +9,7 @@ use std::rc::Rc;
 pub use crate::json::de::from_str;
 use crate::json::de::ordered_object;
 use crate::json::error::Error as JsonError;
+pub use crate::json::json_operations::json_patch;
 use crate::json::json_path::{json_path, JsonPath, PathElement};
 pub use crate::json::ser::to_string;
 use crate::types::{LimboText, OwnedValue, TextSubtype};

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -24,6 +24,7 @@ pub enum Val {
     Float(f64),
     String(String),
     Array(Vec<Val>),
+    Removed,
     #[serde(with = "ordered_object")]
     Object(Vec<(String, Val)>),
 }
@@ -313,6 +314,7 @@ pub fn json_type(value: &OwnedValue, path: Option<&OwnedValue>) -> crate::Result
         Val::String(_) => "text",
         Val::Array(_) => "array",
         Val::Object(_) => "object",
+        Val::Removed => unreachable!(),
     };
 
     Ok(OwnedValue::Text(LimboText::json(Rc::new(val.to_string()))))

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -937,6 +937,17 @@ pub fn translate_expr(
                         target_register,
                         func_ctx,
                     ),
+                    JsonFunc::JsonPatch => {
+                        let args = expect_arguments_exact!(args, 2, j);
+                        translate_function(
+                            program,
+                            args,
+                            referenced_tables,
+                            resolver,
+                            target_register,
+                            func_ctx,
+                        )
+                    }
                 },
                 Func::Scalar(srf) => {
                     match srf {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -42,7 +42,8 @@ use crate::vdbe::insn::Insn;
 use crate::{
     function::JsonFunc, json::get_json, json::is_json_valid, json::json_array,
     json::json_array_length, json::json_arrow_extract, json::json_arrow_shift_extract,
-    json::json_error_position, json::json_extract, json::json_object, json::json_type,
+    json::json_error_position, json::json_extract, json::json_object, json::json_patch,
+    json::json_type,
 };
 use crate::{resolve_ext_path, Connection, Result, TransactionState, DATABASE_VERSION};
 use datetime::{
@@ -1745,6 +1746,13 @@ impl Program {
                             JsonFunc::JsonValid => {
                                 let json_value = &state.registers[*start_reg];
                                 state.registers[*dest] = is_json_valid(json_value)?;
+                            }
+                            JsonFunc::JsonPatch => {
+                                assert_eq!(arg_count, 2);
+                                assert!(*start_reg + 1 < state.registers.len());
+                                let target = &state.registers[*start_reg];
+                                let patch = &state.registers[*start_reg + 1];
+                                state.registers[*dest] = json_patch(target, patch)?;
                             }
                         },
                         crate::function::Func::Scalar(scalar_func) => match scalar_func {

--- a/testing/json.test
+++ b/testing/json.test
@@ -592,9 +592,9 @@ do_execsql_test json-patch-preserve-duplicates-1 {
 do_execsql_test json-patch-preserve-duplicates-2 {
     select json_patch('{"x":100,"x":200}', '{"x":900}');
 } {{{"x":900,"x":200}}}
-do_execsql_test json-patch-first-update-wins {
+do_execsql_test json-patch-last-update-wins {
     select json_patch('{"x":100,"c":200}', '{"x":900, "x":null}');
-} {{{"x":900,"c":200}}}
+} {{{"c":200}}}
 do_execsql_test json-patch-override-1 {
     select json_patch('{"a":1,"b":2}', '{"b":3}');
 } {{{"a":1,"b":3}}}
@@ -636,10 +636,43 @@ do_execsql_test json-patch-add-all-dup-keys-from-patch {
         '{"x":100,"x":200}',
         '{"z":{}, "z":5, "z":100}'
     );
-} {{{"x":100,"x":200,"z":{},"z":5,"z":100}}}
+} {{{"x":100,"x":200,"z":100}}}
 do_execsql_test json-patch-first-occurance-patch {
+    select json_patch('{"x":100,"x":200}','{"x":{}, "x":5, "x":100}');
+} {{{"x":100,"x":200}}}
+do_execsql_test json-patch-complex-nested-dup-keys {
     select json_patch(
-        '{"x":100,"x":200}',
-        '{"x":{}, "x":5, "x":100}'
+        '{"a":{"x":1,"x":2},"a":{"y":3},"b":[{"z":4,"z":5}]}',
+        '{"a":{"w":6},"b":[{"z":7,"z":8}],"b":{"z":9}}'
     );
-} {{{"x":{},"x":200}}}
+} {{{"a":{"x":1,"x":2,"w":6},"a":{"y":3},"b":{"z":9}}}}
+do_execsql_test json-patch-unicode-dup-keys {
+    select json_patch(
+        '{"🔑":1,"🔑":2}',
+        '{"🗝️":3,"🗝️":4}'
+    );
+} {{{"🔑":1,"🔑":2,"🗝️":4}}}
+do_execsql_test json-patch-empty-string-dup-keys {
+    select json_patch(
+        '{"":1,"":2}',
+        '{"":3,"":4}'
+    );
+} {{{"":4,"":2}}}
+do_execsql_test json-patch-multiple-types-dup-keys {
+    select json_patch(
+        '{"x":100,"x":"str","x":true,"x":null}',
+        '{"y":1,"y":{},"y":[],"y":false}'
+    );
+} {{{"x":100,"x":"str","x":true,"x":null,"y":false}}}
+do_execsql_test json-patch-deep-nested-dup-keys {
+    select json_patch(
+        '{"a":{"b":{"c":1}},"a":{"b":{"c":2}},"a":{"b":{"d":3}}}',
+        '{"x":{"y":{"z":4}},"x":{"y":{"z":5}}}'
+    );
+} {{{"a":{"b":{"c":1}},"a":{"b":{"c":2}},"a":{"b":{"d":3}},"x":{"y":{"z":5}}}}}
+do_execsql_test json-patch-abomination {
+    select json_patch(
+        '{"a":{"b":{"x":1,"x":2,"y":{"z":3,"z":{"w":4}}},"b":[{"c":5,"c":6},{"d":{"e":7,"e":null}}],"f":{"g":[1,2,3],"g":{"h":8,"h":[4,5,6]}},"i":{"j":true,"j":{"k":false,"k":{"l":null,"l":"string"}}},"m":{"n":{"o":{"p":9,"p":{"q":10}},"o":{"r":11}}},"m":[{"s":{"t":12}},{"s":{"t":13,"t":{"u":14}}}]},"a":{"v":{"w":{"x":{"y":{"z":15}}}},"v":{"w":{"x":16,"x":{"y":17}}},"aa":[{"bb":{"cc":18,"cc":{"dd":19}}},{"bb":{"cc":{"dd":20},"cc":21}}]}}',
+        '{"a":{"b":{"x":{"new":"value"},"y":null},"b":{"c":{"updated":true},"d":{"e":{"replaced":100}}},"f":{"g":{"h":{"nested":"deep"}}},"i":{"j":{"k":{"l":{"modified":false}}}},"m":{"n":{"o":{"p":{"q":{"extra":"level"}}}},"s":null},"aa":[{"bb":{"cc":{"dd":{"ee":"new"}}}},{"bb":{"cc":{"dd":{"ff":"value"}}}}],"v":{"w":{"x":{"y":{"z":{"final":"update"}}}}}},"newTop":{"level":{"key":{"with":{"deep":{"nesting":true}}},"key":[{"array":{"in":{"deep":{"structure":null}}}}]}}}'
+    );
+} {{{"a":{"b":{"x":{"new":"value"},"x":2,"c":{"updated":true},"d":{"e":{"replaced":100}}},"b":[{"c":5,"c":6},{"d":{"e":7,"e":null}}],"f":{"g":{"h":{"nested":"deep"}},"g":{"h":8,"h":[4,5,6]}},"i":{"j":{"k":{"l":{"modified":false}}},"j":{"k":false,"k":{"l":null,"l":"string"}}},"m":{"n":{"o":{"p":{"q":{"extra":"level"}},"p":{"q":10}},"o":{"r":11}}},"m":[{"s":{"t":12}},{"s":{"t":13,"t":{"u":14}}}],"aa":[{"bb":{"cc":{"dd":{"ee":"new"}}}},{"bb":{"cc":{"dd":{"ff":"value"}}}}],"v":{"w":{"x":{"y":{"z":{"final":"update"}}}}}},"a":{"v":{"w":{"x":{"y":{"z":15}}}},"v":{"w":{"x":16,"x":{"y":17}}},"aa":[{"bb":{"cc":18,"cc":{"dd":19}}},{"bb":{"cc":{"dd":20},"cc":21}}]},"newTop":{"level":{"key":[{"array":{"in":{"deep":{"structure":null}}}}]}}}}}

--- a/testing/json.test
+++ b/testing/json.test
@@ -592,6 +592,9 @@ do_execsql_test json-patch-preserve-duplicates-1 {
 do_execsql_test json-patch-preserve-duplicates-2 {
     select json_patch('{"x":100,"x":200}', '{"x":900}');
 } {{{"x":900,"x":200}}}
+do_execsql_test json-patch-first-update-wins {
+    select json_patch('{"x":100,"c":200}', '{"x":900, "x":null}');
+} {{{"x":900,"c":200}}}
 do_execsql_test json-patch-override-1 {
     select json_patch('{"a":1,"b":2}', '{"b":3}');
 } {{{"a":1,"b":3}}}

--- a/testing/json.test
+++ b/testing/json.test
@@ -576,3 +576,45 @@ do_execsql_test json_valid_3 {
 do_execsql_test json_valid_9 {
     SELECT json_valid(NULL);
 } {}
+do_execsql_test json-patch-basic-1 {
+    select json_patch('{"a":1}', '{"b":2}');
+} {{{"a":1,"b":2}}}
+do_execsql_test json-patch-basic-2 {
+    select json_patch('{"x":100,"y":200}', '{"z":300}');
+} {{{"x":100,"y":200,"z":300}}}
+do_execsql_test json-patch-override-1 {
+    select json_patch('{"a":1,"b":2}', '{"b":3}');
+} {{{"a":1,"b":3}}}
+do_execsql_test json-patch-override-2 {
+    select json_patch('{"name":"john","age":25}', '{"age":26,"city":"NYC"}');
+} {{{"name":"john","age":26,"city":"NYC"}}}
+do_execsql_test json-patch-nested-1 {
+    select json_patch('{"user":{"name":"john"}}', '{"user":{"age":30}}');
+} {{{"user":{"name":"john","age":30}}}}
+do_execsql_test json-patch-nested-2 {
+    select json_patch('{"settings":{"theme":"dark"}}', '{"settings":{"theme":"light","font":"arial"}}');
+} {{{"settings":{"theme":"light","font":"arial"}}}}
+do_execsql_test json-patch-array-1 {
+    select json_patch('{"arr":[1,2,3]}', '{"arr":[4,5,6]}');
+} {{{"arr":[4,5,6]}}}
+do_execsql_test json-patch-array-2 {
+    select json_patch('{"list":["a","b"]}', '{"list":["c"]}');
+} {{{"list":["c"]}}}
+do_execsql_test json-patch-empty-1 {
+    select json_patch('{}', '{"a":1}');
+} {{{"a":1}}}
+do_execsql_test json-patch-empty-2 {
+    select json_patch('{"a":1}', '{}');
+} {{{"a":1}}}
+do_execsql_test json-patch-deep-nested-1 {
+    select json_patch(
+        '{"level1":{"level2":{"value":100}}}',
+        '{"level1":{"level2":{"newValue":200}}}'
+    );
+} {{{"level1":{"level2":{"value":100,"newValue":200}}}}}
+do_execsql_test json-patch-mixed-types-1 {
+    select json_patch(
+        '{"str":"hello","num":42,"bool":true}',
+        '{"arr":[1,2,3],"obj":{"x":1}}'
+    );
+} {{{"str":"hello","num":42,"bool":true,"arr":[1,2,3],"obj":{"x":1}}}}

--- a/testing/json.test
+++ b/testing/json.test
@@ -8,6 +8,10 @@ do_execsql_test json5-ecma-script-1 {
 } {{{"a":5,"b":6}}}
 
 do_execsql_test json5-ecma-script-2 {
+    select json('{a:5,a:3}') ;
+} {{{"a":5,"a":3}}}
+
+do_execsql_test json5-ecma-script-3 {
    SELECT json('{ MNO_123$xyz : 789 }');
 } {{{"MNO_123$xyz":789}}}
 
@@ -582,6 +586,12 @@ do_execsql_test json-patch-basic-1 {
 do_execsql_test json-patch-basic-2 {
     select json_patch('{"x":100,"y":200}', '{"z":300}');
 } {{{"x":100,"y":200,"z":300}}}
+do_execsql_test json-patch-preserve-duplicates-1 {
+    select json_patch('{"x":100,"x":200}', '{"z":300}');
+} {{{"x":100,"x":200,"z":300}}}
+do_execsql_test json-patch-preserve-duplicates-2 {
+    select json_patch('{"x":100,"x":200}', '{"x":900}');
+} {{{"x":900,"x":200}}}
 do_execsql_test json-patch-override-1 {
     select json_patch('{"a":1,"b":2}', '{"b":3}');
 } {{{"a":1,"b":3}}}

--- a/testing/json.test
+++ b/testing/json.test
@@ -631,3 +631,15 @@ do_execsql_test json-patch-mixed-types-1 {
         '{"arr":[1,2,3],"obj":{"x":1}}'
     );
 } {{{"str":"hello","num":42,"bool":true,"arr":[1,2,3],"obj":{"x":1}}}}
+do_execsql_test json-patch-add-all-dup-keys-from-patch {
+    select json_patch(
+        '{"x":100,"x":200}',
+        '{"z":{}, "z":5, "z":100}'
+    );
+} {{{"x":100,"x":200,"z":{},"z":5,"z":100}}}
+do_execsql_test json-patch-first-occurance-patch {
+    select json_patch(
+        '{"x":100,"x":200}',
+        '{"x":{}, "x":5, "x":100}'
+    );
+} {{{"x":{},"x":200}}}


### PR DESCRIPTION
First review #820
The function follows RFC 7386 JSON Merge Patch semantics:
* If the patch is null, the target is replaced with null
* If the patch contains a scalar value, the target is replaced with that value
* If both target and patch are objects, the patch is recursively applied
* null values in the patch result in property removal from the target