### PR TITLE
Fixes limbo creating an extra btree,  when table has single column PRIMARY KEY.

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -258,7 +258,7 @@ fn emit_schema_entry(
 ///
 /// An automatic PRIMARY KEY index is not required if:
 /// - The table has no PRIMARY KEY
-/// - The table has a single-column PRIMARY KEY whose typename is _exactly_ "INTEGER" e.g. not "INT".
+/// - The table has a single-column PRIMARY KEY whose typename is _exactly_ "integer" e.g. not "INT".
 ///   In this case, the PRIMARY KEY column becomes an alias for the rowid.
 ///
 /// Otherwise, an automatic PRIMARY KEY index is required.
@@ -348,7 +348,7 @@ fn check_automatic_pk_index_required(
             let needs_auto_index = if let Some(primary_key_definition) = &primary_key_definition {
                 match primary_key_definition {
                     PrimaryKeyDefinitionType::Simple { typename } => {
-                        let is_integer = typename.is_some() && typename.unwrap() == "INTEGER";
+                        let is_integer = typename.is_some() && typename.unwrap() == "integer";
                         !is_integer
                     }
                     PrimaryKeyDefinitionType::Composite => true,


### PR DESCRIPTION
The error is due to comparing the PRIMARY KEY's name to INTEGER when in it was all in lowercase. This was causing `needs_auto_index` to be set to `true`. 


After the fix:

```
/limbo /tmp/sc2-limbo.db
Limbo v0.0.13
Enter ".help" for usage hints.
limbo> CREATE TABLE temp (t1 integer, primary key (t1));


hexdump -s 28 -n 4 /tmp/sc2-limbo.db
000001c 0000 0200 -- matches SQLite                             
0000020
```

Closes https://github.com/tursodatabase/limbo/issues/824
