### PR TITLE
Simplify bytecode emitters

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -560,13 +560,10 @@ fn list_pragmas(
     init_label: BranchOffset,
     start_offset: BranchOffset,
 ) {
-    let mut pragma_strings: Vec<String> = PragmaName::iter().map(|x| x.to_string()).collect();
-    pragma_strings.sort();
-
-    let register = program.alloc_register();
-    for pragma in &pragma_strings {
+    for x in PragmaName::iter() {
+        let register = program.alloc_register();
         program.emit_insn(Insn::String8 {
-            value: pragma.to_string(),
+            value: x.to_string(),
             dest: register,
         });
         program.emit_insn(Insn::ResultRow {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -98,6 +98,70 @@ impl ProgramBuilder {
         self.insns.push(insn);
     }
 
+    pub fn emit_string8(&mut self, value: String, dest: usize) {
+        self.emit_insn(Insn::String8 { value, dest });
+    }
+
+    pub fn emit_string8_new_reg(&mut self, value: String) -> usize {
+        let dest = self.alloc_register();
+        self.emit_insn(Insn::String8 { value, dest });
+        dest
+    }
+
+    pub fn emit_int(&mut self, value: i64, dest: usize) {
+        self.emit_insn(Insn::Integer { value, dest });
+    }
+
+    pub fn emit_bool(&mut self, value: bool, dest: usize) {
+        self.emit_insn(Insn::Integer {
+            value: if value { 1 } else { 0 },
+            dest,
+        });
+    }
+
+    pub fn emit_null(&mut self, dest: usize) {
+        self.emit_insn(Insn::Null {
+            dest,
+            dest_end: None,
+        });
+    }
+
+    pub fn emit_result_row(&mut self, start_reg: usize, count: usize) {
+        self.emit_insn(Insn::ResultRow { start_reg, count });
+    }
+
+    pub fn emit_halt(&mut self) {
+        self.emit_insn(Insn::Halt {
+            err_code: 0,
+            description: String::new(),
+        });
+    }
+
+    // no users yet, but I want to avoid someone else in the future
+    // just adding parameters to emit_halt! If you use this, remove the
+    // clippy warning please.
+    #[allow(dead_code)]
+    pub fn emit_halt_err(&mut self, err_code: usize, description: String) {
+        self.emit_insn(Insn::Halt {
+            err_code,
+            description,
+        });
+    }
+
+    pub fn emit_init(&mut self) -> BranchOffset {
+        let target_pc = self.allocate_label();
+        self.emit_insn(Insn::Init { target_pc });
+        target_pc
+    }
+
+    pub fn emit_transaction(&mut self, write: bool) {
+        self.emit_insn(Insn::Transaction { write });
+    }
+
+    pub fn emit_goto(&mut self, target_pc: BranchOffset) {
+        self.emit_insn(Insn::Goto { target_pc });
+    }
+
     pub fn add_comment(&mut self, insn_index: BranchOffset, comment: &'static str) {
         self.comments.insert(insn_index.to_offset_int(), comment);
     }

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1594,10 +1594,10 @@ pub enum PragmaName {
     CacheSize,
     /// `journal_mode` pragma
     JournalMode,
-    /// trigger a checkpoint to run on database(s) if WAL is enabled
-    WalCheckpoint,
     /// returns information about the columns of a table
     TableInfo,
+    /// trigger a checkpoint to run on database(s) if WAL is enabled
+    WalCheckpoint,
 }
 
 /// `CREATE TRIGGER` time
@@ -1894,7 +1894,8 @@ pub enum FrameExclude {
 
 #[cfg(test)]
 mod test {
-    use super::Name;
+    use super::{Name, PragmaName};
+    use strum::IntoEnumIterator;
 
     #[test]
     fn test_dequote() {
@@ -1904,6 +1905,16 @@ mod test {
         assert_eq!(name(r#""x""#), "x");
         assert_eq!(name(r#""x""y""#), "x\"y");
         assert_eq!(name("[x]"), "x");
+    }
+
+    #[test]
+    // pragma pragma_list expects this to be sorted. We can avoid allocations there if we keep
+    // the list sorted.
+    fn pragma_list_sorted() {
+        let pragma_strings: Vec<String> = PragmaName::iter().map(|x| x.to_string()).collect();
+        let mut pragma_strings_sorted = pragma_strings.clone();
+        pragma_strings_sorted.sort();
+        assert_eq!(pragma_strings, pragma_strings_sorted);
     }
 
     fn name(s: &'static str) -> Name {


### PR DESCRIPTION
    Instead of always having the caller specify all instructions, this
    work introduces convenience functions into the program builder,
    making the code a lot cleaner.
    
    Draft for now, as this is done on top of #841 