### PR TITLE
Dont fsync the WAL on read queries

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -63,7 +63,7 @@ pub use storage::wal::CheckpointStatus;
 pub use storage::wal::Wal;
 pub static DATABASE_VERSION: OnceLock<String> = OnceLock::new();
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 enum TransactionState {
     Write,
     Read,

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -215,6 +215,11 @@ impl Pager {
         Ok(CheckpointStatus::Done)
     }
 
+    pub fn end_read_tx(&self) -> Result<()> {
+        self.wal.borrow().end_read_tx()?;
+        Ok(())
+    }
+
     /// Reads a page from the database.
     pub fn read_page(&self, page_idx: usize) -> Result<PageRef> {
         trace!("read_page(page_idx = {})", page_idx);


### PR DESCRIPTION
```sql
Execute `SELECT * FROM users LIMIT ?`/Limbo/1
                        time:   [450.92 ns 452.30 ns 453.70 ns]
                        change: [-37.717% -37.400% -37.132%] (p = 0.00 < 0.05)
                        Performance has improved.
Execute `SELECT * FROM users LIMIT ?`/Limbo/10
                        time:   [2.7040 µs 2.7151 µs 2.7267 µs]
                        change: [-11.078% -10.679% -10.272%] (p = 0.00 < 0.05)
                        Performance has improved.
Execute `SELECT * FROM users LIMIT ?`/Limbo/50
                        time:   [12.871 µs 12.933 µs 13.004 µs]
                        change: [-3.9378% -3.4992% -3.0381%] (p = 0.00 < 0.05)
                        Performance has improved.
Execute `SELECT * FROM users LIMIT ?`/Limbo/100
                        time:   [25.638 µs 25.729 µs 25.817 µs]
                        change: [-2.5777% -2.0966% -1.6317%] (p = 0.00 < 0.05)
                        Performance has improved.
Execute `SELECT 1`/Limbo
                        time:   [59.180 ns 59.292 ns 59.414 ns]
                        change: [-81.323% -81.205% -81.094%] (p = 0.00 < 0.05)
                        Performance has improved.
```