### PR TITLE
Fix `Parser` continuing to parse after encountering an error

### DIFF
--- a/vendored/sqlite3-parser/src/lexer/sql/test.rs
+++ b/vendored/sqlite3-parser/src/lexer/sql/test.rs
@@ -339,6 +339,21 @@ fn qualified_table_name_within_triggers() {
 }
 
 #[test]
+fn select_from_error_stops_at_first_error() {
+    let mut parser = Parser::new(b"SELECT FROM foo;");
+
+    // First next() call should return the first syntax error
+    let err = parser.next().unwrap_err();
+    assert!(matches!(err, Error::ParserError(_, _, _)));
+
+    // Second next() call should return Ok(None) since parsing should have stopped
+    assert_eq!(parser.next().unwrap(), None);
+
+    // Third next() call should also return Ok(None)
+    assert_eq!(parser.next().unwrap(), None);
+}
+
+#[test]
 fn indexed_by_clause_within_triggers() {
     expect_parser_err_msg(
         b"CREATE TRIGGER main.t16err5 AFTER INSERT ON tA BEGIN


### PR DESCRIPTION
Added  `had_true: bool` to `Parser` to track the state of error encounter, this will be set to `true` once we encounter an error.

If `had_error` is set to true we early return `Ok(None)`.


`FallibleIterator` works in the following way [when `next()` returns](https://docs.rs/fallible-iterator/latest/fallible_iterator/trait.FallibleIterator.html#tymethod.next):
- `Ok(Some(item))` if there's a valid next item.
- `Ok(None)` if the iteration is complete.
- `Err(e)` if there's an error. 


I have also added a unit test to check the above contract holds when parsing `SELECT FROM foo`.

After the fix:

```
limbo> SELECT FROM foo;

  × near "FROM": syntax error at (1, 12)
   ╭────
 1 │ SELECT FROM foo; 
   ·           ▲
   ·           ╰── syntax error
   ╰────
```

Closes #865 