### PR TITLE
prepare perf: make ProgramBuilder aware of plan to count/estimate required memory

### DIFF
--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -52,18 +52,25 @@ pub enum QueryMode {
     Explain,
 }
 
+pub struct ProgramBuilderOpts {
+    pub query_mode: QueryMode,
+    pub num_cursors: usize,
+    pub approx_num_insns: usize,
+    pub approx_num_labels: usize,
+}
+
 impl ProgramBuilder {
-    pub fn new(query_mode: QueryMode) -> Self {
+    pub fn new(opts: ProgramBuilderOpts) -> Self {
         Self {
             next_free_register: 1,
             next_free_cursor_id: 0,
-            insns: Vec::new(),
+            insns: Vec::with_capacity(opts.approx_num_insns),
             next_insn_label: None,
-            cursor_ref: Vec::new(),
+            cursor_ref: Vec::with_capacity(opts.num_cursors),
             constant_insns: Vec::new(),
-            label_to_resolved_offset: Vec::with_capacity(4), // 4 is arbitrary, we guess to assign at least this much
+            label_to_resolved_offset: Vec::with_capacity(opts.approx_num_labels),
             seekrowid_emitted_bitmask: 0,
-            comments: if query_mode == QueryMode::Explain {
+            comments: if opts.query_mode == QueryMode::Explain {
                 Some(HashMap::new())
             } else {
                 None


### PR DESCRIPTION
Use knowledge of query plan to inform how much memory to initially allocate for `ProgramBuilder` vectors

Some of them are exact, some are semi-random estimates

```sql
Prepare `SELECT 1`/Limbo/SELECT 1
                        time:   [756.93 ns 758.11 ns 759.59 ns]
                        change: [-4.5974% -4.3153% -4.0393%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

Prepare `SELECT * FROM users LIMIT 1`/Limbo/SELECT * FROM users LIMIT 1
                        time:   [1.4739 µs 1.4769 µs 1.4800 µs]
                        change: [-7.9364% -7.7171% -7.4979%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Prepare `SELECT first_name, count(1) FROM users GROUP BY first_name HAVING count(1) > 1 ORDER BY cou...`
                        time:   [3.7440 µs 3.7520 µs 3.7596 µs]
                        change: [-5.4627% -5.1578% -4.8445%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
```