### PR TITLE
Adding checkpoint result

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -61,6 +61,8 @@ pub use storage::pager::Page;
 pub use storage::pager::Pager;
 pub use storage::wal::CheckpointStatus;
 pub use storage::wal::Wal;
+use crate::storage::wal::CheckpointResult;
+
 pub static DATABASE_VERSION: OnceLock<String> = OnceLock::new();
 
 #[derive(Clone)]
@@ -393,7 +395,7 @@ impl Connection {
         Ok(())
     }
 
-    pub fn checkpoint(&self) -> Result<()> {
+    pub fn checkpoint(&self) -> Result<(CheckpointResult)> {
         self.pager.clear_page_cache();
         Ok(())
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -47,6 +47,7 @@ pub use error::LimboError;
 use translate::select::prepare_select_plan;
 pub type Result<T, E = LimboError> = std::result::Result<T, E>;
 
+use crate::storage::wal::CheckpointResult;
 use crate::translate::optimizer::optimize_plan;
 pub use io::OpenFlags;
 pub use io::PlatformIO;
@@ -61,7 +62,6 @@ pub use storage::pager::Page;
 pub use storage::pager::Pager;
 pub use storage::wal::CheckpointStatus;
 pub use storage::wal::Wal;
-use crate::storage::wal::CheckpointResult;
 
 pub static DATABASE_VERSION: OnceLock<String> = OnceLock::new();
 
@@ -395,9 +395,9 @@ impl Connection {
         Ok(())
     }
 
-    pub fn checkpoint(&self) -> Result<(CheckpointResult)> {
-        self.pager.clear_page_cache();
-        Ok(())
+    pub fn checkpoint(&self) -> Result<CheckpointResult> {
+        let checkpoint_result = self.pager.clear_page_cache();
+        Ok(checkpoint_result)
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -410,7 +410,7 @@ impl Connection {
         loop {
             // TODO: make this async?
             match self.pager.checkpoint()? {
-                CheckpointStatus::Done => {
+                CheckpointStatus::Done(_) => {
                     return Ok(());
                 }
                 CheckpointStatus::IO => {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -26,6 +26,12 @@ pub const SHARED_LOCK: u32 = 1;
 pub const WRITE_LOCK: u32 = 2;
 
 #[derive(Debug)]
+pub struct CheckpointResult {
+    /// number of pages moved successfully from WAL to db file after checkpoint
+    nbackfills: u64,
+}
+
+#[derive(Debug)]
 pub enum CheckpointMode {
     Passive,
     Full,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -32,6 +32,7 @@ use crate::info;
 use crate::pseudo::PseudoCursor;
 use crate::result::LimboResult;
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
+use crate::storage::wal::CheckpointResult;
 use crate::storage::{btree::BTreeCursor, pager::Pager};
 use crate::types::{
     AggContext, Cursor, CursorResult, ExternalAggState, OwnedRecord, OwnedValue, Record, SeekKey,
@@ -137,6 +138,7 @@ pub type PageIdx = usize;
 // Index of insn in list of insns
 type InsnReference = u32;
 
+#[derive(Debug)]
 pub enum StepResult<'a> {
     Done,
     IO,
@@ -468,15 +470,18 @@ impl Program {
                 } => {
                     let result = self.connection.upgrade().unwrap().checkpoint();
                     match result {
-                        Ok(()) => {
+                        Ok(CheckpointResult {
+                            num_wal_frames: num_wal_pages,
+                            num_checkpointed_frames: num_checkpointed_pages,
+                        }) => {
                             // https://sqlite.org/pragma.html#pragma_wal_checkpoint
-                            // TODO make 2nd and 3rd cols available through checkpoint method
                             // 1st col: 1 (checkpoint SQLITE_BUSY) or 0 (not busy).
                             state.registers[*dest] = OwnedValue::Integer(0);
                             // 2nd col: # modified pages written to wal file
-                            state.registers[*dest + 1] = OwnedValue::Integer(0);
+                            state.registers[*dest + 1] = OwnedValue::Integer(num_wal_pages as i64);
                             // 3rd col: # pages moved to db after checkpoint
-                            state.registers[*dest + 2] = OwnedValue::Integer(0);
+                            state.registers[*dest + 2] =
+                                OwnedValue::Integer(num_checkpointed_pages as i64);
                         }
                         Err(_err) => state.registers[*dest] = OwnedValue::Integer(1),
                     }
@@ -1015,7 +1020,7 @@ impl Program {
                     return if self.auto_commit {
                         match pager.end_tx() {
                             Ok(crate::storage::wal::CheckpointStatus::IO) => Ok(StepResult::IO),
-                            Ok(crate::storage::wal::CheckpointStatus::Done) => {
+                            Ok(crate::storage::wal::CheckpointStatus::Done(_)) => {
                                 if self.change_cnt_on {
                                     if let Some(conn) = self.connection.upgrade() {
                                         conn.set_changes(self.n_change.get());

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -13,13 +13,17 @@ pub struct TempDatabase {
 #[allow(dead_code, clippy::arc_with_non_send_sync)]
 impl TempDatabase {
     pub fn new_empty() -> Self {
-        let mut path = TempDir::new().unwrap().into_path();
-        path.push("test.db");
-        let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::PlatformIO::new().unwrap());
+        Self::new("test.db")
+    }
 
+    pub fn new(db_name: &str) -> Self {
+        let mut path = TempDir::new().unwrap().into_path();
+        path.push(db_name);
+        let io: Arc<dyn IO> = Arc::new(limbo_core::PlatformIO::new().unwrap());
         Self { path, io }
     }
-    pub fn new(table_sql: &str) -> Self {
+
+    pub fn new_with_rusqlite(table_sql: &str) -> Self {
         let mut path = TempDir::new().unwrap().into_path();
         path.push("test.db");
         {
@@ -47,7 +51,7 @@ impl TempDatabase {
 pub(crate) fn do_flush(conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
     loop {
         match conn.cacheflush()? {
-            CheckpointStatus::Done => {
+            CheckpointStatus::Done(_) => {
                 break;
             }
             CheckpointStatus::IO => {
@@ -82,8 +86,9 @@ mod tests {
     #[test]
     fn test_statement_columns() -> anyhow::Result<()> {
         let _ = env_logger::try_init();
-        let tmp_db =
-            TempDatabase::new("create table test (foo integer, bar integer, baz integer);");
+        let tmp_db = TempDatabase::new_with_rusqlite(
+            "create table test (foo integer, bar integer, baz integer);",
+        );
         let conn = tmp_db.connect_limbo();
 
         let stmt = conn.prepare("select * from test;")?;

--- a/tests/integration/functions/test_function_rowid.rs
+++ b/tests/integration/functions/test_function_rowid.rs
@@ -4,7 +4,9 @@ use limbo_core::{StepResult, Value};
 #[test]
 fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("CREATE TABLE test_rowid (id INTEGER PRIMARY KEY, val TEXT);");
+    let tmp_db = TempDatabase::new_with_rusqlite(
+        "CREATE TABLE test_rowid (id INTEGER PRIMARY KEY, val TEXT);",
+    );
     let conn = tmp_db.connect_limbo();
 
     // Simple insert
@@ -85,7 +87,8 @@ fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
 #[test]
 fn test_integer_primary_key() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("CREATE TABLE test_rowid (id INTEGER PRIMARY KEY);");
+    let tmp_db =
+        TempDatabase::new_with_rusqlite("CREATE TABLE test_rowid (id INTEGER PRIMARY KEY);");
     let conn = tmp_db.connect_limbo();
 
     for query in &[

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -3,3 +3,4 @@ mod functions;
 mod fuzz;
 mod pragma;
 mod query_processing;
+mod wal;

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -4,7 +4,7 @@ use limbo_core::{StepResult, Value};
 #[test]
 fn test_statement_reset_bind() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("create table test (i integer);");
+    let tmp_db = TempDatabase::new_with_rusqlite("create table test (i integer);");
     let conn = tmp_db.connect_limbo();
 
     let mut stmt = conn.prepare("select ?")?;
@@ -41,7 +41,7 @@ fn test_statement_reset_bind() -> anyhow::Result<()> {
 #[test]
 fn test_statement_bind() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("create table test (i integer);");
+    let tmp_db = TempDatabase::new_with_rusqlite("create table test (i integer);");
     let conn = tmp_db.connect_limbo();
 
     let mut stmt = conn.prepare("select ?, ?1, :named, ?3, ?4")?;

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -7,7 +7,8 @@ use std::rc::Rc;
 #[test]
 fn test_simple_overflow_page() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);");
+    let tmp_db =
+        TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);");
     let conn = tmp_db.connect_limbo();
 
     let mut huge_text = String::new();
@@ -75,7 +76,8 @@ fn test_simple_overflow_page() -> anyhow::Result<()> {
 #[test]
 fn test_sequential_overflow_page() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);");
+    let tmp_db =
+        TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);");
     let conn = tmp_db.connect_limbo();
     let iterations = 10_usize;
 
@@ -152,7 +154,7 @@ fn test_sequential_overflow_page() -> anyhow::Result<()> {
 fn test_sequential_write() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
 
-    let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);");
     let conn = tmp_db.connect_limbo();
 
     let list_query = "SELECT * FROM test";
@@ -219,7 +221,7 @@ fn test_sequential_write() -> anyhow::Result<()> {
 /// https://github.com/tursodatabase/limbo/pull/679
 fn test_regression_multi_row_insert() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("CREATE TABLE test (x REAL);");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x REAL);");
     let conn = tmp_db.connect_limbo();
 
     let insert_query = "INSERT INTO test VALUES (-2), (-3), (-1)";
@@ -284,7 +286,7 @@ fn test_regression_multi_row_insert() -> anyhow::Result<()> {
 #[test]
 fn test_statement_reset() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("create table test (i integer);");
+    let tmp_db = TempDatabase::new_with_rusqlite("create table test (i integer);");
     let conn = tmp_db.connect_limbo();
 
     conn.execute("insert into test values (1)")?;
@@ -323,7 +325,7 @@ fn test_statement_reset() -> anyhow::Result<()> {
 #[ignore]
 fn test_wal_checkpoint() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);");
     // threshold is 1000 by default
     let iterations = 1001_usize;
     let conn = tmp_db.connect_limbo();
@@ -386,7 +388,7 @@ fn test_wal_checkpoint() -> anyhow::Result<()> {
 #[test]
 fn test_wal_restart() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);");
     // threshold is 1000 by default
 
     fn insert(i: usize, conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {

--- a/tests/integration/wal/mod.rs
+++ b/tests/integration/wal/mod.rs
@@ -1,0 +1,1 @@
+mod test_wal;

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -1,0 +1,90 @@
+use crate::common::{do_flush, TempDatabase};
+use limbo_core::{Connection, LimboError, Result, StepResult, Value};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[allow(clippy::arc_with_non_send_sync)]
+#[test]
+fn test_wal_checkpoint_result() -> Result<()> {
+    let tmp_db = TempDatabase::new("test_wal.db");
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t1 (id text);")?;
+
+    let res = execute_and_get_strings(&tmp_db, &conn, "pragma journal_mode;")?;
+    assert_eq!(res, vec!["wal"]);
+
+    conn.execute("insert into t1(id) values (1), (2);")?;
+    do_flush(&conn, &tmp_db).unwrap();
+    conn.execute("select * from t1;")?;
+    do_flush(&conn, &tmp_db).unwrap();
+
+    // checkpoint result should return > 0 num pages now as database has data
+    let res = execute_and_get_ints(&tmp_db, &conn, "pragma wal_checkpoint;")?;
+    println!("'pragma wal_checkpoint;' returns: {res:?}");
+    assert_eq!(res.len(), 3);
+    assert_eq!(res[0], 0); // checkpoint successfully
+    assert!(res[1] > 0); // num pages in wal
+    assert!(res[2] > 0); // num pages checkpointed successfully
+
+    Ok(())
+}
+
+/// Execute a statement and get strings result
+pub(crate) fn execute_and_get_strings(
+    tmp_db: &TempDatabase,
+    conn: &Rc<Connection>,
+    sql: &str,
+) -> Result<Vec<String>> {
+    let statement = conn.prepare(sql)?;
+    let stmt = Rc::new(RefCell::new(statement));
+    let mut result = Vec::new();
+
+    while let Ok(step_result) = stmt.borrow_mut().step() {
+        match step_result {
+            StepResult::Row(row) => {
+                for el in &row.values {
+                    result.push(format!("{el}"));
+                }
+            }
+            StepResult::Done => break,
+            StepResult::Interrupt => break,
+            StepResult::IO => tmp_db.io.run_once()?,
+            StepResult::Busy => tmp_db.io.run_once()?,
+        }
+    }
+    Ok(result)
+}
+
+/// Execute a statement and get integers
+pub(crate) fn execute_and_get_ints(
+    tmp_db: &TempDatabase,
+    conn: &Rc<Connection>,
+    sql: &str,
+) -> Result<Vec<i64>> {
+    let statement = conn.prepare(sql)?;
+    let stmt = Rc::new(RefCell::new(statement));
+    let mut result = Vec::new();
+
+    while let Ok(step_result) = stmt.borrow_mut().step() {
+        match step_result {
+            StepResult::Row(row) => {
+                for value in &row.values {
+                    let out = match value {
+                        Value::Integer(i) => *i,
+                        _ => {
+                            return Err(LimboError::ConversionError(format!(
+                                "cannot convert {value} to int"
+                            )))
+                        }
+                    };
+                    result.push(out);
+                }
+            }
+            StepResult::Done => break,
+            StepResult::Interrupt => break,
+            StepResult::IO => tmp_db.io.run_once()?,
+            StepResult::Busy => tmp_db.io.run_once()?,
+        }
+    }
+    Ok(result)
+}


### PR DESCRIPTION
### What?
adding checkpoint result returning number of pages in wal and num pages checkpointed.
Part of #696 

### Context

SQLite returns in checkpoint result of calling `pragma wal_checkpoint;` `0|3|3` while limbo returns `0|0|0`. https://sqlite.org/pragma.html#pragma_wal_checkpoint
- 1st col: 1 (checkpoint SQLITE_BUSY) or 0 (not busy).
- 2nd col: # modified pages written to wal file
- 3rd col: # pages moved to db after checkpoint

This PR aims to add 2nd and 3rd column to the checkpoint result.

SQLite
```
sqlite3 test.db
sqlite> pragma journal_mode=wal;
wal
sqlite> pragma journal_mode;
wal
sqlite> create table t1 (id text);
sqlite> insert into t1(id) values (1),(2);
sqlite> select * from t1;
1
2
sqlite> pragma wal_checkpoint;
0|3|3
```

Limbo
```
./target/debug/limbo test.db
Limbo v0.0.13
Enter ".help" for usage hints.
limbo> pragma journal_mode;
wal
limbo> create table t1(id text);
limbo> insert into t1(id) values (1),(2);
limbo> select * from t1;
1
2
# current the 2nd and 3rd columns are hard coded in limbo to 0
limbo> pragma wal_checkpoint;
0|0|0
```