### PR TITLE
Implement `json_set`

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -374,7 +374,7 @@ Modifiers:
 | jsonb_remove(json,path,...)        |         |                                                                                                                                              |
 | json_replace(json,path,value,...)  |         |                                                                                                                                              |
 | jsonb_replace(json,path,value,...) |         |                                                                                                                                              |
-| json_set(json,path,value,...)      |         |                                                                                                                                              |
+| json_set(json,path,value,...)      | Yes     |                                                                                                                                              |
 | jsonb_set(json,path,value,...)     |         |                                                                                                                                              |
 | json_type(json)                    | Yes     |                                                                                                                                              |
 | json_type(json,path)               | Yes     |                                                                                                                                              |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "limbo"
-version = "0.0.14"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_time"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "chrono",
  "limbo_ext",

--- a/core/function.rs
+++ b/core/function.rs
@@ -83,6 +83,7 @@ pub enum JsonFunc {
     JsonPatch,
     JsonRemove,
     JsonPretty,
+    JsonSet,
 }
 
 #[cfg(feature = "json")]
@@ -105,6 +106,7 @@ impl Display for JsonFunc {
                 Self::JsonPatch => "json_patch".to_string(),
                 Self::JsonRemove => "json_remove".to_string(),
                 Self::JsonPretty => "json_pretty".to_string(),
+                Self::JsonSet => "json_set".to_string(),
             }
         )
     }
@@ -540,6 +542,8 @@ impl Func {
             "json_remove" => Ok(Self::Json(JsonFunc::JsonRemove)),
             #[cfg(feature = "json")]
             "json_pretty" => Ok(Self::Json(JsonFunc::JsonPretty)),
+            #[cfg(feature = "json")]
+            "json_set" => Ok(Self::Json(JsonFunc::JsonSet)),
             "unixepoch" => Ok(Self::Scalar(ScalarFunc::UnixEpoch)),
             "julianday" => Ok(Self::Scalar(ScalarFunc::JulianDay)),
             "hex" => Ok(Self::Scalar(ScalarFunc::Hex)),

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -918,14 +918,16 @@ pub fn translate_expr(
                             func_ctx,
                         )
                     }
