### PR TITLE
Add support for lazy records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "limbo"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "clap",

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -377,7 +377,7 @@ impl BTreeCursor {
 
                     let record = crate::storage::sqlite3_ondisk::read_record(payload)?;
                     if predicate.is_none() {
-                        let rowid = match record.values.last() {
+                        let rowid = match record.values().last() {
                             Some(OwnedValue::Integer(rowid)) => *rowid as u64,
                             _ => unreachable!("index cells should have an integer rowid"),
                         };
@@ -394,7 +394,7 @@ impl BTreeCursor {
                         SeekOp::EQ => &record == *index_key,
                     };
                     if found {
-                        let rowid = match record.values.last() {
+                        let rowid = match record.values().last() {
                             Some(OwnedValue::Integer(rowid)) => *rowid as u64,
                             _ => unreachable!("index cells should have an integer rowid"),
                         };
@@ -407,7 +407,7 @@ impl BTreeCursor {
                     self.stack.advance();
                     let record = crate::storage::sqlite3_ondisk::read_record(payload)?;
                     if predicate.is_none() {
-                        let rowid = match record.values.last() {
+                        let rowid = match record.values().last() {
                             Some(OwnedValue::Integer(rowid)) => *rowid as u64,
                             _ => unreachable!("index cells should have an integer rowid"),
                         };
@@ -423,7 +423,7 @@ impl BTreeCursor {
                         SeekOp::EQ => &record == *index_key,
                     };
                     if found {
-                        let rowid = match record.values.last() {
+                        let rowid = match record.values().last() {
                             Some(OwnedValue::Integer(rowid)) => *rowid as u64,
                             _ => unreachable!("index cells should have an integer rowid"),
                         };
@@ -488,18 +488,18 @@ impl BTreeCursor {
                         let record = crate::storage::sqlite3_ondisk::read_record(payload)?;
                         let found = match op {
                             SeekOp::GT => {
-                                &record.values[..record.values.len() - 1] > &index_key.values
+                                &record.values()[..record.values().len() - 1] > &index_key.values()
                             }
                             SeekOp::GE => {
-                                &record.values[..record.values.len() - 1] >= &index_key.values
+                                &record.values()[..record.values().len() - 1] >= &index_key.values()
                             }
                             SeekOp::EQ => {
-                                record.values[..record.values.len() - 1] == index_key.values
+                                record.values()[..record.values().len() - 1] == *index_key.values()
                             }
                         };
                         self.stack.advance();
                         if found {
-                            let rowid = match record.values.last() {
+                            let rowid = match record.values().last() {
                                 Some(OwnedValue::Integer(rowid)) => *rowid as u64,
                                 _ => unreachable!("index cells should have an integer rowid"),
                             };

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -969,7 +969,7 @@ pub fn read_record(payload: &[u8]) -> Result<OwnedRecord> {
         pos += n;
         values.push(value);
     }
-    Ok(OwnedRecord::new(values))
+    Ok(OwnedRecord::from_values(values))
 }
 
 pub fn read_value(buf: &[u8], serial_type: &SerialType) -> Result<(OwnedValue, usize)> {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -949,8 +949,7 @@ impl TryFrom<u64> for SerialType {
 }
 
 pub fn read_record(payload: &[u8]) -> Result<OwnedRecord> {
-    let values = parse_record(payload)?;
-    Ok(OwnedRecord::from_values(values))
+    Ok(OwnedRecord::from_payload(payload))
 }
 
 pub fn parse_record(payload: &[u8]) -> Result<Vec<OwnedValue>> {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -949,6 +949,11 @@ impl TryFrom<u64> for SerialType {
 }
 
 pub fn read_record(payload: &[u8]) -> Result<OwnedRecord> {
+    let values = parse_record(payload)?;
+    Ok(OwnedRecord::from_values(values))
+}
+
+pub fn parse_record(payload: &[u8]) -> Result<Vec<OwnedValue>> {
     let mut pos = 0;
     let (header_size, nr) = read_varint(payload)?;
     assert!((header_size as usize) >= nr);
@@ -969,7 +974,7 @@ pub fn read_record(payload: &[u8]) -> Result<OwnedRecord> {
         pos += n;
         values.push(value);
     }
-    Ok(OwnedRecord::from_values(values))
+    Ok(values)
 }
 
 pub fn read_value(buf: &[u8], serial_type: &SerialType) -> Result<(OwnedValue, usize)> {

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -72,7 +72,7 @@ pub fn init_group_by(
     program.emit_insn(Insn::SorterOpen {
         cursor_id: sort_cursor,
         columns: aggregates.len() + group_by.exprs.len(),
-        order: OwnedRecord::new(order),
+        order: OwnedRecord::from_values(order),
     });
 
     program.add_comment(program.offset(), "clear group by abort flag");

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -47,7 +47,7 @@ pub fn init_order_by(
     program.emit_insn(Insn::SorterOpen {
         cursor_id: sort_cursor,
         columns: order_by.len(),
-        order: OwnedRecord::new(order),
+        order: OwnedRecord::from_values(order),
     });
     Ok(())
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -479,7 +479,7 @@ impl<'a> Record<'a> {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OwnedRecord {
-    pub values: Vec<OwnedValue>,
+    values: Vec<OwnedValue>,
 }
 
 const I8_LOW: i64 = -128;
@@ -556,11 +556,19 @@ impl OwnedRecord {
         Self { values }
     }
 
+    pub fn get(&self, idx: usize) -> &OwnedValue {
+        &self.values[idx]
+    }
+
+    pub fn values(&self) -> &[OwnedValue] {
+        &self.values
+    }
+
     pub fn serialize(&self, buf: &mut Vec<u8>) {
         let initial_i = buf.len();
 
         // write serial types
-        for value in &self.values {
+        for value in self.values() {
             let serial_type = SerialType::from(value);
             buf.resize(buf.len() + 9, 0); // Ensure space for varint (1-9 bytes in length)
             let len = buf.len();
@@ -570,7 +578,7 @@ impl OwnedRecord {
 
         let mut header_size = buf.len() - initial_i;
         // write content
-        for value in &self.values {
+        for value in self.values() {
             match value {
                 OwnedValue::Null => {}
                 OwnedValue::Integer(i) => {
@@ -694,7 +702,7 @@ mod tests {
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
-        let header_length = record.values.len() + 1;
+        let header_length = record.values().len() + 1;
         let header = &buf[0..header_length];
         // First byte should be header size
         assert_eq!(header[0], header_length as u8);
@@ -717,7 +725,7 @@ mod tests {
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
-        let header_length = record.values.len() + 1;
+        let header_length = record.values().len() + 1;
         let header = &buf[0..header_length];
         // First byte should be header size
         assert_eq!(header[0], header_length as u8); // Header should be larger than number of values
@@ -786,7 +794,7 @@ mod tests {
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
-        let header_length = record.values.len() + 1;
+        let header_length = record.values().len() + 1;
         let header = &buf[0..header_length];
         // First byte should be header size
         assert_eq!(header[0], header_length as u8);
@@ -807,7 +815,7 @@ mod tests {
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
-        let header_length = record.values.len() + 1;
+        let header_length = record.values().len() + 1;
         let header = &buf[0..header_length];
         // First byte should be header size
         assert_eq!(header[0], header_length as u8);
@@ -826,7 +834,7 @@ mod tests {
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
-        let header_length = record.values.len() + 1;
+        let header_length = record.values().len() + 1;
         let header = &buf[0..header_length];
         // First byte should be header size
         assert_eq!(header[0], header_length as u8);
@@ -850,7 +858,7 @@ mod tests {
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
-        let header_length = record.values.len() + 1;
+        let header_length = record.values().len() + 1;
         let header = &buf[0..header_length];
         // First byte should be header size
         assert_eq!(header[0], header_length as u8);

--- a/core/types.rs
+++ b/core/types.rs
@@ -552,7 +552,7 @@ impl From<SerialType> for u64 {
 }
 
 impl OwnedRecord {
-    pub fn new(values: Vec<OwnedValue>) -> Self {
+    pub fn from_values(values: Vec<OwnedValue>) -> Self {
         Self { values }
     }
 
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     fn test_serialize_null() {
-        let record = OwnedRecord::new(vec![OwnedValue::Null]);
+        let record = OwnedRecord::from_values(vec![OwnedValue::Null]);
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
@@ -714,7 +714,7 @@ mod tests {
 
     #[test]
     fn test_serialize_integers() {
-        let record = OwnedRecord::new(vec![
+        let record = OwnedRecord::from_values(vec![
             OwnedValue::Integer(42),                // Should use SERIAL_TYPE_I8
             OwnedValue::Integer(1000),              // Should use SERIAL_TYPE_I16
             OwnedValue::Integer(1_000_000),         // Should use SERIAL_TYPE_I24
@@ -790,7 +790,7 @@ mod tests {
     #[test]
     fn test_serialize_float() {
         #[warn(clippy::approx_constant)]
-        let record = OwnedRecord::new(vec![OwnedValue::Float(3.15555)]);
+        let record = OwnedRecord::from_values(vec![OwnedValue::Float(3.15555)]);
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
@@ -811,7 +811,7 @@ mod tests {
     #[test]
     fn test_serialize_text() {
         let text = Rc::new("hello".to_string());
-        let record = OwnedRecord::new(vec![OwnedValue::Text(LimboText::new(text.clone()))]);
+        let record = OwnedRecord::from_values(vec![OwnedValue::Text(LimboText::new(text.clone()))]);
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
@@ -830,7 +830,7 @@ mod tests {
     #[test]
     fn test_serialize_blob() {
         let blob = Rc::new(vec![1, 2, 3, 4, 5]);
-        let record = OwnedRecord::new(vec![OwnedValue::Blob(blob.clone())]);
+        let record = OwnedRecord::from_values(vec![OwnedValue::Blob(blob.clone())]);
         let mut buf = Vec::new();
         record.serialize(&mut buf);
 
@@ -849,7 +849,7 @@ mod tests {
     #[test]
     fn test_serialize_mixed_types() {
         let text = Rc::new("test".to_string());
-        let record = OwnedRecord::new(vec![
+        let record = OwnedRecord::from_values(vec![
             OwnedValue::Null,
             OwnedValue::Integer(42),
             OwnedValue::Float(3.15),

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -737,7 +737,7 @@ pub fn insn_to_str(
             } => {
                 let _p4 = String::new();
                 let to_print: Vec<String> = order
-                    .values
+                    .values()
                     .iter()
                     .map(|v| match v {
                         OwnedValue::Integer(i) => {
@@ -757,7 +757,7 @@ pub fn insn_to_str(
                     0,
                     OwnedValue::build_text(Rc::new(format!(
                         "k({},{})",
-                        order.values.len(),
+                        order.values().len(),
                         to_print.join(",")
                     ))),
                     0,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -924,7 +924,7 @@ impl Program {
                                 state.registers[*dest] = if cursor.get_null_flag() {
                                     OwnedValue::Null
                                 } else {
-                                    record.values[*column].clone()
+                                    record.get(*column).clone()
                                 };
                             } else {
                                 state.registers[*dest] = OwnedValue::Null;
@@ -933,7 +933,7 @@ impl Program {
                         CursorType::Sorter => {
                             let cursor = get_cursor_as_sorter_mut(&mut cursors, *cursor_id);
                             if let Some(record) = cursor.record() {
-                                state.registers[*dest] = record.values[*column].clone();
+                                state.registers[*dest] = record.get(*column).clone();
                             } else {
                                 state.registers[*dest] = OwnedValue::Null;
                             }
@@ -941,7 +941,7 @@ impl Program {
                         CursorType::Pseudo(_) => {
                             let cursor = get_cursor_as_pseudo_mut(&mut cursors, *cursor_id);
                             if let Some(record) = cursor.record() {
-                                state.registers[*dest] = record.values[*column].clone();
+                                state.registers[*dest] = record.get(*column).clone();
                             } else {
                                 state.registers[*dest] = OwnedValue::Null;
                             }
@@ -1301,8 +1301,8 @@ impl Program {
                         make_owned_record(&state.registers, start_reg, num_regs);
                     if let Some(ref idx_record) = *cursor.record()? {
                         // omit the rowid from the idx_record, which is the last value
-                        if idx_record.values[..idx_record.values.len() - 1]
-                            >= *record_from_regs.values
+                        if idx_record.values()[..idx_record.values().len() - 1]
+                            >= *record_from_regs.values()
                         {
                             state.pc = target_pc.to_offset_int();
                         } else {
@@ -1325,8 +1325,8 @@ impl Program {
                         make_owned_record(&state.registers, start_reg, num_regs);
                     if let Some(ref idx_record) = *cursor.record()? {
                         // omit the rowid from the idx_record, which is the last value
-                        if idx_record.values[..idx_record.values.len() - 1]
-                            > *record_from_regs.values
+                        if idx_record.values()[..idx_record.values().len() - 1]
+                            > *record_from_regs.values()
                         {
                             state.pc = target_pc.to_offset_int();
                         } else {
@@ -1642,7 +1642,7 @@ impl Program {
                     order,
                 } => {
                     let order = order
-                        .values
+                        .values()
                         .iter()
                         .map(|v| match v {
                             OwnedValue::Integer(i) => *i == 0,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2635,7 +2635,7 @@ fn make_owned_record(registers: &[OwnedValue], start_reg: &usize, count: &usize)
     for r in registers.iter().skip(*start_reg).take(*count) {
         values.push(r.clone())
     }
-    OwnedRecord::new(values)
+    OwnedRecord::from_values(values)
 }
 
 fn trace_insn(program: &Program, addr: InsnReference, insn: &Insn) {

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -27,8 +27,8 @@ impl Sorter {
     pub fn sort(&mut self) {
         self.records.sort_by(|a, b| {
             let cmp_by_idx = |idx: usize, ascending: bool| {
-                let a = &a.values[idx];
-                let b = &b.values[idx];
+                let a = a.get(idx);
+                let b = b.get(idx);
                 if ascending {
                     a.cmp(b)
                 } else {
@@ -56,6 +56,7 @@ impl Sorter {
     }
 
     pub fn insert(&mut self, record: &OwnedRecord) {
-        self.records.push(OwnedRecord::new(record.values.to_vec()));
+        self.records
+            .push(OwnedRecord::new(record.values().to_vec()));
     }
 }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -57,6 +57,6 @@ impl Sorter {
 
     pub fn insert(&mut self, record: &OwnedRecord) {
         self.records
-            .push(OwnedRecord::new(record.values().to_vec()));
+            .push(OwnedRecord::from_values(record.values().to_vec()));
     }
 }


### PR DESCRIPTION
A lazy record is just the binary payload unparsed. This does not yet improve performance because we end up converting everything eagerly to `Values`. However, we no longer forcefully parse the records in the lowest level on-disk format layer.