### PR TITLE
core: Switch to parking_lot for RwLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,6 +1590,7 @@ dependencies = [
  "miette",
  "mimalloc",
  "mockall",
+ "parking_lot",
  "pest",
  "pest_derive",
  "polling",
@@ -1681,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_time"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "chrono",
  "limbo_ext",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -69,6 +69,7 @@ limbo_percentile = { path = "../extensions/percentile", optional = true, feature
 limbo_time = { path = "../extensions/time", optional = true, features = ["static"] }
 miette = "7.4.0"
 strum = "0.26"
+parking_lot = "0.12.3"
 
 [build-dependencies]
 chrono = "0.4.38"

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -24,13 +24,14 @@ use fallible_iterator::FallibleIterator;
 use libloading::{Library, Symbol};
 use limbo_ext::{ExtensionApi, ExtensionEntryPoint};
 use log::trace;
+use parking_lot::RwLock;
 use schema::Schema;
 use sqlite3_parser::ast;
 use sqlite3_parser::{ast::Cmd, lexer::sql::Parser};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::num::NonZero;
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, OnceLock};
 use std::{cell::RefCell, rc::Rc};
 use storage::btree::btree_init_page;
 #[cfg(feature = "fs")]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -49,10 +49,11 @@ use crate::storage::pager::Pager;
 use crate::types::{OwnedRecord, OwnedValue};
 use crate::{File, Result};
 use log::trace;
+use parking_lot::RwLock;
 use std::cell::RefCell;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use super::pager::PageRef;
 
@@ -1147,7 +1148,7 @@ pub fn begin_read_wal_header(io: &Rc<dyn File>) -> Result<Arc<RwLock<WalHeader>>
 fn finish_read_wal_header(buf: Rc<RefCell<Buffer>>, header: Arc<RwLock<WalHeader>>) -> Result<()> {
     let buf = buf.borrow();
     let buf = buf.as_slice();
-    let mut header = header.write().unwrap();
+    let mut header = header.write();
     header.magic = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
     header.file_format = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]);
     header.page_size = u32::from_be_bytes([buf[8], buf[9], buf[10], buf[11]]);


### PR DESCRIPTION
We really need to make the WAL lock less expensive, but switching to `parking_lot` is anyway something we should do.

Before:

```
Execute `SELECT 1`/Limbo
                        time:   [56.230 ns 56.463 ns 56.688 ns]
```

After:

```
Execute `SELECT 1`/Limbo
                        time:   [52.003 ns 52.132 ns 52.287 ns]
```