### PR TITLE
prepare perf: dont eagerly allocate result column name strings

### DIFF
--- a/bindings/go/rs_src/rows.rs
+++ b/bindings/go/rs_src/rows.rs
@@ -103,7 +103,7 @@ pub extern "C" fn rows_get_columns(rows_ptr: *mut c_void) -> i32 {
         return -1;
     }
     let rows = LimboRows::from_ptr(rows_ptr);
-    rows.stmt.columns().len() as i32
+    rows.stmt.num_columns() as i32
 }
 
 /// Returns a pointer to a string with the name of the column at the given index.
@@ -115,11 +115,16 @@ pub extern "C" fn rows_get_column_name(rows_ptr: *mut c_void, idx: i32) -> *cons
         return std::ptr::null_mut();
     }
     let rows = LimboRows::from_ptr(rows_ptr);
-    if idx < 0 || idx as usize >= rows.stmt.columns().len() {
+    if idx < 0 || idx as usize >= rows.stmt.num_columns() {
         return std::ptr::null_mut();
     }
-    let name = &rows.stmt.columns()[idx as usize];
-    let cstr = std::ffi::CString::new(name.as_bytes()).expect("Failed to create CString");
+    let name = rows.stmt.get_column_name(idx as usize);
+    let cstr = std::ffi::CString::new(
+        name.as_ref()
+            .unwrap_or(&&format!("column_{}", idx))
+            .as_bytes(),
+    )
+    .expect("Failed to create CString");
     cstr.into_raw() as *const c_char
 }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -470,8 +470,12 @@ impl Statement {
         self.program.step(&mut self.state, self.pager.clone())
     }
 
