### PR TITLE
Small perf optimizations to statement preparation

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -331,7 +331,7 @@ impl Connection {
                             *select,
                             &self.db.syms.borrow(),
                         )?;
-                        optimize_plan(&mut plan)?;
+                        optimize_plan(&mut plan, &self.schema.borrow())?;
                         println!("{}", plan);
                     }
                     _ => todo!(),

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -66,8 +66,14 @@ impl Table {
 
     pub fn get_column_at(&self, index: usize) -> &Column {
         match self {
-            Self::BTree(table) => table.columns.get(index).unwrap(),
-            Self::Pseudo(table) => table.columns.get(index).unwrap(),
+            Self::BTree(table) => table
+                .columns
+                .get(index)
+                .expect("column index out of bounds"),
+            Self::Pseudo(table) => table
+                .columns
+                .get(index)
+                .expect("column index out of bounds"),
         }
     }
 

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -18,7 +18,7 @@ pub fn translate_delete(
     syms: &SymbolTable,
 ) -> Result<()> {
     let mut delete_plan = prepare_delete_plan(schema, tbl_name, where_clause, limit)?;
-    optimize_plan(&mut delete_plan)?;
+    optimize_plan(&mut delete_plan, schema)?;
     emit_program(program, delete_plan, syms)
 }
 
@@ -55,7 +55,6 @@ pub fn prepare_delete_plan(
         order_by: None,
         limit: resolved_limit,
         offset: resolved_offset,
-        available_indexes: vec![],
         contains_constant_false_condition: false,
     };
 

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -60,6 +60,10 @@ pub fn init_loop(
     tables: &[TableReference],
     mode: &OperationMode,
 ) -> Result<()> {
+    assert!(
+        t_ctx.meta_left_joins.len() == tables.len(),
+        "meta_left_joins length does not match tables length"
+    );
     for (table_index, table) in tables.iter().enumerate() {
         // Initialize bookkeeping for OUTER JOIN
         if let Some(join_info) = table.join_info.as_ref() {

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -1,18 +1,21 @@
-use std::rc::Rc;
+use std::{collections::HashMap, rc::Rc};
 
 use sqlite3_parser::ast;
 
-use crate::{schema::Index, Result};
+use crate::{
+    schema::{Index, Schema},
+    Result,
+};
 
 use super::plan::{
     DeletePlan, Direction, IterationDirection, Operation, Plan, Search, SelectPlan, TableReference,
     WhereTerm,
 };
 
-pub fn optimize_plan(plan: &mut Plan) -> Result<()> {
+pub fn optimize_plan(plan: &mut Plan, schema: &Schema) -> Result<()> {
     match plan {
-        Plan::Select(plan) => optimize_select_plan(plan),
-        Plan::Delete(plan) => optimize_delete_plan(plan),
+        Plan::Select(plan) => optimize_select_plan(plan, schema),
+        Plan::Delete(plan) => optimize_delete_plan(plan, schema),
     }
 }
 
@@ -21,8 +24,8 @@ pub fn optimize_plan(plan: &mut Plan) -> Result<()> {
  * TODO: these could probably be done in less passes,
  * but having them separate makes them easier to understand
  */
-fn optimize_select_plan(plan: &mut SelectPlan) -> Result<()> {
-    optimize_subqueries(plan)?;
+fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
+    optimize_subqueries(plan, schema)?;
     rewrite_exprs_select(plan)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?
@@ -33,16 +36,16 @@ fn optimize_select_plan(plan: &mut SelectPlan) -> Result<()> {
 
     use_indexes(
         &mut plan.table_references,
-        &plan.available_indexes,
+        &schema.indexes,
         &mut plan.where_clause,
     )?;
 
-    eliminate_unnecessary_orderby(plan)?;
+    eliminate_unnecessary_orderby(plan, schema)?;
 
     Ok(())
 }
 
-fn optimize_delete_plan(plan: &mut DeletePlan) -> Result<()> {
+fn optimize_delete_plan(plan: &mut DeletePlan, schema: &Schema) -> Result<()> {
     rewrite_exprs_delete(plan)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?
@@ -53,17 +56,17 @@ fn optimize_delete_plan(plan: &mut DeletePlan) -> Result<()> {
 
     use_indexes(
         &mut plan.table_references,
-        &plan.available_indexes,
+        &schema.indexes,
         &mut plan.where_clause,
     )?;
 
     Ok(())
 }
 
-fn optimize_subqueries(plan: &mut SelectPlan) -> Result<()> {
+fn optimize_subqueries(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
     for table in plan.table_references.iter_mut() {
         if let Operation::Subquery { plan, .. } = &mut table.op {
-            optimize_select_plan(&mut *plan)?;
+            optimize_select_plan(&mut *plan, schema)?;
         }
     }
 
@@ -73,7 +76,7 @@ fn optimize_subqueries(plan: &mut SelectPlan) -> Result<()> {
 fn query_is_already_ordered_by(
     table_references: &[TableReference],
     key: &mut ast::Expr,
-    available_indexes: &Vec<Rc<Index>>,
+    available_indexes: &HashMap<String, Vec<Rc<Index>>>,
 ) -> Result<bool> {
     let first_table = table_references.first();
     if first_table.is_none() {
@@ -86,10 +89,9 @@ fn query_is_already_ordered_by(
             Search::RowidEq { .. } => Ok(key.is_rowid_alias_of(0)),
             Search::RowidSearch { .. } => Ok(key.is_rowid_alias_of(0)),
             Search::IndexSearch { index, .. } => {
-                let index_idx = key.check_index_scan(0, &table_reference, available_indexes)?;
-                let index_is_the_same = index_idx
-                    .map(|i| Rc::ptr_eq(&available_indexes[i], index))
-                    .unwrap_or(false);
+                let index_rc = key.check_index_scan(0, &table_reference, available_indexes)?;
+                let index_is_the_same =
+                    index_rc.map(|irc| Rc::ptr_eq(index, &irc)).unwrap_or(false);
                 Ok(index_is_the_same)
             }
         },
@@ -97,7 +99,7 @@ fn query_is_already_ordered_by(
     }
 }
 
-fn eliminate_unnecessary_orderby(plan: &mut SelectPlan) -> Result<()> {
+fn eliminate_unnecessary_orderby(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
     if plan.order_by.is_none() {
         return Ok(());
     }
@@ -115,7 +117,7 @@ fn eliminate_unnecessary_orderby(plan: &mut SelectPlan) -> Result<()> {
     let (key, direction) = o.first_mut().unwrap();
 
     let already_ordered =
-        query_is_already_ordered_by(&plan.table_references, key, &plan.available_indexes)?;
+        query_is_already_ordered_by(&plan.table_references, key, &schema.indexes)?;
 
     if already_ordered {
         push_scan_direction(&mut plan.table_references[0], direction);
@@ -136,7 +138,7 @@ fn eliminate_unnecessary_orderby(plan: &mut SelectPlan) -> Result<()> {
  */
 fn use_indexes(
     table_references: &mut [TableReference],
-    available_indexes: &Vec<Rc<Index>>,
+    available_indexes: &HashMap<String, Vec<Rc<Index>>>,
     where_clause: &mut Vec<WhereTerm>,
 ) -> Result<()> {
     if where_clause.is_empty() {
@@ -274,8 +276,8 @@ pub trait Optimizable {
         &mut self,
         table_index: usize,
         table_reference: &TableReference,
-        available_indexes: &[Rc<Index>],
-    ) -> Result<Option<usize>>;
+        available_indexes: &HashMap<String, Vec<Rc<Index>>>,
+    ) -> Result<Option<Rc<Index>>>;
 }
 
 impl Optimizable for ast::Expr {
@@ -293,19 +295,23 @@ impl Optimizable for ast::Expr {
         &mut self,
         table_index: usize,
         table_reference: &TableReference,
-        available_indexes: &[Rc<Index>],
-    ) -> Result<Option<usize>> {
+        available_indexes: &HashMap<String, Vec<Rc<Index>>>,
+    ) -> Result<Option<Rc<Index>>> {
         match self {
             Self::Column { table, column, .. } => {
                 if *table != table_index {
                     return Ok(None);
                 }
-                for (idx, index) in available_indexes.iter().enumerate() {
-                    if index.table_name == table_reference.table.get_name() {
-                        let column = table_reference.table.get_column_at(*column);
-                        if index.columns.first().unwrap().name == column.name {
-                            return Ok(Some(idx));
-                        }
+                let available_indexes_for_table =
+                    available_indexes.get(table_reference.table.get_name());
+                if available_indexes_for_table.is_none() {
+                    return Ok(None);
+                }
+                let available_indexes_for_table = available_indexes_for_table.unwrap();
+                for index in available_indexes_for_table.iter() {
+                    let column = table_reference.table.get_column_at(*column);
+                    if index.columns.first().unwrap().name == column.name {
+                        return Ok(Some(index.clone()));
                     }
                 }
                 Ok(None)
@@ -489,7 +495,7 @@ pub fn try_extract_index_search_expression(
     cond: &mut WhereTerm,
     table_index: usize,
     table_reference: &TableReference,
-    available_indexes: &[Rc<Index>],
+    available_indexes: &HashMap<String, Vec<Rc<Index>>>,
 ) -> Result<Option<Search>> {
     if cond.eval_at_loop != table_index {
         return Ok(None);
@@ -556,7 +562,7 @@ pub fn try_extract_index_search_expression(
                 }
             }
 
-            if let Some(index_index) =
+            if let Some(index_rc) =
                 lhs.check_index_scan(table_index, &table_reference, available_indexes)?
             {
                 match operator {
@@ -567,7 +573,7 @@ pub fn try_extract_index_search_expression(
                     | ast::Operator::LessEquals => {
                         let rhs_owned = rhs.take_ownership();
                         return Ok(Some(Search::IndexSearch {
-                            index: available_indexes[index_index].clone(),
+                            index: index_rc,
                             cmp_op: *operator,
                             cmp_expr: WhereTerm {
                                 expr: rhs_owned,
@@ -580,7 +586,7 @@ pub fn try_extract_index_search_expression(
                 }
             }
 
-            if let Some(index_index) =
+            if let Some(index_rc) =
                 rhs.check_index_scan(table_index, &table_reference, available_indexes)?
             {
                 match operator {
@@ -591,7 +597,7 @@ pub fn try_extract_index_search_expression(
                     | ast::Operator::LessEquals => {
                         let lhs_owned = lhs.take_ownership();
                         return Ok(Some(Search::IndexSearch {
-                            index: available_indexes[index_index].clone(),
+                            index: index_rc,
                             cmp_op: opposite_cmp_op(*operator),
                             cmp_expr: WhereTerm {
                                 expr: lhs_owned,

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -302,14 +302,13 @@ impl Optimizable for ast::Expr {
                 if *table != table_index {
                     return Ok(None);
                 }
-                let available_indexes_for_table =
-                    available_indexes.get(table_reference.table.get_name());
-                if available_indexes_for_table.is_none() {
+                let Some(available_indexes_for_table) =
+                    available_indexes.get(table_reference.table.get_name())
+                else {
                     return Ok(None);
-                }
-                let available_indexes_for_table = available_indexes_for_table.unwrap();
+                };
+                let column = table_reference.table.get_column_at(*column);
                 for index in available_indexes_for_table.iter() {
-                    let column = table_reference.table.get_column_at(*column);
                     if index.columns.first().unwrap().name == column.name {
                         return Ok(Some(index.clone()));
                     }

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -142,7 +142,7 @@ pub fn emit_order_by(
         let reg = start_reg + i;
         program.emit_insn(Insn::Column {
             cursor_id,
-            column: t_ctx.result_column_indexes_in_orderby_sorter[&i],
+            column: t_ctx.result_column_indexes_in_orderby_sorter[i],
             dest: reg,
         });
     }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -89,8 +89,6 @@ pub struct SelectPlan {
     pub limit: Option<isize>,
     /// offset clause
     pub offset: Option<isize>,
-    /// all the indexes available
-    pub available_indexes: Vec<Rc<Index>>,
     /// query contains a constant condition that is always false
     pub contains_constant_false_condition: bool,
     /// query type (top level or subquery)
@@ -112,8 +110,6 @@ pub struct DeletePlan {
     pub limit: Option<isize>,
     /// offset clause
     pub offset: Option<isize>,
-    /// all the indexes available
-    pub available_indexes: Vec<Rc<Index>>,
     /// query contains a constant condition that is always false
     pub contains_constant_false_condition: bool,
 }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -48,9 +48,30 @@ pub fn prepare_select_plan(
             // Parse the FROM clause into a vec of TableReferences. Fold all the join conditions expressions into the WHERE clause.
             let table_references = parse_from(schema, from, syms, &mut where_predicates)?;
 
+            // Preallocate space for the result columns
+            let result_columns = Vec::with_capacity(
+                columns
+                    .iter()
+                    .map(|c| match c {
+                        // Allocate space for all columns in all tables
+                        ResultColumn::Star => {
+                            table_references.iter().map(|t| t.columns().len()).sum()
+                        }
+                        // Guess 5 columns if we can't find the table using the identifier (maybe it's in [brackets] or `tick_quotes`, or miXeDcAse)
+                        ResultColumn::TableStar(n) => table_references
+                            .iter()
+                            .find(|t| t.identifier == n.0)
+                            .map(|t| t.columns().len())
+                            .unwrap_or(5),
+                        // Otherwise allocate space for 1 column
+                        ResultColumn::Expr(_, _) => 1,
+                    })
+                    .sum(),
+            );
+
             let mut plan = SelectPlan {
                 table_references,
-                result_columns: vec![],
+                result_columns,
                 where_clause: where_predicates,
                 group_by: None,
                 order_by: None,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -21,7 +21,7 @@ pub fn translate_select(
     syms: &SymbolTable,
 ) -> Result<()> {
     let mut select_plan = prepare_select_plan(schema, select, syms)?;
-    optimize_plan(&mut select_plan)?;
+    optimize_plan(&mut select_plan, schema)?;
     emit_program(program, select_plan, syms)
 }
 
@@ -78,7 +78,6 @@ pub fn prepare_select_plan(
                 aggregates: vec![],
                 limit: None,
                 offset: None,
-                available_indexes: schema.indexes.clone().into_values().flatten().collect(),
                 contains_constant_false_condition: false,
                 query_type: SelectQueryType::TopLevel,
             };

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::{
     vdbe::{builder::ProgramBuilder, insn::Insn},
     Result,
@@ -7,6 +5,7 @@ use crate::{
 
 use super::{
     emitter::{emit_query, Resolver, TranslateCtx},
+    main_loop::LoopLabels,
     plan::{Operation, SelectPlan, SelectQueryType, TableReference},
 };
 
@@ -68,14 +67,16 @@ pub fn emit_subquery<'a>(
     }
     let end_coroutine_label = program.allocate_label();
     let mut metadata = TranslateCtx {
-        labels_main_loop: vec![],
+        labels_main_loop: (0..plan.table_references.len())
+            .map(|_| LoopLabels::new(program))
+            .collect(),
         label_main_loop_end: None,
         meta_group_by: None,
-        meta_left_joins: HashMap::new(),
+        meta_left_joins: (0..plan.table_references.len()).map(|_| None).collect(),
         meta_sort: None,
         reg_agg_start: None,
         reg_result_cols_start: None,
-        result_column_indexes_in_orderby_sorter: HashMap::new(),
+        result_column_indexes_in_orderby_sorter: (0..plan.result_columns.len()).collect(),
         result_columns_to_skip_in_orderby_sorter: None,
         reg_limit: plan.limit.map(|_| program.alloc_register()),
         reg_offset: plan.offset.map(|_| program.alloc_register()),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -74,7 +74,7 @@ pub enum BranchOffset {
     /// A label is a named location in the program.
     /// If there are references to it, it must always be resolved to an Offset
     /// via program.resolve_label().
-    Label(i32),
+    Label(u32),
     /// An offset is a direct index into the instruction list.
     Offset(InsnReference),
     /// A placeholder is a temporary value to satisfy the compiler.
@@ -103,7 +103,7 @@ impl BranchOffset {
     }
 
     /// Returns the label value. Panics if the branch offset is an offset or placeholder.
-    pub fn to_label_value(&self) -> i32 {
+    pub fn to_label_value(&self) -> u32 {
         match self {
             BranchOffset::Label(v) => *v,
             BranchOffset::Offset(_) => unreachable!("Offset cannot be converted to label value"),
@@ -116,7 +116,7 @@ impl BranchOffset {
     /// label or placeholder.
     pub fn to_debug_int(&self) -> i32 {
         match self {
-            BranchOffset::Label(v) => *v,
+            BranchOffset::Label(v) => *v as i32,
             BranchOffset::Offset(v) => *v as i32,
             BranchOffset::Placeholder => i32::MAX,
         }


### PR DESCRIPTION
```bash
Prepare `SELECT 1`/Limbo/SELECT 1
                        time:   [765.94 ns 768.26 ns 771.03 ns]
                        change: [-7.8340% -7.4887% -7.1406%] (p = 0.00 < 0.05)
                        Performance has improved.

Prepare `SELECT * FROM users LIMIT 1`/Limbo/SELECT * FROM users LIMIT 1
                        time:   [1.5673 µs 1.5699 µs 1.5731 µs]
                        change: [-10.810% -9.7122% -8.4951%] (p = 0.00 < 0.05)
                        Performance has improved.

Prepare `SELECT first_name, count(1) FROM users GROUP BY first_name HAVING count(1) > 1 ORDER BY cou...
                        time:   [4.1331 µs 4.1421 µs 4.1513 µs]
                        change: [-9.3157% -9.0255% -8.7372%] (p = 0.00 < 0.05)
                        Performance has improved.
```

flamegraph for prepare `SELECT 1`:

<img width="1718" alt="Screenshot 2025-02-03 at 10 34 14" src="https://github.com/user-attachments/assets/ba67fe2f-78b2-4796-9a09-837d8e79fe62" />
