### PR TITLE
bindings/go Support blob types in query arguments, free non-gc allocations

### DIFF
--- a/bindings/go/limbo_test.go
+++ b/bindings/go/limbo_test.go
@@ -100,7 +100,7 @@ func TestQuery(t *testing.T) {
 			t.Fatalf("Error scanning row: %v", err)
 		}
 		if a != i || b != rowsMap[i] || string(c) != rowsMap[i] {
-			t.Fatalf("Expected %d, %s, got %d, %s, %b", i, rowsMap[i], a, b, c)
+			t.Fatalf("Expected %d, %s, %s, got %d, %s, %b", i, rowsMap[i], rowsMap[i], a, b, c)
 		}
 		fmt.Println("RESULTS: ", a, b, string(c))
 		i++

--- a/bindings/go/limbo_test.go
+++ b/bindings/go/limbo_test.go
@@ -2,6 +2,7 @@ package limbo_test
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 
 	_ "limbo"
@@ -76,7 +77,7 @@ func TestQuery(t *testing.T) {
 	}
 	defer rows.Close()
 
-	expectedCols := []string{"foo", "bar"}
+	expectedCols := []string{"foo", "bar", "baz"}
 	cols, err := rows.Columns()
 	if err != nil {
 		t.Fatalf("Error getting columns: %v", err)
@@ -93,13 +94,15 @@ func TestQuery(t *testing.T) {
 	for rows.Next() {
 		var a int
 		var b string
-		err = rows.Scan(&a, &b)
+		var c []byte
+		err = rows.Scan(&a, &b, &c)
 		if err != nil {
 			t.Fatalf("Error scanning row: %v", err)
 		}
-		if a != i || b != rowsMap[i] {
-			t.Fatalf("Expected %d, %s, got %d, %s", i, rowsMap[i], a, b)
+		if a != i || b != rowsMap[i] || string(c) != rowsMap[i] {
+			t.Fatalf("Expected %d, %s, got %d, %s, %b", i, rowsMap[i], a, b, c)
 		}
+		fmt.Println("RESULTS: ", a, b, string(c))
 		i++
 	}
 
@@ -111,7 +114,7 @@ func TestQuery(t *testing.T) {
 var rowsMap = map[int]string{1: "hello", 2: "world", 3: "foo", 4: "bar", 5: "baz"}
 
 func createTable(conn *sql.DB) error {
-	insert := "CREATE TABLE test (foo INT, bar TEXT);"
+	insert := "CREATE TABLE test (foo INT, bar TEXT, baz BLOB);"
 	stmt, err := conn.Prepare(insert)
 	if err != nil {
 		return err
@@ -123,13 +126,13 @@ func createTable(conn *sql.DB) error {
 
 func insertData(conn *sql.DB) error {
 	for i := 1; i <= 5; i++ {
-		insert := "INSERT INTO test (foo, bar) VALUES (?, ?);"
+		insert := "INSERT INTO test (foo, bar, baz) VALUES (?, ?, ?);"
 		stmt, err := conn.Prepare(insert)
 		if err != nil {
 			return err
 		}
 		defer stmt.Close()
-		if _, err = stmt.Exec(i, rowsMap[i]); err != nil {
+		if _, err = stmt.Exec(i, rowsMap[i], []byte(rowsMap[i])); err != nil {
 			return err
 		}
 	}

--- a/bindings/go/limbo_unix.go
+++ b/bindings/go/limbo_unix.go
@@ -35,7 +35,7 @@ func loadLibrary() error {
 	for _, path := range paths {
 		libPath := filepath.Join(path, libraryName)
 		if _, err := os.Stat(libPath); err == nil {
-			slib, dlerr := purego.Dlopen(libPath, purego.RTLD_LAZY)
+			slib, dlerr := purego.Dlopen(libPath, purego.RTLD_NOW|purego.RTLD_GLOBAL)
 			if dlerr != nil {
 				return fmt.Errorf("failed to load library at %s: %w", libPath, dlerr)
 			}

--- a/bindings/go/rs_src/rows.rs
+++ b/bindings/go/rs_src/rows.rs
@@ -65,8 +65,7 @@ pub extern "C" fn rows_get_value(ctx: *mut c_void, col_idx: usize) -> *const c_v
 
     if let Some(ref cursor) = ctx.cursor {
         if let Some(value) = cursor.values.get(col_idx) {
-            let val = LimboValue::from_value(value);
-            return val.to_ptr();
+            return LimboValue::from_value(value).to_ptr();
         }
     }
     std::ptr::null()

--- a/bindings/go/stmt.go
+++ b/bindings/go/stmt.go
@@ -59,7 +59,8 @@ func (ls *limboStmt) Close() error {
 }
 
 func (ls *limboStmt) Exec(args []driver.Value) (driver.Result, error) {
-	argArray, err := buildArgs(args)
+	argArray, cleanup, err := buildArgs(args)
+	defer cleanup()
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +88,8 @@ func (ls *limboStmt) Exec(args []driver.Value) (driver.Result, error) {
 }
 
 func (st *limboStmt) Query(args []driver.Value) (driver.Rows, error) {
-	queryArgs, err := buildArgs(args)
+	queryArgs, cleanup, err := buildArgs(args)
+	defer cleanup()
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +107,8 @@ func (st *limboStmt) Query(args []driver.Value) (driver.Rows, error) {
 
 func (ls *limboStmt) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	stripped := namedValueToValue(args)
-	argArray, err := getArgsPtr(stripped)
+	argArray, cleanup, err := getArgsPtr(stripped)
+	defer cleanup()
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +135,8 @@ func (ls *limboStmt) ExecContext(ctx context.Context, query string, args []drive
 }
 
 func (ls *limboStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
-	queryArgs, err := buildNamedArgs(args)
+	queryArgs, allocs, err := buildNamedArgs(args)
+	defer allocs()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixes/adds support for the Blob type and adds the appropriate tests.
 
Types created on the Go side will be cleaned up rather quickly if nothing is referencing them, so this approach uses `runtime.Pinner` to pin the bytes in memory so the pointers will be valid when Rust uses `from_raw_parts` and then owns a new vec. They are then cleaned up after the FFI call with `pinner.Unpin`. 