### PR TITLE
bindings/go: Progress on Go driver, add sync primitives, prevent crashing on concurrent connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ dist/
 
 # Javascript
 **/node_modules/
+
+# testing
+testing/limbo_output.txt

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,41 +1,71 @@
-## Limbo driver for Go's `database/sql` library
+# Limbo driver for Go's `database/sql` library
 
 
-**NOTE:** this is currently __heavily__ W.I.P and is not yet in a usable state. This is merged in only for the purposes of incremental progress and not because the existing code here proper. Expect many and frequent changes.
+**NOTE:** this is currently __heavily__ W.I.P and is not yet in a usable state.
 
-This uses the [purego](https://github.com/ebitengine/purego) library to call C (in this case Rust with C ABI) functions from Go without the use of `CGO`.
-
-
+This driver uses the awesome [purego](https://github.com/ebitengine/purego) library to call C (in this case Rust with C ABI) functions from Go without the use of `CGO`.
 
 
-### To test
+## To use: (_UNSTABLE_ testing or development purposes only)
 
-
-## Linux | MacOS
+### Linux | MacOS
 
 _All commands listed are relative to the bindings/go directory in the limbo repository_
 
 ```
 cargo build --package limbo-go
 
-
 # Your LD_LIBRARY_PATH environment variable must include limbo's `target/debug` directory
 
-LD_LIBRARY_PATH="../../target/debug:$LD_LIBRARY_PATH" go test
+export LD_LIBRARY_PATH="/path/to/limbo/target/debug:$LD_LIBRARY_PATH"
 
 ```
-
 
 ## Windows
 
 ```
 cargo build --package limbo-go
 
-# Copy the lib_limbo_go.dll into the current working directory (bindings/go)
-# Alternatively, you could add the .dll to a location in your PATH
+# You must add limbo's `target/debug` directory to your PATH
+# or you could built + copy the .dll to a location in your PATH
+# or just the CWD of your go module
 
-cp ../../target/debug/lib_limbo_go.dll .
+cp path\to\limbo\target\debug\lib_limbo_go.dll .
 
 go test
 
+```
+**Temporarily** you may have to clone the limbo repository and run:
+
+`go mod edit -replace github.com/tursodatabase/limbo=/path/to/limbo/bindings/go`
+
+```go
+import (
+    "fmt"
+    "database/sql"
+    _"github.com/tursodatabase/limbo"
+)
+
+func main() {
+	conn, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+        fmt.Printf("Error: %v\n", err)
+        os.Exit(1)
+	}
+    sql := "CREATE table go_limbo (foo INTEGER, bar TEXT)"
+    _ = conn.Exec(sql)
+
+    sql = "INSERT INTO go_limbo (foo, bar) values (?, ?)"
+    stmt, _ := conn.Prepare(sql)
+    defer stmt.Close()
+    _  = stmt.Exec(42, "limbo")
+    rows, _ := conn.Query("SELECT * from go_limbo")
+    defer rows.Close()
+    for rows.Next() {
+        var a int
+        var b string
+		_ = rows.Scan(&a, &b)
+        fmt.Printf("%d, %s", a, b)
+    }
+}
 ```

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,4 +1,4 @@
-module limbo
+module github.com/tursodatabase/limbo
 
 go 1.23.4
 

--- a/bindings/go/limbo_test.go
+++ b/bindings/go/limbo_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"testing"
 
-	_ "limbo"
+	_ "github.com/tursodatabase/limbo"
 )
 
 var conn *sql.DB

--- a/bindings/go/limbo_unix.go
+++ b/bindings/go/limbo_unix.go
@@ -3,7 +3,6 @@
 package limbo
 
 import (
-	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,12 +42,4 @@ func loadLibrary() (uintptr, error) {
 		}
 	}
 	return 0, fmt.Errorf("%s library not found in LD_LIBRARY_PATH or CWD", libName)
-}
-
-func init() {
-	err := ensureLibLoaded()
-	if err != nil {
-		panic(err)
-	}
-	sql.Register("sqlite3", &limboDriver{})
 }

