### PR TITLE
Fix logical codegen

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1227,15 +1227,21 @@ pub fn translate_expr(
                                     srf.to_string()
                                 );
                             };
-                            for arg in args {
-                                let _ =
-                                    translate_and_mark(program, referenced_tables, arg, resolver);
+                            let func_registers = program.alloc_registers(args.len());
+                            for (i, arg) in args.iter().enumerate() {
+                                let _ = translate_expr(
+                                    program,
+                                    referenced_tables,
+                                    arg,
+                                    func_registers + i,
+                                    resolver,
+                                )?;
                             }
                             program.emit_insn(Insn::Function {
                                 // Only constant patterns for LIKE are supported currently, so this
                                 // is always 1
                                 constant_mask: 1,
-                                start_reg: target_register + 1,
+                                start_reg: func_registers,
                                 dest: target_register,
                                 func: func_ctx,
                             });

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1146,9 +1146,10 @@ pub fn translate_expr(
                                 temp_reg,
                                 resolver,
                             )?;
+                            let before_copy_label = program.allocate_label();
                             program.emit_insn(Insn::NotNull {
                                 reg: temp_reg,
-                                target_pc: program.offset().add(2u32),
+                                target_pc: before_copy_label,
                             });
 
                             translate_expr(
@@ -1158,6 +1159,7 @@ pub fn translate_expr(
                                 temp_reg,
                                 resolver,
                             )?;
+                            program.resolve_label(before_copy_label, program.offset());
                             program.emit_insn(Insn::Copy {
                                 src_reg: temp_reg,
                                 dst_reg: target_register,

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -675,6 +675,10 @@ fn rewrite_expr(expr: &mut ast::Expr) -> Result<()> {
             }
             Ok(())
         }
+        ast::Expr::Unary(_, arg) => {
+            rewrite_expr(arg)?;
+            Ok(())
+        }
         _ => Ok(()),
     }
 }

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -211,7 +211,7 @@ mod tests {
             // unfortunatelly, sqlite behaves weirdly when IS operator is used with TRUE/FALSE constants
             // e.g. 8 IS TRUE == 1 (although 8 = TRUE == 0)
             // so, we do not use TRUE/FALSE constants as they will produce diff with sqlite results
-            .options_str(["1", "0", "NULL", "1.0", "1.5", "-0.5", "-1.0", "'x'"])
+            .options_str(["1", "0", "NULL", "2.0", "1.5", "-0.5", "-2.0", "(1 / 0)"])
             .build();
 
         let sql = g.create().concat(" ").push_str("SELECT").push(expr).build();

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -158,6 +158,8 @@ mod tests {
             "SELECT FALSE",
             "SELECT NOT FALSE",
             "SELECT ((NULL) IS NOT TRUE <= ((NOT (FALSE))))",
+            "SELECT ifnull(0, NOT 0)",
+            "SELECT like('a%', 'a') = 1",
         ] {
             let limbo = limbo_exec_row(&limbo_conn, query);
             let sqlite = sqlite_exec_row(&sqlite_conn, query);


### PR DESCRIPTION
Fix few logical codegen issues and add fuzz tests for logical expressions

-  Right now Limbo fails to recognize `false` constant in case when any unary operator is used on the AST path. This PR add unary operator option in the rewrite code and handle such cases properly.

```sql
limbo> SELECT NOT FALSE;

  × Parse error: no such column: FALSE - should this be a string literal in single-quotes?

```

- `ifnull` implementation produced incorrect codegen due to "careless" management of registers
```
limbo> SELECT ifnull(0, NOT 0)
[NULL here]
```

- `like` implementation produced incorrect codegen due to "careless" management of registers
```
limbo> SELECT like('a%', 'a') = 1;
thread 'main' panicked at core/vdbe/mod.rs:1902:41:
internal error: entered unreachable code: Like on non-text registers
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Depends on https://github.com/tursodatabase/limbo/pull/867 (need `GrammarGenerator` from this branch)