### PR TITLE
implement json_pretty

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -23,6 +23,7 @@ This document describes the compatibility of Limbo with SQLite.
   - [Extensions](#extensions)
     - [UUID](#uuid)
     - [regexp](#regexp)
+    - [Vector](#vector)
 
 ## Features
 
@@ -349,7 +350,7 @@ Modifiers:
 #### JSON functions
 
 | Function                           | Status  | Comment                                                                                                                                      |
-|------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | json(json)                         | Partial |                                                                                                                                              |
 | jsonb(json)                        |         |                                                                                                                                              |
 | json_array(value1,value2,...)      | Yes     |                                                                                                                                              |
@@ -367,7 +368,7 @@ Modifiers:
 | jsonb_object(label1,value1,...)    |         |                                                                                                                                              |
 | json_patch(json1,json2)            | Yes     |                                                                                                                                              |
 | jsonb_patch(json1,json2)           |         |                                                                                                                                              |
-| json_pretty(json)                  |         |                                                                                                                                              |
+| json_pretty(json)                  | Partial | Shares same json(val) limitations. Also, when passing blobs for indentation, conversion is not exactly the same as in SQLite                 |
 | json_remove(json,path,...)         | Partial | Uses same json path parser as json_extract so shares same limitations.                                                                       |
 | jsonb_remove(json,path,...)        |         |                                                                                                                                              |
 | json_replace(json,path,value,...)  |         |                                                                                                                                              |

--- a/core/function.rs
+++ b/core/function.rs
@@ -82,6 +82,7 @@ pub enum JsonFunc {
     JsonValid,
     JsonPatch,
     JsonRemove,
+    JsonPretty,
 }
 
 #[cfg(feature = "json")]
@@ -103,6 +104,7 @@ impl Display for JsonFunc {
                 Self::JsonValid => "json_valid".to_string(),
                 Self::JsonPatch => "json_patch".to_string(),
                 Self::JsonRemove => "json_remove".to_string(),
+                Self::JsonPretty => "json_pretty".to_string(),
             }
         )
     }
@@ -534,6 +536,8 @@ impl Func {
             "json_patch" => Ok(Self::Json(JsonFunc::JsonPatch)),
             #[cfg(feature = "json")]
             "json_remove" => Ok(Self::Json(JsonFunc::JsonRemove)),
+            #[cfg(feature = "json")]
+            "json_pretty" => Ok(Self::Json(JsonFunc::JsonPretty)),
             "unixepoch" => Ok(Self::Scalar(ScalarFunc::UnixEpoch)),
             "julianday" => Ok(Self::Scalar(ScalarFunc::JulianDay)),
             "hex" => Ok(Self::Scalar(ScalarFunc::Hex)),

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1108,6 +1108,18 @@ pub fn translate_expr(
                         });
                         Ok(target_register)
                     }
+                    JsonFunc::JsonPretty => {
+                        let args = expect_arguments_max!(args, 2, j);
+
+                        translate_function(
+                            program,
+                            args,
+                            referenced_tables,
+                            resolver,
+                            target_register,
+                            func_ctx,
+                        )
+                    }
                 },
                 Func::Scalar(srf) => {
                     match srf {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1690,7 +1690,7 @@ impl Program {
                         crate::function::Func::Json(json_func) => match json_func {
                             JsonFunc::Json => {
                                 let json_value = &state.registers[*start_reg];
-                                let json_str = get_json(json_value);
+                                let json_str = get_json(json_value, None);
                                 match json_str {
                                     Ok(json) => state.registers[*dest] = json,
                                     Err(e) => return Err(e),
@@ -1786,6 +1786,40 @@ impl Program {
                                 state.registers[*dest] = json_remove(
                                     &state.registers[*start_reg..*start_reg + arg_count],
                                 )?;
+                            }
+                            JsonFunc::JsonPretty => {
+                                let json_value = &state.registers[*start_reg];
+                                let indent = if arg_count > 1 {
+                                    Some(&state.registers[*start_reg + 1])
+                                } else {
+                                    None
+                                };
+
+                                // Blob should be converted to Ascii in a lossy way
+                                // However, Rust strings uses utf-8
+                                // so the behavior at the moment is slightly different
+                                // To the way blobs are parsed here in SQLite.
+                                let indent = match indent {
+                                    Some(value) => match value {
+                                        OwnedValue::Text(text) => text.value.as_str(),
+                                        OwnedValue::Integer(val) => &val.to_string(),
+                                        OwnedValue::Float(val) => &val.to_string(),
+                                        OwnedValue::Blob(val) => &String::from_utf8_lossy(val),
+                                        OwnedValue::Agg(ctx) => match ctx.final_value() {
+                                            OwnedValue::Text(text) => text.value.as_str(),
+                                            OwnedValue::Integer(val) => &val.to_string(),
+                                            OwnedValue::Float(val) => &val.to_string(),
+                                            OwnedValue::Blob(val) => &String::from_utf8_lossy(val),
+                                            _ => "    ",
+                                        },
+                                        _ => "    ",
+                                    },
+                                    // If the second argument is omitted or is NULL, then indentation is four spaces per level
+                                    None => "    ",
+                                };
+
+                                let json_str = get_json(json_value, Some(indent))?;
+                                state.registers[*dest] = json_str;
                             }
                         },
                         crate::function::Func::Scalar(scalar_func) => match scalar_func {

--- a/testing/json.test
+++ b/testing/json.test
@@ -60,6 +60,128 @@ do_execsql_test json5-multi-comment {
           123 /* xyz */ , /* 123 */ }')
 } {{{"aaa":123}}}
 
+do_execsql_test json5-ecma-script-1-pretty {
+    select json_pretty('{a:5,b:6}') ;
+} {{{
+    "a": 5,
+    "b": 6
+}}}
+
+do_execsql_test json5-ecma-script-2-pretty {
+    select json_pretty('{a:5,a:3}') ;
+} {{{
+    "a": 5,
+    "a": 3
+}}}
+
+do_execsql_test json5-ecma-script-3-pretty {
+   SELECT json_pretty('{ MNO_123$xyz : 789 }');
+} {{{
+    "MNO_123$xyz": 789
+}}}
+
+do_execsql_test json5-with-single-trailing-comma-valid-pretty {
+    select json_pretty('{"a":5, "b":6, }');
+} {{{
+    "a": 5,
+    "b": 6
+}}}
+
+do_execsql_test json5-single-quoted-pretty {
+    SELECT json_pretty('{"a": ''abcd''}');
+} {{{
+    "a": "abcd"
+}}}
+
+do_execsql_test json5-hexadecimal-1-pretty {
+   SELECT json_pretty('{a: 0x0}');
+} {{{
+    "a": 0
+}}}
+
+do_execsql_test json5-hexadecimal-2-pretty {
+   SELECT json_pretty('{a: 0xabcdef}');
+} {{{
+    "a": 11259375
+}}}
+
+do_execsql_test json5-hexadecimal-2-pretty {
+   SELECT json_pretty('{a: -0xabcdef}');
+} {{{
+    "a": -11259375
+}}}
+
+do_execsql_test json5-number-1-pretty {
+   SELECT json_pretty('{x: 4.}');
+} {{{
+    "x": 4.0
+}}}
+
+do_execsql_test json5-number-2-pretty {
+   SELECT json_pretty('{x: +4.}');
+} {{{
+    "x": 4.0
+}}}
+
+do_execsql_test json5-number-3-pretty {
+   SELECT json_pretty('{x: -4.}');
+} {{{
+    "x": -4.0
+}}}
+
+do_execsql_test json5-number-5-pretty {
+   SELECT json_pretty('{x: Infinity}');
+} {{{
+    "x": 9e999
+}}}
+
+do_execsql_test json5-number-6-pretty {
+   SELECT json_pretty('{x: -Infinity}');
+} {{{
+    "x": -9e999
+}}}
+
+do_execsql_test json5-multi-comment-pretty {
+   SELECT json_pretty(' /* abc */ { /*def*/ aaa /* xyz */ : // to the end of line
+          123 /* xyz */ , /* 123 */ }');
+} {{{
+    "aaa": 123
+}}}
+
+do_execsql_test json-pretty-ident-1 {
+   SELECT json_pretty('{x: 1}', '');
+} {{{
+"x": 1
+}}}
+
+do_execsql_test json-pretty-ident-2 {
+   SELECT json_pretty('{x: 1}', '11');
+} {{{
+11"x": 1
+}}}
+
+do_execsql_test json-pretty-ident-null {
+   SELECT json_pretty('{x: 1}', NULL);
+} {{{
+    "x": 1
+}}}
+
+do_execsql_test json-pretty-ident-blob-1 {
+   SELECT json_pretty('{x: 1}', x'33');
+} {{{
+3"x": 1
+}}}
+
+# TODO
+# Currently conversion from blob to string is not exactly the same as in sqlite.
+# The blob below should evaluate to two whitespaces TEXT value
+
+# do_execsql_test json-pretty-ident-blob-2 {
+#    SELECT json_pretty('{x: 1}', x'1111');
+# } {{{
+#   "x": 1
+# }}}
+
 do_execsql_test json_array_str {
    SELECT json_array('a')
 } {{["a"]}}


### PR DESCRIPTION
This PR implements json_pretty. At the moment, support for jsonb is being added, so this function suffers from the same limitations as in json(x). Also, I have not found a way to implement the same conversion of Blob -> String that SQLite does. From my own experimentation, I believe SQLite converts blobs to a lossy ascii representation, but I would appreciate some help on this.