### PR TITLE
dont store insn comments unless the query is EXPLAIN

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -42,6 +42,7 @@ pub use storage::wal::WalFile;
 pub use storage::wal::WalFileShared;
 pub use types::Value;
 use util::parse_schema_rows;
+use vdbe::builder::QueryMode;
 
 pub use error::LimboError;
 use translate::select::prepare_select_plan;
@@ -273,6 +274,7 @@ impl Connection {
                         self.pager.clone(),
                         Rc::downgrade(self),
                         syms,
+                        QueryMode::Normal,
                     )?);
                     Ok(Statement::new(program, self.pager.clone()))
                 }
@@ -307,6 +309,7 @@ impl Connection {
                     self.pager.clone(),
                     Rc::downgrade(self),
                     syms,
+                    QueryMode::Normal,
                 )?);
                 let stmt = Statement::new(program, self.pager.clone());
                 Ok(Some(stmt))
@@ -319,6 +322,7 @@ impl Connection {
                     self.pager.clone(),
                     Rc::downgrade(self),
                     syms,
+                    QueryMode::Explain,
                 )?;
                 program.explain();
                 Ok(None)
@@ -361,6 +365,7 @@ impl Connection {
                         self.pager.clone(),
                         Rc::downgrade(self),
                         syms,
+                        QueryMode::Explain,
                     )?;
                     program.explain();
                 }
@@ -373,6 +378,7 @@ impl Connection {
                         self.pager.clone(),
                         Rc::downgrade(self),
                         syms,
+                        QueryMode::Normal,
                     )?;
 
                     let mut state =

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -28,7 +28,7 @@ use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
 use crate::translate::delete::translate_delete;
 use crate::util::PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX;
-use crate::vdbe::builder::CursorType;
+use crate::vdbe::builder::{CursorType, QueryMode};
 use crate::vdbe::{builder::ProgramBuilder, insn::Insn, Program};
 use crate::{bail_parse_error, Connection, LimboError, Result, SymbolTable};
 use insert::translate_insert;
@@ -46,8 +46,9 @@ pub fn translate(
     pager: Rc<Pager>,
     connection: Weak<Connection>,
     syms: &SymbolTable,
+    query_mode: QueryMode,
 ) -> Result<Program> {
-    let mut program = ProgramBuilder::new();
+    let mut program = ProgramBuilder::new(query_mode);
     let mut change_cnt_on = false;
 
     match stmt {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -377,7 +377,7 @@ pub struct Program {
     pub insns: Vec<Insn>,
     pub cursor_ref: Vec<(Option<String>, CursorType)>,
     pub database_header: Rc<RefCell<DatabaseHeader>>,
-    pub comments: HashMap<InsnReference, &'static str>,
+    pub comments: Option<HashMap<InsnReference, &'static str>>,
     pub parameters: crate::parameters::Parameters,
     pub connection: Weak<Connection>,
     pub auto_commit: bool,
@@ -2551,7 +2551,10 @@ fn trace_insn(program: &Program, addr: InsnReference, insn: &Insn) {
             addr,
             insn,
             String::new(),
-            program.comments.get(&{ addr }).copied()
+            program
+                .comments
+                .as_ref()
+                .and_then(|comments| comments.get(&{ addr }).copied())
         )
     );
 }
@@ -2562,7 +2565,10 @@ fn print_insn(program: &Program, addr: InsnReference, insn: &Insn, indent: Strin
         addr,
         insn,
         indent,
-        program.comments.get(&{ addr }).copied(),
+        program
+            .comments
+            .as_ref()
+            .and_then(|comments| comments.get(&{ addr }).copied()),
     );
     println!("{}", s);
 }


### PR DESCRIPTION
We spend a lot of time especially in `GROUP BY` queries providing helpful comments for `EXPLAIN`, even when the query is not an `EXPLAIN`. So let's not do that

Closes #784 

```sql
Prepare `SELECT first_name, count(1) FROM users GROUP BY first_name HAVING count(1) > 1 ORDER BY cou...
                        time:   [4.2724 µs 4.2783 µs 4.2848 µs]
                        change: [-6.1063% -5.7376% -5.3626%] (p = 0.00 < 0.05)
                        Performance has improved.
```

doesn't affect the other trivial prepare benchmarks