--- a/bindings/go/limbo_windows.go
+++ b/bindings/go/limbo_windows.go
@@ -3,7 +3,6 @@
 package limbo
 
 import (
-	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,14 +11,14 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func loadLibrary() error {
+func loadLibrary() (uintptr, error) {
 	libName := fmt.Sprintf("%s.dll", libName)
 	pathEnv := os.Getenv("PATH")
 	paths := strings.Split(pathEnv, ";")
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return err
+		return 0, err
 	}
 	paths = append(paths, cwd)
 	for _, path := range paths {
@@ -27,21 +26,11 @@ func loadLibrary() error {
 		if _, err := os.Stat(dllPath); err == nil {
 			slib, loadErr := windows.LoadLibrary(dllPath)
 			if loadErr != nil {
-				return fmt.Errorf("failed to load library at %s: %w", dllPath, loadErr)
+				return 0, fmt.Errorf("failed to load library at %s: %w", dllPath, loadErr)
 			}
-			limboLib = uintptr(slib)
-			return nil
+			return uintptr(slib), nil
 		}
 	}
 
-	return fmt.Errorf("library %s not found in PATH or CWD", libName)
-}
-
-func init() {
-	err := loadLibrary()
-	if err != nil {
-		fmt.Println("Error opening limbo library: ", err)
-		os.Exit(1)
-	}
-	sql.Register("sqlite3", &limboDriver{})
+	return 0, fmt.Errorf("library %s not found in PATH or CWD", libName)
 }

--- a/bindings/go/rows.go
+++ b/bindings/go/rows.go
@@ -1,0 +1,82 @@
+package limbo
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// only construct limboRows with initRows function to ensure proper initialization
+type limboRows struct {
+	mu      sync.Mutex
+	ctx     uintptr
+	columns []string
+	closed  bool
+}
+
+// Initialize/register the FFI function pointers for the rows methods
+// DO NOT construct 'limboRows' without this function
+func initRows(ctx uintptr) *limboRows {
+	return &limboRows{
+		mu:  sync.Mutex{},
+		ctx: ctx,
+	}
+}
+
+func (r *limboRows) Columns() []string {
+	if r.ctx == 0 || r.closed {
+		return nil
+	}
+	if r.columns == nil {
+		var columnCount uint
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		colArrayPtr := rowsGetColumns(r.ctx, &columnCount)
+		if colArrayPtr != 0 && columnCount > 0 {
+			r.columns = cArrayToGoStrings(colArrayPtr, columnCount)
+			if freeCols != nil {
+				defer freeCols(colArrayPtr)
+			}
+		}
+	}
+	return r.columns
+}
+
+func (r *limboRows) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.mu.Lock()
+	r.closed = true
+	closeRows(r.ctx)
+	r.ctx = 0
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *limboRows) Next(dest []driver.Value) error {
+	if r.ctx == 0 || r.closed {
+		return io.EOF
+	}
+	for {
+		status := rowsNext(r.ctx)
+		switch ResultCode(status) {
+		case Row:
+			for i := range dest {
+				r.mu.Lock()
+				valPtr := rowsGetValue(r.ctx, int32(i))
+				r.mu.Unlock()
+				val := toGoValue(valPtr)
+				dest[i] = val
+			}
+			return nil
+		case Io:
+			continue
+		case Done:
+			return io.EOF
+		default:
+			return fmt.Errorf("unexpected status: %d", status)
+		}
+	}
+}

--- a/bindings/go/rs_src/lib.rs
+++ b/bindings/go/rs_src/lib.rs
@@ -7,7 +7,7 @@ use std::{
     ffi::{c_char, c_void},
     rc::Rc,
     str::FromStr,
-    sync::{Arc, RwLock},
+    sync::Arc,
 };
 
 /// # Safety
@@ -40,21 +40,18 @@ pub unsafe extern "C" fn db_open(path: *const c_char) -> *mut c_void {
 
 #[allow(dead_code)]
 struct LimboConn {
-    conn: RwLock<Rc<Connection>>,
+    conn: Rc<Connection>,
     io: Arc<dyn limbo_core::IO>,
 }
 
 impl<'conn> LimboConn {
     fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
-        LimboConn {
-            conn: conn.into(),
-            io,
-        }
+        LimboConn { conn, io }
     }
 
     #[allow(clippy::wrong_self_convention)]
     fn to_ptr(self) -> *mut c_void {
-        Arc::into_raw(Arc::new(self)) as *mut c_void
+        Box::into_raw(Box::new(self)) as *mut c_void
     }
 
     fn from_ptr(ptr: *mut c_void) -> &'conn mut LimboConn {

--- a/bindings/go/rs_src/lib.rs
+++ b/bindings/go/rs_src/lib.rs
@@ -7,7 +7,7 @@ use std::{
     ffi::{c_char, c_void},
     rc::Rc,
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, RwLock},
 };
 
 /// # Safety
