### PR TITLE
core: Fix benchmark panic if syscall is interrupted

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -66,7 +66,7 @@ fn bench(criterion: &mut Criterion) {
                             black_box(row);
                         }
                         limbo_core::StepResult::IO => {
-                            io.run_once().unwrap();
+                            let _ = io.run_once();
                         }
                         limbo_core::StepResult::Done => {
                             break;
@@ -113,7 +113,7 @@ fn bench(criterion: &mut Criterion) {
                         black_box(row);
                     }
                     limbo_core::StepResult::IO => {
-                        io.run_once().unwrap();
+                        let _ = io.run_once();
                     }
                     limbo_core::StepResult::Done => {
                         break;


### PR DESCRIPTION
Fixes the following panics:

Benchmarking Execute `SELECT * FROM users LIMIT ?`/Limbo/100: Profiling for 5.0000 sthread 'main' panicked at core/benches/benchmark.rs:69:43:
called `Result::unwrap()` on an `Err` value: IOError(Os { code: 4, kind: Interrupted, message: "Interrupted system call" })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace