### PR TITLE
core: Kill Statement::query() method

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -59,9 +59,8 @@ fn bench(criterion: &mut Criterion) {
                 .unwrap();
             let io = io.clone();
             b.iter(|| {
-                let mut rows = stmt.query().unwrap();
                 loop {
-                    match rows.step().unwrap() {
+                    match stmt.step().unwrap() {
                         limbo_core::StepResult::Row(row) => {
                             black_box(row);
                         }
@@ -106,9 +105,8 @@ fn bench(criterion: &mut Criterion) {
         let mut stmt = limbo_conn.prepare("SELECT 1").unwrap();
         let io = io.clone();
         b.iter(|| {
-            let mut rows = stmt.query().unwrap();
             loop {
-                match rows.step().unwrap() {
+                match stmt.step().unwrap() {
                     limbo_core::StepResult::Row(row) => {
                         black_box(row);
                     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -474,11 +474,6 @@ impl Statement {
         }
     }
 
-    pub fn query(&mut self) -> Result<Statement> {
-        let stmt = Statement::new(self.program.clone(), self.pager.clone());
-        Ok(stmt)
-    }
-
     pub fn columns(&self) -> &[String] {
         &self.program.columns
     }


### PR DESCRIPTION
It's a pointless wrapper on top of `step()` that introduce additional memory allocation and deallocation.