@@ -26,7 +26,6 @@ pub unsafe extern "C" fn db_open(path: *const c_char) -> *mut c_void {
         let db = Database::open_file(io.clone(), &db_options.path.to_string());
         match db {
             Ok(db) => {
-                println!("Opened database: {}", path);
                 let conn = db.connect();
                 return LimboConn::new(conn, io).to_ptr();
             }
@@ -41,20 +40,24 @@ pub unsafe extern "C" fn db_open(path: *const c_char) -> *mut c_void {
 
 #[allow(dead_code)]
 struct LimboConn {
-    conn: Rc<Connection>,
+    conn: RwLock<Rc<Connection>>,
     io: Arc<dyn limbo_core::IO>,
 }
 
-impl LimboConn {
+impl<'conn> LimboConn {
     fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
-        LimboConn { conn, io }
-    }
-    #[allow(clippy::wrong_self_convention)]
-    fn to_ptr(self) -> *mut c_void {
-        Box::into_raw(Box::new(self)) as *mut c_void
+        LimboConn {
+            conn: conn.into(),
+            io,
+        }
     }
 
-    fn from_ptr(ptr: *mut c_void) -> &'static mut LimboConn {
+    #[allow(clippy::wrong_self_convention)]
+    fn to_ptr(self) -> *mut c_void {
+        Arc::into_raw(Arc::new(self)) as *mut c_void
+    }
+
+    fn from_ptr(ptr: *mut c_void) -> &'conn mut LimboConn {
         if ptr.is_null() {
             panic!("Null pointer");
         }

--- a/bindings/go/rs_src/rows.rs
+++ b/bindings/go/rs_src/rows.rs
@@ -90,6 +90,9 @@ pub extern "C" fn rows_get_columns(rows_ptr: *mut c_void) -> i32 {
     rows.stmt.columns().len() as i32
 }
 
+/// Returns a pointer to a string with the name of the column at the given index.
+/// The caller is responsible for freeing the memory, it should be copied on the Go side
+/// immediately and 'free_string' called
 #[no_mangle]
 pub extern "C" fn rows_get_column_name(rows_ptr: *mut c_void, idx: i32) -> *const c_char {
     if rows_ptr.is_null() {

--- a/bindings/go/rs_src/statement.rs
+++ b/bindings/go/rs_src/statement.rs
@@ -13,10 +13,7 @@ pub extern "C" fn db_prepare(ctx: *mut c_void, query: *const c_char) -> *mut c_v
     let query_str = unsafe { std::ffi::CStr::from_ptr(query) }.to_str().unwrap();
 
     let db = LimboConn::from_ptr(ctx);
-    let Ok(conn) = db.conn.read() else {
-        return std::ptr::null_mut();
-    };
-    let stmt = conn.prepare(query_str);
+    let stmt = db.conn.prepare(query_str);
     match stmt {
         Ok(stmt) => LimboStatement::new(Some(stmt), LimboConn::from_ptr(ctx)).to_ptr(),
         Err(_) => std::ptr::null_mut(),
@@ -55,10 +52,7 @@ pub extern "C" fn stmt_execute(
                 return ResultCode::Error;
             }
             Ok(StepResult::Done) => {
-                let Ok(conn) = stmt.conn.conn.read() else {
-                    return ResultCode::Done;
-                };
-                let total_changes = conn.total_changes();
+                let total_changes = stmt.conn.conn.total_changes();
                 if !changes.is_null() {
                     unsafe {
                         *changes = total_changes;

--- a/bindings/go/rs_src/statement.rs
+++ b/bindings/go/rs_src/statement.rs
@@ -132,13 +132,9 @@ pub struct LimboStatement<'conn> {
 #[no_mangle]
 pub extern "C" fn stmt_close(ctx: *mut c_void) -> ResultCode {
     if !ctx.is_null() {
-        let stmt = LimboStatement::from_ptr(ctx);
-        if stmt.statement.is_none() {
-            return ResultCode::Error;
-        } else {
-            let _ = unsafe { Box::from_raw(ctx as *mut LimboStatement) };
-            return ResultCode::Ok;
-        }
+        let stmt = unsafe { Box::from_raw(ctx as *mut LimboStatement) };
+        drop(stmt);
+        return ResultCode::Ok;
     }
     ResultCode::Invalid
 }

--- a/bindings/go/stmt.go
+++ b/bindings/go/stmt.go
@@ -1,11 +1,10 @@
 package limbo
 
 import (
-	"context"
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"io"
+	"sync"
 	"unsafe"
 )
 
@@ -13,43 +12,32 @@ import (
 // inUse tracks whether or not `query` has been called. if inUse > 0, stmt no longer
 // owns the underlying data and `rows` is responsible for cleaning it up on close.
 type limboStmt struct {
-	ctx           uintptr
-	sql           string
-	inUse         int
-	query         func(stmtPtr uintptr, argsPtr uintptr, argCount uint64) uintptr
-	execute       func(stmtPtr uintptr, argsPtr uintptr, argCount uint64, changes uintptr) int32
-	getParamCount func(uintptr) int32
-	closeStmt     func(uintptr) int32
+	mu    sync.Mutex
+	ctx   uintptr
+	sql   string
+	inUse int
 }
 
 // Initialize/register the FFI function pointers for the statement methods
 func initStmt(ctx uintptr, sql string) *limboStmt {
-	var query func(stmtPtr uintptr, argsPtr uintptr, argCount uint64) uintptr
-	getFfiFunc(&query, FfiStmtQuery)
-	var execute func(stmtPtr uintptr, argsPtr uintptr, argCount uint64, changes uintptr) int32
-	getFfiFunc(&execute, FfiStmtExec)
-	var getParamCount func(uintptr) int32
-	getFfiFunc(&getParamCount, FfiStmtParameterCount)
-	var closeStmt func(uintptr) int32
-	getFfiFunc(&closeStmt, FfiStmtClose)
 	return &limboStmt{
-		ctx:           uintptr(ctx),
-		sql:           sql,
-		inUse:         0,
-		execute:       execute,
-		query:         query,
-		getParamCount: getParamCount,
-		closeStmt:     closeStmt,
+		ctx:   uintptr(ctx),
+		sql:   sql,
+		inUse: 0,
 	}
 }
 
 func (ls *limboStmt) NumInput() int {
-	return int(ls.getParamCount(ls.ctx))
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	return int(stmtParamCount(ls.ctx))
 }
 
 func (ls *limboStmt) Close() error {
 	if ls.inUse == 0 {
-		res := ls.closeStmt(ls.ctx)
+		ls.mu.Lock()
+		res := closeStmt(ls.ctx)
+		ls.mu.Unlock()
 		if ResultCode(res) != Ok {
 			return fmt.Errorf("error closing statement: %s", ResultCode(res).String())
 		}
@@ -59,8 +47,12 @@ func (ls *limboStmt) Close() error {
 }
 
 func (ls *limboStmt) Exec(args []driver.Value) (driver.Result, error) {
+	ls.mu.Lock()
 	argArray, cleanup, err := buildArgs(args)
-	defer cleanup()
+	defer func() {
+		cleanup()
+		ls.mu.Unlock()
+	}()
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +62,7 @@ func (ls *limboStmt) Exec(args []driver.Value) (driver.Result, error) {
 		argPtr = uintptr(unsafe.Pointer(&argArray[0]))
 	}
 	var changes uint64
-	rc := ls.execute(ls.ctx, argPtr, argCount, uintptr(unsafe.Pointer(&changes)))
+	rc := stmtExec(ls.ctx, argPtr, argCount, uintptr(unsafe.Pointer(&changes)))
 	switch ResultCode(rc) {
 	case Ok, Done:
 		return driver.RowsAffected(changes), nil
@@ -87,9 +79,10 @@ func (ls *limboStmt) Exec(args []driver.Value) (driver.Result, error) {
 	}
 }
 
-func (st *limboStmt) Query(args []driver.Value) (driver.Rows, error) {
+func (ls *limboStmt) Query(args []driver.Value) (driver.Rows, error) {
+	ls.mu.Lock()
 	queryArgs, cleanup, err := buildArgs(args)
-	defer cleanup()
+	defer func() { cleanup(); ls.mu.Unlock() }()
 	if err != nil {
 		return nil, err
 	}
@@ -97,59 +90,7 @@ func (st *limboStmt) Query(args []driver.Value) (driver.Rows, error) {
 	if len(args) > 0 {
 		argPtr = uintptr(unsafe.Pointer(&queryArgs[0]))
 	}
-	rowsPtr := st.query(st.ctx, argPtr, uint64(len(queryArgs)))
-	if rowsPtr == 0 {
-		return nil, fmt.Errorf("query failed for: %q", st.sql)
-	}
-	st.inUse++
-	return initRows(rowsPtr), nil
-}
-
-func (ls *limboStmt) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	stripped := namedValueToValue(args)
-	argArray, cleanup, err := getArgsPtr(stripped)
-	defer cleanup()
-	if err != nil {
-		return nil, err
-	}
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-	var changes uint64
-	res := ls.execute(ls.ctx, argArray, uint64(len(args)), uintptr(unsafe.Pointer(&changes)))
-	switch ResultCode(res) {
-	case Ok, Done:
-		changes := uint64(changes)
-		return driver.RowsAffected(changes), nil
-	case Error:
-		return nil, errors.New("error executing statement")
-	case Busy:
-		return nil, errors.New("busy")
-	case Interrupt:
-		return nil, errors.New("interrupted")
-	default:
-		return nil, fmt.Errorf("unexpected status: %d", res)
-	}
-}
-
-func (ls *limboStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
-	queryArgs, allocs, err := buildNamedArgs(args)
-	defer allocs()
-	if err != nil {
-		return nil, err
-	}
-	argsPtr := uintptr(0)
-	if len(queryArgs) > 0 {
-		argsPtr = uintptr(unsafe.Pointer(&queryArgs[0]))
-	}
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-	rowsPtr := ls.query(ls.ctx, argsPtr, uint64(len(queryArgs)))
+	rowsPtr := stmtQuery(ls.ctx, argPtr, uint64(len(queryArgs)))
 	if rowsPtr == 0 {
 		return nil, fmt.Errorf("query failed for: %q", ls.sql)
 	}
@@ -157,81 +98,56 @@ func (ls *limboStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 	return initRows(rowsPtr), nil
 }
 
-// only construct limboRows with initRows function to ensure proper initialization
-type limboRows struct {
-	ctx       uintptr
-	columns   []string
-	closed    bool
-	getCols   func(uintptr, *uint) uintptr
-	next      func(uintptr) uintptr
-	getValue  func(uintptr, int32) uintptr
-	closeRows func(uintptr) uintptr
-	freeCols  func(uintptr) uintptr
-}
-
-// Initialize/register the FFI function pointers for the rows methods
-// DO NOT construct 'limboRows' without this function
-func initRows(ctx uintptr) *limboRows {
-	var getCols func(uintptr, *uint) uintptr
-	getFfiFunc(&getCols, FfiRowsGetColumns)
-	var getValue func(uintptr, int32) uintptr
-	getFfiFunc(&getValue, FfiRowsGetValue)
-	var closeRows func(uintptr) uintptr
-	getFfiFunc(&closeRows, FfiRowsClose)
-	var freeCols func(uintptr) uintptr
-	getFfiFunc(&freeCols, FfiFreeColumns)
-	var next func(uintptr) uintptr
-	getFfiFunc(&next, FfiRowsNext)
-
-	return &limboRows{
-		ctx:       ctx,
-		getCols:   getCols,
-		getValue:  getValue,
-		closeRows: closeRows,
-		freeCols:  freeCols,
-		next:      next,
-	}
-}
-
-func (r *limboRows) Columns() []string {
-	if r.columns == nil {
-		var columnCount uint
-		colArrayPtr := r.getCols(r.ctx, &columnCount)
-		if colArrayPtr != 0 && columnCount > 0 {
-			r.columns = cArrayToGoStrings(colArrayPtr, columnCount)
-			defer r.freeCols(colArrayPtr)
-		}
-	}
-	return r.columns
-}
-
-func (r *limboRows) Close() error {
-	if r.closed {
-		return nil
-	}
-	r.closed = true
-	r.closeRows(r.ctx)
-	r.ctx = 0
-	return nil
-}
-
-func (r *limboRows) Next(dest []driver.Value) error {
-	for {
-		status := r.next(r.ctx)
-		switch ResultCode(status) {
-		case Row:
-			for i := range dest {
-				valPtr := r.getValue(r.ctx, int32(i))
-				val := toGoValue(valPtr)
-				dest[i] = val
-			}
-			return nil
-		case Io:
-			continue
-		case Done:
-			return io.EOF
-		default:
-			return fmt.Errorf("unexpected status: %d", status)
-		}
-	}
-}
+// func (ls *limboStmt) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+// 	ls.mu.Lock()
+// 	stripped := namedValueToValue(args)
+// 	argArray, cleanup, err := getArgsPtr(stripped)
+// 	defer func() { cleanup(); ls.mu.Unlock() }()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	select {
+// 	case <-ctx.Done():
+// 		return nil, ctx.Err()
+// 	default:
+// 	}
+// 	var changes uint64
+// 	res := stmtExec(ls.ctx, argArray, uint64(len(args)), uintptr(unsafe.Pointer(&changes)))
+// 	switch ResultCode(res) {
+// 	case Ok, Done:
+// 		changes := uint64(changes)
+// 		return driver.RowsAffected(changes), nil
+// 	case Error:
+// 		return nil, errors.New("error executing statement")
+// 	case Busy:
+// 		return nil, errors.New("busy")
+// 	case Interrupt:
+// 		return nil, errors.New("interrupted")
+// 	default:
+// 		return nil, fmt.Errorf("unexpected status: %d", res)
+// 	}
+// }
+//
+// func (ls *limboStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+// 	ls.mu.Lock()
+// 	queryArgs, allocs, err := buildNamedArgs(args)
+// 	defer func() { allocs(); ls.mu.Unlock() }()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	argsPtr := uintptr(0)
+// 	if len(queryArgs) > 0 {
+// 		argsPtr = uintptr(unsafe.Pointer(&queryArgs[0]))
+// 	}
+// 	select {
+// 	case <-ctx.Done():
+// 		return nil, ctx.Err()
+// 	default:
+// 	}
+// 	rowsPtr := stmtQuery(ls.ctx, argsPtr, uint64(len(queryArgs)))
+// 	if rowsPtr == 0 {
+// 		return nil, fmt.Errorf("query failed for: %q", ls.sql)
+// 	}
+// 	ls.inUse++
+// 	return initRows(rowsPtr), nil
+// }

--- a/bindings/go/stmt.go
+++ b/bindings/go/stmt.go
@@ -1,6 +1,7 @@
 package limbo
 
 import (
+	"context"
 	"database/sql/driver"
 	"errors"
 	"fmt"
@@ -8,22 +9,16 @@ import (
 	"unsafe"
 )
 
-// only construct limboStmt with initStmt function to ensure proper initialization
-// inUse tracks whether or not `query` has been called. if inUse > 0, stmt no longer
-// owns the underlying data and `rows` is responsible for cleaning it up on close.
 type limboStmt struct {
-	mu    sync.Mutex
-	ctx   uintptr
-	sql   string
-	inUse int
+	mu  sync.Mutex
+	ctx uintptr
+	sql string
 }
 
-// Initialize/register the FFI function pointers for the statement methods
-func initStmt(ctx uintptr, sql string) *limboStmt {
+func newStmt(ctx uintptr, sql string) *limboStmt {
 	return &limboStmt{
-		ctx:   uintptr(ctx),
-		sql:   sql,
-		inUse: 0,
+		ctx: uintptr(ctx),
+		sql: sql,
 	}
 }
 
@@ -34,25 +29,19 @@ func (ls *limboStmt) NumInput() int {
 }
 
 func (ls *limboStmt) Close() error {
-	if ls.inUse == 0 {
-		ls.mu.Lock()
-		res := closeStmt(ls.ctx)
-		ls.mu.Unlock()
-		if ResultCode(res) != Ok {
-			return fmt.Errorf("error closing statement: %s", ResultCode(res).String())
-		}
+	ls.mu.Lock()
+	res := closeStmt(ls.ctx)
+	ls.mu.Unlock()
+	if ResultCode(res) != Ok {
+		return fmt.Errorf("error closing statement: %s", ResultCode(res).String())
 	}
 	ls.ctx = 0
 	return nil
 }
 
 func (ls *limboStmt) Exec(args []driver.Value) (driver.Result, error) {
-	ls.mu.Lock()
 	argArray, cleanup, err := buildArgs(args)
-	defer func() {
-		cleanup()
-		ls.mu.Unlock()
-	}()
+	defer cleanup()
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +51,9 @@ func (ls *limboStmt) Exec(args []driver.Value) (driver.Result, error) {
 		argPtr = uintptr(unsafe.Pointer(&argArray[0]))
 	}
 	var changes uint64
+	ls.mu.Lock()
 	rc := stmtExec(ls.ctx, argPtr, argCount, uintptr(unsafe.Pointer(&changes)))
+	ls.mu.Unlock()
 	switch ResultCode(rc) {
 	case Ok, Done:
 		return driver.RowsAffected(changes), nil
@@ -80,9 +71,8 @@ func (ls *limboStmt) Exec(args []driver.Value) (driver.Result, error) {
 }
 
 func (ls *limboStmt) Query(args []driver.Value) (driver.Rows, error) {
-	ls.mu.Lock()
 	queryArgs, cleanup, err := buildArgs(args)
-	defer func() { cleanup(); ls.mu.Unlock() }()
+	defer cleanup()
 	if err != nil {
 		return nil, err
 	}
@@ -90,64 +80,66 @@ func (ls *limboStmt) Query(args []driver.Value) (driver.Rows, error) {
 	if len(args) > 0 {
 		argPtr = uintptr(unsafe.Pointer(&queryArgs[0]))
 	}
+	ls.mu.Lock()
 	rowsPtr := stmtQuery(ls.ctx, argPtr, uint64(len(queryArgs)))
+	ls.mu.Unlock()
 	if rowsPtr == 0 {
 		return nil, fmt.Errorf("query failed for: %q", ls.sql)
 	}
-	ls.inUse++
-	return initRows(rowsPtr), nil
+	return newRows(rowsPtr), nil
 }
 
-// func (ls *limboStmt) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-// 	ls.mu.Lock()
-// 	stripped := namedValueToValue(args)
-// 	argArray, cleanup, err := getArgsPtr(stripped)
-// 	defer func() { cleanup(); ls.mu.Unlock() }()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	select {
-// 	case <-ctx.Done():
-// 		return nil, ctx.Err()
-// 	default:
-// 	}
-// 	var changes uint64
-// 	res := stmtExec(ls.ctx, argArray, uint64(len(args)), uintptr(unsafe.Pointer(&changes)))
-// 	switch ResultCode(res) {
-// 	case Ok, Done:
-// 		changes := uint64(changes)
-// 		return driver.RowsAffected(changes), nil
-// 	case Error:
-// 		return nil, errors.New("error executing statement")
-// 	case Busy:
-// 		return nil, errors.New("busy")
-// 	case Interrupt:
-// 		return nil, errors.New("interrupted")
-// 	default:
-// 		return nil, fmt.Errorf("unexpected status: %d", res)
-// 	}
-// }
-//
-// func (ls *limboStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
-// 	ls.mu.Lock()
-// 	queryArgs, allocs, err := buildNamedArgs(args)
-// 	defer func() { allocs(); ls.mu.Unlock() }()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	argsPtr := uintptr(0)
-// 	if len(queryArgs) > 0 {
-// 		argsPtr = uintptr(unsafe.Pointer(&queryArgs[0]))
-// 	}
-// 	select {
-// 	case <-ctx.Done():
-// 		return nil, ctx.Err()
-// 	default:
-// 	}
-// 	rowsPtr := stmtQuery(ls.ctx, argsPtr, uint64(len(queryArgs)))
-// 	if rowsPtr == 0 {
-// 		return nil, fmt.Errorf("query failed for: %q", ls.sql)
-// 	}
-// 	ls.inUse++
-// 	return initRows(rowsPtr), nil
-// }
+func (ls *limboStmt) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	stripped := namedValueToValue(args)
+	argArray, cleanup, err := getArgsPtr(stripped)
+	defer cleanup()
+	if err != nil {
+		return nil, err
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	var changes uint64
+	ls.mu.Lock()
+	res := stmtExec(ls.ctx, argArray, uint64(len(args)), uintptr(unsafe.Pointer(&changes)))
+	ls.mu.Unlock()
+	switch ResultCode(res) {
+	case Ok, Done:
+		changes := uint64(changes)
+		return driver.RowsAffected(changes), nil
+	case Error:
+		return nil, errors.New("error executing statement")
+	case Busy:
+		return nil, errors.New("busy")
+	case Interrupt:
+		return nil, errors.New("interrupted")
+	default:
+		return nil, fmt.Errorf("unexpected status: %d", res)
+	}
+}
+
+func (ls *limboStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	queryArgs, allocs, err := buildNamedArgs(args)
+	defer allocs()
+	if err != nil {
+		return nil, err
+	}
+	argsPtr := uintptr(0)
+	if len(queryArgs) > 0 {
+		argsPtr = uintptr(unsafe.Pointer(&queryArgs[0]))
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	ls.mu.Lock()
+	rowsPtr := stmtQuery(ls.ctx, argsPtr, uint64(len(queryArgs)))
+	ls.mu.Unlock()
+	if rowsPtr == 0 {
+		return nil, fmt.Errorf("query failed for: %q", ls.sql)
+	}
+	return newRows(rowsPtr), nil
+}

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -65,20 +65,23 @@ func (rc ResultCode) String() string {
 }
 
 const (
-	FfiDbOpen             string = "db_open"
-	FfiDbClose            string = "db_close"
-	FfiDbPrepare          string = "db_prepare"
-	FfiStmtExec           string = "stmt_execute"
-	FfiStmtQuery          string = "stmt_query"
-	FfiStmtParameterCount string = "stmt_parameter_count"
-	FfiStmtClose          string = "stmt_close"
-	FfiRowsClose          string = "rows_close"
-	FfiRowsGetColumns     string = "rows_get_columns"
-	FfiRowsNext           string = "rows_next"
-	FfiRowsGetValue       string = "rows_get_value"
-	FfiFreeColumns        string = "free_columns"
-	FfiFreeCString        string = "free_string"
-	FfiFreeBlob           string = "free_blob"
+	driverName            = "sqlite3"
+	libName               = "lib_limbo_go"
+	FfiDbOpen             = "db_open"
+	FfiDbClose            = "db_close"
+	FfiDbPrepare          = "db_prepare"
+	FfiStmtExec           = "stmt_execute"
+	FfiStmtQuery          = "stmt_query"
+	FfiStmtParameterCount = "stmt_parameter_count"
+	FfiStmtClose          = "stmt_close"
+	FfiRowsClose          = "rows_close"
+	FfiRowsGetColumns     = "rows_get_columns"
+	FfiRowsGetColumnName  = "rows_get_column_name"
+	FfiRowsNext           = "rows_next"
+	FfiRowsGetValue       = "rows_get_value"
+	FfiFreeColumns        = "free_columns"
+	FfiFreeCString        = "free_string"
+	FfiFreeBlob           = "free_blob"
 )
 
 // convert a namedValue slice into normal values until named parameters are supported
@@ -210,22 +213,6 @@ func freeCString(cstrPtr uintptr) {
 		return
 	}
 	freeStringFunc(cstrPtr)
-}
-
-func cArrayToGoStrings(arrayPtr uintptr, length uint) []string {
-	if arrayPtr == 0 || length == 0 {
-		return nil
-	}
-	ptrSlice := unsafe.Slice(
-		(**byte)(unsafe.Pointer(arrayPtr)),
-		length,
-	)
-
-	out := make([]string, 0, length)
-	for _, cstr := range ptrSlice {
-		out = append(out, GoString(uintptr(unsafe.Pointer(cstr))))
-	}
-	return out
 }
 
 // convert a Go slice of driver.Value to a slice of limboValue that can be sent over FFI

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -198,26 +198,16 @@ func toGoBlob(blobPtr uintptr) []byte {
 	return copied
 }
 
-var freeBlobFunc func(uintptr)
-
 func freeBlob(blobPtr uintptr) {
 	if blobPtr == 0 {
 		return
 	}
-	if freeBlobFunc == nil {
-		getFfiFunc(&freeBlobFunc, FfiFreeBlob)
-	}
 	freeBlobFunc(blobPtr)
 }
-
-var freeStringFunc func(uintptr)
 
 func freeCString(cstrPtr uintptr) {
 	if cstrPtr == 0 {
 		return
-	}
-	if freeStringFunc == nil {
-		getFfiFunc(&freeStringFunc, FfiFreeCString)
 	}
 	freeStringFunc(cstrPtr)
 }
@@ -226,7 +216,6 @@ func cArrayToGoStrings(arrayPtr uintptr, length uint) []string {
 	if arrayPtr == 0 || length == 0 {
 		return nil
 	}
-
 	ptrSlice := unsafe.Slice(
 		(**byte)(unsafe.Pointer(arrayPtr)),
 		length,
@@ -259,6 +248,7 @@ func buildArgs(args []driver.Value) ([]limboValue, func(), error) {
 		case string:
 			limboVal.Type = textVal
 			cstr := CString(val)
+			pinner.Pin(cstr)
 			*(*uintptr)(unsafe.Pointer(&limboVal.Value)) = uintptr(unsafe.Pointer(cstr))
 		case []byte:
 			limboVal.Type = blobVal


### PR DESCRIPTION
This PR continues work on the Go bindings.

- Register all symbols from the library at load time to prevent any repeated `dlsym` calls.
- Add locks to prevent multiple concurrent FFI calls to functions that act on the same state.
- Adds documentation/example in the go module `README`.
- Fixes memory access issue causing segfault due to passing pointer to array of strings, that is difficult to work with in Go without the right primitives. In place, simply return the amount of ResultColumns and Go can provide the index to receive the column name, similar to `rowsGetValue` 

On next limbo release, I'll add the example to the main `README` next to the other language examples. Until then, `go get github.com/tursodatabase/limbo` will not work so the example will remain in the bindings readme.