### PR TITLE
implement isnull / not null for filter expressions

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -444,6 +444,22 @@ pub fn translate_condition_expr(
                 );
             }
         }
+        ast::Expr::NotNull(expr) => {
+            let cur_reg = program.alloc_register();
+            translate_expr(program, Some(referenced_tables), expr, cur_reg, resolver)?;
+            program.emit_insn(Insn::IsNull {
+                src: cur_reg,
+                target_pc: condition_metadata.jump_target_when_false,
+            });
+        }
+        ast::Expr::IsNull(expr) => {
+            let cur_reg = program.alloc_register();
+            translate_expr(program, Some(referenced_tables), expr, cur_reg, resolver)?;
+            program.emit_insn(Insn::NotNull {
+                reg: cur_reg,
+                target_pc: condition_metadata.jump_target_when_false,
+            });
+        }
         _ => todo!("op {:?} not implemented", expr),
     }
     Ok(())

--- a/testing/where.test
+++ b/testing/where.test
@@ -11,6 +11,14 @@ do_execsql_test where-clause-eq-string {
     select count(1) from users where last_name = 'Rodriguez';
 } {61}
 
+do_execsql_test where-clause-isnull {
+    select count(1) from users where last_name isnull;
+} {0}
+
+do_execsql_test where-clause-notnull {
+    select count(1) from users where last_name not null;
+} {10000}
+
 do_execsql_test where-clause-ne {
     select count(1) from users where id != 2000;
 } {9999}


### PR DESCRIPTION
Allow us to write queries like:

	SELECT name, type, sql FROM sqlite_schema where sql isnull

and

	SELECT name, type, sql FROM sqlite_schema where sql not null