-    pub fn columns(&self) -> &[String] {
-        &self.program.columns
+    pub fn num_columns(&self) -> usize {
+        self.program.result_columns.len()
+    }
+
+    pub fn get_column_name(&self, idx: usize) -> Option<&String> {
+        self.program.result_columns[idx].name(&self.program.table_references)
     }
 
     pub fn parameters(&self) -> &parameters::Parameters {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -129,7 +129,7 @@ impl BTreeTable {
     pub fn get_column(&self, name: &str) -> Option<(usize, &Column)> {
         let name = normalize_ident(name);
         for (i, column) in self.columns.iter().enumerate() {
-            if column.name == name {
+            if column.name.as_ref().map_or(false, |n| *n == name) {
                 return Some((i, column));
             }
         }
@@ -155,7 +155,7 @@ impl BTreeTable {
                 sql.push_str(",\n");
             }
             sql.push_str("  ");
-            sql.push_str(&column.name);
+            sql.push_str(&column.name.as_ref().expect("column name is None"));
             sql.push(' ');
             sql.push_str(&column.ty.to_string());
         }
@@ -180,7 +180,7 @@ impl PseudoTable {
 
     pub fn add_column(&mut self, name: &str, ty: Type, primary_key: bool) {
         self.columns.push(Column {
-            name: normalize_ident(name),
+            name: Some(normalize_ident(name)),
             ty,
             ty_str: ty.to_string(),
             primary_key,
@@ -192,7 +192,7 @@ impl PseudoTable {
     pub fn get_column(&self, name: &str) -> Option<(usize, &Column)> {
         let name = normalize_ident(name);
         for (i, column) in self.columns.iter().enumerate() {
-            if column.name == name {
+            if column.name.as_ref().map_or(false, |n| *n == name) {
                 return Some((i, column));
             }
         }
@@ -315,7 +315,7 @@ fn create_table(
                 }
 
                 cols.push(Column {
-                    name: normalize_ident(&name),
+                    name: Some(normalize_ident(&name)),
                     ty,
                     ty_str,
                     primary_key,
@@ -366,7 +366,7 @@ pub fn _build_pseudo_table(columns: &[ResultColumn]) -> PseudoTable {
 
 #[derive(Debug, Clone)]
 pub struct Column {
-    pub name: String,
+    pub name: Option<String>,
     pub ty: Type,
     // many sqlite operations like table_info retain the original string
     pub ty_str: String,
@@ -408,7 +408,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
         primary_key_column_names: vec![],
         columns: vec![
             Column {
-                name: "type".to_string(),
+                name: Some("type".to_string()),
                 ty: Type::Text,
                 ty_str: "TEXT".to_string(),
                 primary_key: false,
@@ -417,7 +417,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 default: None,
             },
             Column {
-                name: "name".to_string(),
+                name: Some("name".to_string()),
                 ty: Type::Text,
                 ty_str: "TEXT".to_string(),
                 primary_key: false,
@@ -426,7 +426,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 default: None,
             },
             Column {
-                name: "tbl_name".to_string(),
+                name: Some("tbl_name".to_string()),
                 ty: Type::Text,
                 ty_str: "TEXT".to_string(),
                 primary_key: false,
@@ -435,7 +435,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 default: None,
             },
             Column {
-                name: "rootpage".to_string(),
+                name: Some("rootpage".to_string()),
                 ty: Type::Integer,
                 ty_str: "INT".to_string(),
                 primary_key: false,
@@ -444,7 +444,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 default: None,
             },
             Column {
-                name: "sql".to_string(),
+                name: Some("sql".to_string()),
                 ty: Type::Text,
                 ty_str: "TEXT".to_string(),
                 primary_key: false,
@@ -911,7 +911,7 @@ mod tests {
             has_rowid: true,
             primary_key_column_names: vec!["nonexistent".to_string()],
             columns: vec![Column {
-                name: "a".to_string(),
+                name: Some("a".to_string()),
                 ty: Type::Integer,
                 ty_str: "INT".to_string(),
                 primary_key: false,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -187,11 +187,8 @@ fn emit_program_for_select(
 
     // Finalize program
     epilogue(program, init_label, start_offset)?;
-    program.columns = plan
-        .result_columns
-        .iter()
-        .map(|rc| rc.name.clone())
-        .collect::<Vec<_>>();
+    program.result_columns = plan.result_columns;
+    program.table_references = plan.table_references;
     Ok(())
 }
 
@@ -320,11 +317,8 @@ fn emit_program_for_delete(
 
     // Finalize program
     epilogue(program, init_label, start_offset)?;
-    program.columns = plan
-        .result_columns
-        .iter()
-        .map(|rc| rc.name.clone())
-        .collect::<Vec<_>>();
+    program.result_columns = plan.result_columns;
+    program.table_references = plan.table_references;
     Ok(())
 }
 

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -2096,32 +2096,6 @@ pub fn translate_and_mark(
     Ok(target_register)
 }
 
-/// Get an appropriate name for an expression.
-/// If the query provides an alias (e.g. `SELECT a AS b FROM t`), use that (e.g. `b`).
-/// If the expression is a column from a table, use the column name (e.g. `a`).
-/// Otherwise we just use a generic fallback name (e.g. `expr_<index>`).
-pub fn get_name(
-    maybe_alias: Option<&ast::As>,
-    expr: &ast::Expr,
-    referenced_tables: &[TableReference],
-    fallback: impl Fn() -> String,
-) -> String {
-    let alias = maybe_alias.map(|a| match a {
-        ast::As::As(id) => id.0.clone(),
-        ast::As::Elided(id) => id.0.clone(),
-    });
-    if let Some(alias) = alias {
-        return alias;
-    }
-    match expr {
-        ast::Expr::Column { table, column, .. } => {
-            let table_reference = referenced_tables.get(*table).unwrap();
-            table_reference.table.get_column_at(*column).name.clone()
-        }
-        _ => fallback(),
-    }
-}
-
 /// Sanitaizes a string literal by removing single quote at front and back
 /// and escaping double single quotes
 pub fn sanitize_string(input: &str) -> String {

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -167,8 +167,8 @@ pub fn emit_group_by<'a>(
     // sorter column names do not matter
     let ty = crate::schema::Type::Null;
     let pseudo_columns = (0..sorter_column_count)
-        .map(|i| Column {
-            name: i.to_string(),
+        .map(|_| Column {
+            name: None,
             primary_key: false,
             ty,
             ty_str: ty.to_string(),

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -309,7 +309,11 @@ impl Optimizable for ast::Expr {
                 };
                 let column = table_reference.table.get_column_at(*column);
                 for index in available_indexes_for_table.iter() {
-                    if index.columns.first().unwrap().name == column.name {
+                    if column
+                        .name
+                        .as_ref()
+                        .map_or(false, |name| *name == index.columns.first().unwrap().name)
+                    {
                         return Ok(Some(index.clone()));
                     }
                 }

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -66,11 +66,11 @@ pub fn emit_order_by(
     let sort_loop_next_label = program.allocate_label();
     let sort_loop_end_label = program.allocate_label();
     let mut pseudo_columns = vec![];
-    for (i, _) in order_by.iter().enumerate() {
+    for _ in 0..order_by.len() {
         let ty = crate::schema::Type::Null;
         pseudo_columns.push(Column {
             // Names don't matter. We are tracking which result column is in which position in the ORDER BY clause in m.result_column_indexes_in_orderby_sorter.
-            name: format!("sort_key_{}", i),
+            name: None,
             primary_key: false,
             ty,
             ty_str: ty.to_string(),
@@ -79,7 +79,7 @@ pub fn emit_order_by(
             default: None,
         });
     }
-    for (i, rc) in result_columns.iter().enumerate() {
+    for i in 0..result_columns.len() {
         // If any result columns are not in the ORDER BY sorter, it's because they are equal to a sort key and were already added to the pseudo columns above.
         if let Some(ref v) = t_ctx.result_columns_to_skip_in_orderby_sorter {
             if v.contains(&i) {
@@ -88,7 +88,7 @@ pub fn emit_order_by(
         }
         let ty = crate::schema::Type::Null;
         pseudo_columns.push(Column {
-            name: rc.expr.to_string(),
+            name: None,
             primary_key: false,
             ty,
             ty_str: ty.to_string(),

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -210,7 +210,7 @@ fn query_pragma(
                     // cid
                     program.emit_int(i as i64, base_reg);
                     // name
-                    program.emit_string8(column.name.clone(), base_reg + 1);
+                    program.emit_string8(column.name.clone().unwrap_or_default(), base_reg + 1);
 
                     // type
                     program.emit_string8(column.ty_str.clone(), base_reg + 2);

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1,5 +1,4 @@
 use super::emitter::emit_program;
-use super::expr::get_name;
 use super::plan::{select_star, SelectQueryType};
 use crate::function::{AggFunc, ExtFunc, Func};
 use crate::translate::optimizer::optimize_plan;
@@ -83,7 +82,7 @@ pub fn prepare_select_plan(
             };
 
             let mut aggregate_expressions = Vec::new();
-            for (result_column_idx, column) in columns.iter_mut().enumerate() {
+            for column in columns.iter_mut() {
                 match column {
                     ResultColumn::Star => {
                         select_star(&plan.table_references, &mut plan.result_columns);
@@ -108,7 +107,7 @@ pub fn prepare_select_plan(
                                     column: idx,
                                     is_rowid_alias: col.is_rowid_alias,
                                 },
-                                name: col.name.clone(),
+                                alias: None,
                                 contains_aggregates: false,
                             });
                         }
@@ -158,12 +157,10 @@ pub fn prepare_select_plan(
                                         };
                                         aggregate_expressions.push(agg.clone());
                                         plan.result_columns.push(ResultSetColumn {
-                                            name: get_name(
-                                                maybe_alias.as_ref(),
-                                                expr,
-                                                &plan.table_references,
-                                                || format!("expr_{}", result_column_idx),
-                                            ),
+                                            alias: maybe_alias.as_ref().map(|alias| match alias {
+                                                ast::As::Elided(alias) => alias.0.clone(),
+                                                ast::As::As(alias) => alias.0.clone(),
+                                            }),
                                             expr: expr.clone(),
                                             contains_aggregates: true,
                                         });
@@ -172,12 +169,10 @@ pub fn prepare_select_plan(
                                         let contains_aggregates =
                                             resolve_aggregates(expr, &mut aggregate_expressions);
                                         plan.result_columns.push(ResultSetColumn {
-                                            name: get_name(
-                                                maybe_alias.as_ref(),
-                                                expr,
-                                                &plan.table_references,
-                                                || format!("expr_{}", result_column_idx),
-                                            ),
+                                            alias: maybe_alias.as_ref().map(|alias| match alias {
+                                                ast::As::Elided(alias) => alias.0.clone(),
+                                                ast::As::As(alias) => alias.0.clone(),
+                                            }),
                                             expr: expr.clone(),
                                             contains_aggregates,
                                         });
@@ -191,12 +186,14 @@ pub fn prepare_select_plan(
                                                     &mut aggregate_expressions,
                                                 );
                                                 plan.result_columns.push(ResultSetColumn {
-                                                    name: get_name(
-                                                        maybe_alias.as_ref(),
-                                                        expr,
-                                                        &plan.table_references,
-                                                        || format!("expr_{}", result_column_idx),
-                                                    ),
+                                                    alias: maybe_alias.as_ref().map(|alias| {
+                                                        match alias {
+                                                            ast::As::Elided(alias) => {
+                                                                alias.0.clone()
+                                                            }
+                                                            ast::As::As(alias) => alias.0.clone(),
+                                                        }
+                                                    }),
                                                     expr: expr.clone(),
                                                     contains_aggregates,
                                                 });
@@ -208,12 +205,14 @@ pub fn prepare_select_plan(
                                                 };
                                                 aggregate_expressions.push(agg.clone());
                                                 plan.result_columns.push(ResultSetColumn {
-                                                    name: get_name(
-                                                        maybe_alias.as_ref(),
-                                                        expr,
-                                                        &plan.table_references,
-                                                        || format!("expr_{}", result_column_idx),
-                                                    ),
+                                                    alias: maybe_alias.as_ref().map(|alias| {
+                                                        match alias {
+                                                            ast::As::Elided(alias) => {
+                                                                alias.0.clone()
+                                                            }
+                                                            ast::As::As(alias) => alias.0.clone(),
+                                                        }
+                                                    }),
                                                     expr: expr.clone(),
                                                     contains_aggregates: true,
                                                 });
@@ -242,12 +241,10 @@ pub fn prepare_select_plan(
                                     };
                                     aggregate_expressions.push(agg.clone());
                                     plan.result_columns.push(ResultSetColumn {
-                                        name: get_name(
-                                            maybe_alias.as_ref(),
-                                            expr,
-                                            &plan.table_references,
-                                            || format!("expr_{}", result_column_idx),
-                                        ),
+                                        alias: maybe_alias.as_ref().map(|alias| match alias {
+                                            ast::As::Elided(alias) => alias.0.clone(),
+                                            ast::As::As(alias) => alias.0.clone(),
+                                        }),
                                         expr: expr.clone(),
                                         contains_aggregates: true,
                                     });
@@ -262,12 +259,10 @@ pub fn prepare_select_plan(
                                 let contains_aggregates =
                                     resolve_aggregates(expr, &mut aggregate_expressions);
                                 plan.result_columns.push(ResultSetColumn {
-                                    name: get_name(
-                                        maybe_alias.as_ref(),
-                                        expr,
-                                        &plan.table_references,
-                                        || format!("expr_{}", result_column_idx),
-                                    ),
+                                    alias: maybe_alias.as_ref().map(|alias| match alias {
+                                        ast::As::Elided(alias) => alias.0.clone(),
+                                        ast::As::As(alias) => alias.0.clone(),
+                                    }),
                                     expr: expr.clone(),
                                     contains_aggregates,
                                 });

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -8,6 +8,7 @@ use crate::{
     parameters::Parameters,
     schema::{BTreeTable, Index, PseudoTable},
     storage::sqlite3_ondisk::DatabaseHeader,
+    translate::plan::{ResultSetColumn, TableReference},
     Connection,
 };
 
@@ -29,7 +30,8 @@ pub struct ProgramBuilder {
     // map of instruction index to manual comment (used in EXPLAIN only)
     comments: Option<HashMap<InsnReference, &'static str>>,
     pub parameters: Parameters,
-    pub columns: Vec<String>,
+    pub result_columns: Vec<ResultSetColumn>,
+    pub table_references: Vec<TableReference>,
 }
 
 #[derive(Debug, Clone)]
@@ -69,7 +71,8 @@ impl ProgramBuilder {
                 None
             },
             parameters: Parameters::new(),
-            columns: Vec::new(),
+            result_columns: Vec::new(),
+            table_references: Vec::new(),
         }
     }
 
@@ -437,7 +440,8 @@ impl ProgramBuilder {
             parameters: self.parameters,
             n_change: Cell::new(0),
             change_cnt_on,
-            columns: self.columns,
+            result_columns: self.result_columns,
+            table_references: self.table_references,
         }
     }
 }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -409,15 +409,18 @@ pub fn insn_to_str(
                 dest,
             } => {
                 let (table_identifier, cursor_type) = &program.cursor_ref[*cursor_id];
-                let column_name = match cursor_type {
+                let column_name: Option<&String> = match cursor_type {
                     CursorType::BTreeTable(table) => {
-                        Some(&table.columns.get(*column).unwrap().name)
+                        let name = table.columns.get(*column).unwrap().name.as_ref();
+                        name
                     }
                     CursorType::BTreeIndex(index) => {
-                        Some(&index.columns.get(*column).unwrap().name)
+                        let name = &index.columns.get(*column).unwrap().name;
+                        Some(name)
                     }
                     CursorType::Pseudo(pseudo_table) => {
-                        Some(&pseudo_table.columns.get(*column).unwrap().name)
+                        let name = pseudo_table.columns.get(*column).unwrap().name.as_ref();
+                        name
                     }
                     CursorType::Sorter => None,
                 };

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -35,6 +35,7 @@ use crate::result::LimboResult;
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
 use crate::storage::wal::CheckpointResult;
 use crate::storage::{btree::BTreeCursor, pager::Pager};
+use crate::translate::plan::{ResultSetColumn, TableReference};
 use crate::types::{
     AggContext, Cursor, CursorResult, ExternalAggState, OwnedRecord, OwnedValue, Record, SeekKey,
     SeekOp,
@@ -387,7 +388,8 @@ pub struct Program {
     pub auto_commit: bool,
     pub n_change: Cell<i64>,
     pub change_cnt_on: bool,
-    pub columns: Vec<String>,
+    pub result_columns: Vec<ResultSetColumn>,
+    pub table_references: Vec<TableReference>,
 }
 
 impl Program {

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -97,30 +97,30 @@ mod tests {
 
         let stmt = conn.prepare("select * from test;")?;
 
-        let columns = stmt.columns();
-        assert_eq!(columns.len(), 3);
-        assert_eq!(&columns[0], "foo");
-        assert_eq!(&columns[1], "bar");
-        assert_eq!(&columns[2], "baz");
+        let columns = stmt.num_columns();
+        assert_eq!(columns, 3);
+        assert_eq!(stmt.get_column_name(0), Some(&"foo".to_string()));
+        assert_eq!(stmt.get_column_name(1), Some(&"bar".to_string()));
+        assert_eq!(stmt.get_column_name(2), Some(&"baz".to_string()));
 
         let stmt = conn.prepare("select foo, bar from test;")?;
 
-        let columns = stmt.columns();
-        assert_eq!(columns.len(), 2);
-        assert_eq!(&columns[0], "foo");
-        assert_eq!(&columns[1], "bar");
+        let columns = stmt.num_columns();
+        assert_eq!(columns, 2);
+        assert_eq!(stmt.get_column_name(0), Some(&"foo".to_string()));
+        assert_eq!(stmt.get_column_name(1), Some(&"bar".to_string()));
 
         let stmt = conn.prepare("delete from test;")?;
-        let columns = stmt.columns();
-        assert_eq!(columns.len(), 0);
+        let columns = stmt.num_columns();
+        assert_eq!(columns, 0);
 
         let stmt = conn.prepare("insert into test (foo, bar, baz) values (1, 2, 3);")?;
-        let columns = stmt.columns();
-        assert_eq!(columns.len(), 0);
+        let columns = stmt.num_columns();
+        assert_eq!(columns, 0);
 
         let stmt = conn.prepare("delete from test where foo = 1")?;
-        let columns = stmt.columns();
-        assert_eq!(columns.len(), 0);
+        let columns = stmt.num_columns();
+        assert_eq!(columns, 0);
 
         Ok(())
     }


### PR DESCRIPTION
- Remove eagerly allocated `name` from `ResultSetColumn`
- `ResultSetColumn` can calculate `name()` on demand:
    - if it has an alias (`foo as bar`), use that
    - if it is a column reference, use that
    - otherwise return none, and callers can assign it a placeholder name (like `column_1`)
- move the `plan.result_columns` and `plan.table_references` to `Program` after preparing statement is done, so that column names can be returned upon request
- make `name` in `Column` optional, not needed for pseudo tables and sorters so avoids an extra string allocation


```sql
Prepare `SELECT 1`/Limbo/SELECT 1
                        time:   [756.80 ns 758.27 ns 760.04 ns]
                        change: [-3.3257% -3.0252% -2.7035%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low severe
  3 (3.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

Prepare `SELECT * FROM users LIMIT 1`/Limbo/SELECT * FROM users LIMIT 1
                        time:   [1.4646 µs 1.4669 µs 1.4696 µs]
                        change: [-6.4769% -6.2021% -5.9137%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high severe

Prepare `SELECT first_name, count(1) FROM users GROUP BY first_name HAVING count(1) > 1 ORDER BY cou...`
                        time:   [3.7256 µs 3.7311 µs 3.7376 µs]
                        change: [-4.5195% -4.2192% -3.9309%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
```