-                    JsonFunc::JsonArray | JsonFunc::JsonExtract => translate_function(
-                        program,
-                        args.as_deref().unwrap_or_default(),
-                        referenced_tables,
-                        resolver,
-                        target_register,
-                        func_ctx,
-                    ),
+                    JsonFunc::JsonArray | JsonFunc::JsonExtract | JsonFunc::JsonSet => {
+                        translate_function(
+                            program,
+                            args.as_deref().unwrap_or_default(),
+                            referenced_tables,
+                            resolver,
+                            target_register,
+                            func_ctx,
+                        )
+                    }
                     JsonFunc::JsonArrowExtract | JsonFunc::JsonArrowShiftExtract => {
                         unreachable!(
                             "These two functions are only reachable via the -> and ->> operators"

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -47,7 +47,7 @@ use crate::{
     function::JsonFunc, json::get_json, json::is_json_valid, json::json_array,
     json::json_array_length, json::json_arrow_extract, json::json_arrow_shift_extract,
     json::json_error_position, json::json_extract, json::json_object, json::json_patch,
-    json::json_remove, json::json_type,
+    json::json_remove, json::json_set, json::json_type,
 };
 use crate::{resolve_ext_path, Connection, Result, TransactionState, DATABASE_VERSION};
 use datetime::{
@@ -1836,6 +1836,18 @@ impl Program {
 
                                 let json_str = get_json(json_value, Some(indent))?;
                                 state.registers[*dest] = json_str;
+                            }
+                            JsonFunc::JsonSet => {
+                                let reg_values =
+                                    &state.registers[*start_reg + 1..*start_reg + arg_count];
+
+                                let json_result =
+                                    json_set(&state.registers[*start_reg], reg_values);
+
+                                match json_result {
+                                    Ok(json) => state.registers[*dest] = json,
+                                    Err(e) => return Err(e),
+                                }
                             }
                         },
                         crate::function::Func::Scalar(scalar_func) => match scalar_func {

--- a/testing/json.test
+++ b/testing/json.test
@@ -826,3 +826,55 @@ do_execsql_test json-remove-6 {
 do_execsql_test json-remove-7 {
     SELECT json_remove('{"a": 1, "b": [1,2], "c": {"d": 3}}', '$.a', '$.b[0]', '$.c.d');
 } {{{"b":[2],"c":{}}}}
+
+do_execsql_test json_set_field_empty_object {
+   SELECT json_set('{}', '$.field', 'value');
+} {{{"field":"value"}}}
+
+do_execsql_test json_set_replace_field {
+   SELECT json_set('{"field":"old_value"}', '$.field', 'new_value');
+} {{{"field":"new_value"}}}
+
+do_execsql_test json_set_set_deeply_nested_key {
+   SELECT json_set('{}', '$.object.doesnt.exist', 'value');
+} {{{"object":{"doesnt":{"exist":"value"}}}}}
+
+do_execsql_test json_set_add_value_to_empty_array {
+   SELECT json_set('[]', '$[0]', 'value');
+} {{["value"]}}
+
+do_execsql_test json_set_add_value_to_nonexistent_array {
+   SELECT json_set('{}', '$.some_array[0]', 123);
+} {{{"some_array":[123]}}}
+
+do_execsql_test json_set_add_value_to_array {
+   SELECT json_set('[123]', '$[1]', 456);
+} {{[123,456]}}
+
+do_execsql_test json_set_add_value_to_array_out_of_bounds {
+   SELECT json_set('[123]', '$[200]', 456);
+} {{[123]}}
+
+do_execsql_test json_set_replace_value_in_array {
+   SELECT json_set('[123]', '$[0]', 456);
+} {{[456]}}
+
+do_execsql_test json_set_null_path {
+   SELECT json_set('{}', NULL, 456);
+} {{{}}}
+
+do_execsql_test json_set_multiple_keys {
+   SELECT json_set('[123]', '$[0]', 456, '$[1]', 789);
+} {{[456,789]}}
+
+do_execsql_test json_set_add_array_in_nested_object {
+   SELECT json_set('{}', '$.object[0].field', 123);
+} {{{"object":[{"field":123}]}}}
+
+do_execsql_test json_set_add_array_in_array_in_nested_object {
+   SELECT json_set('{}', '$.object[0][0]', 123);
+} {{{"object":[[123]]}}}
+
+do_execsql_test json_set_add_array_in_array_in_nested_object_out_of_bounds {
+   SELECT json_set('{}', '$.object[123].another', 'value', '$.field', 'value');
+} {{{"field":"value"}}}


### PR DESCRIPTION
This PR adds support for `json_set`.

There are three helper functions added:
1. `json_path_from_owned_value`, this function turns an `OwnedValue` into a `JsonPath`.
2. `find_or_create_target`, this function is similar to `find_target` with the added bonus of creating the target if it doesn't exist. There is a caveat with this function and that is that it will create objects/arrays as it goes, meaning if you send `{}` into it and try getting the path `$.some.nested.array[123].field`, it will return `{"some":{"nested":array:[]}}` since creation of `some`, `nested` and `array` will succeed, but accessing element `123` will fail.
3. `create_and_mutate_json_by_path`, this function is very similar to `mutate_json_by_path` but calls `find_or_create_target` instead of `find_target`
 
Related to #127 

---

Related questions: (This is my first PR in this project :) )
How do I test for errors in testing/\*.test files? I added `{{Runtime errror: ...}}` and it worked fine when running `make test` but it failed in CI?
How do I run all the CI on my machine? Just so I don't have to force-push as much, I did `cargo clippy --fix` but it gave changes in unrelated files.

Also, sorry for the messy Github log, I opened this PR as a draft and wrote some questions, before making it into a real PR. And while waiting for CI to finish I discovered a couple of edge cases that didn't work like sqlite did, all of those have been fixed now and test cases have been added. Some day I'll get the hang of the workflow and I'll be more thorough in the future!