### PR TITLE
Support column aliases in GROUP BY, ORDER BY and HAVING

### DIFF
--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -43,7 +43,7 @@ pub fn prepare_delete_plan(
     let mut where_predicates = vec![];
 
     // Parse the WHERE clause
-    parse_where(where_clause, &table_references, &mut where_predicates)?;
+    parse_where(where_clause, &table_references, None, &mut where_predicates)?;
 
     // Parse the LIMIT/OFFSET clause
     let (resolved_limit, resolved_offset) = limit.map_or(Ok((None, None)), |l| parse_limit(*l))?;

--- a/testing/groupby.test
+++ b/testing/groupby.test
@@ -175,3 +175,9 @@ David|165|53.0
 Robert|159|51.0
 Jennifer|151|51.0
 John|145|50.0}
+
+# Wanda = 9, Whitney = 11, William = 111
+do_execsql_test column_alias_in_group_by_order_by_having {
+  select first_name as fn, count(1) as fn_count from users where fn in ('Wanda', 'Whitney', 'William') group by fn having fn_count > 10 order by fn_count;
+} {Whitney|11
+William|111}


### PR DESCRIPTION
Closes #744 

```sql
# Wanda = 9, Whitney = 11, William = 111
do_execsql_test column_alias_in_group_by_order_by_having {
  select first_name as fn, count(1) as fn_count from users where fn in ('Wanda', 'Whitney', 'William') group by fn having fn_count > 10 order by fn_count;
} {Whitney|11
William|111}
```