### PR TITLE
core: Move result row to ProgramState

### DIFF
--- a/bindings/go/rs_src/statement.rs
+++ b/bindings/go/rs_src/statement.rs
@@ -50,7 +50,7 @@ pub extern "C" fn stmt_execute(
     }
     loop {
         match statement.step() {
-            Ok(StepResult::Row(_)) => {
+            Ok(StepResult::Row) => {
                 // unexpected row during execution, error out.
                 return ResultCode::Error;
             }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -129,10 +129,12 @@ impl Cursor {
     pub fn fetchone(&mut self, py: Python) -> Result<Option<PyObject>> {
         if let Some(smt) = &self.smt {
             loop {
-                match smt.borrow_mut().step().map_err(|e| {
+                let mut stmt = smt.borrow_mut();
+                match stmt.step().map_err(|e| {
                     PyErr::new::<OperationalError, _>(format!("Step error: {:?}", e))
                 })? {
-                    limbo_core::StepResult::Row(row) => {
+                    limbo_core::StepResult::Row => {
+                        let row = stmt.row().unwrap();
                         let py_row = row_to_py(py, &row);
                         return Ok(Some(py_row));
                     }
@@ -163,10 +165,12 @@ impl Cursor {
         let mut results = Vec::new();
         if let Some(smt) = &self.smt {
             loop {
-                match smt.borrow_mut().step().map_err(|e| {
+                let mut stmt = smt.borrow_mut();
+                match stmt.step().map_err(|e| {
                     PyErr::new::<OperationalError, _>(format!("Step error: {:?}", e))
                 })? {
-                    limbo_core::StepResult::Row(row) => {
+                    limbo_core::StepResult::Row => {
+                        let row = stmt.row().unwrap();
                         let py_row = row_to_py(py, &row);
                         results.push(py_row);
                     }
@@ -298,7 +302,7 @@ fn row_to_py(py: Python, row: &limbo_core::Row) -> PyObject {
     let py_values: Vec<PyObject> = row
         .values
         .iter()
-        .map(|value| match value {
+        .map(|value| match value.to_value() {
             limbo_core::Value::Null => py.None(),
             limbo_core::Value::Integer(i) => i.to_object(py),
             limbo_core::Value::Float(f) => f.to_object(py),

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -71,10 +71,13 @@ impl RowIterator {
 
     #[wasm_bindgen]
     pub fn next(&mut self) -> JsValue {
-        match self.inner.borrow_mut().step() {
-            Ok(limbo_core::StepResult::Row(row)) => {
+        let mut stmt = self.inner.borrow_mut();
+        match stmt.step() {
+            Ok(limbo_core::StepResult::Row) => {
+                let row = stmt.row().unwrap();
                 let row_array = Array::new();
-                for value in row.values {
+                for value in &row.values {
+                    let value = value.to_value();
                     let value = to_js_value(value);
                     row_array.push(&value);
                 }
@@ -109,10 +112,13 @@ impl Statement {
     }
 
     pub fn get(&self) -> JsValue {
-        match self.inner.borrow_mut().step() {
-            Ok(limbo_core::StepResult::Row(row)) => {
+        let mut stmt = self.inner.borrow_mut();
+        match stmt.step() {
+            Ok(limbo_core::StepResult::Row) => {
+                let row = stmt.row().unwrap();
                 let row_array = js_sys::Array::new();
-                for value in row.values {
+                for value in &row.values {
+                    let value = value.to_value();
                     let value = to_js_value(value);
                     row_array.push(&value);
                 }
@@ -129,10 +135,13 @@ impl Statement {
     pub fn all(&self) -> js_sys::Array {
         let array = js_sys::Array::new();
         loop {
-            match self.inner.borrow_mut().step() {
-                Ok(limbo_core::StepResult::Row(row)) => {
+            let mut stmt = self.inner.borrow_mut();
+            match stmt.step() {
+                Ok(limbo_core::StepResult::Row) => {
+                    let row = stmt.row().unwrap();
                     let row_array = js_sys::Array::new();
-                    for value in row.values {
+                    for value in &row.values {
+                        let value = value.to_value();
                         let value = to_js_value(value);
                         row_array.push(&value);
                     }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -625,8 +625,10 @@ impl Limbo {
                     }
 
                     match rows.step() {
-                        Ok(StepResult::Row(row)) => {
+                        Ok(StepResult::Row) => {
+                            let row = rows.row().unwrap();
                             for (i, value) in row.values.iter().enumerate() {
+                                let value = value.to_value();
                                 if i > 0 {
                                     let _ = self.writer.write(b"|");
                                 }
@@ -670,11 +672,12 @@ impl Limbo {
                     let mut table_rows: Vec<Vec<_>> = vec![];
                     loop {
                         match rows.step() {
-                            Ok(StepResult::Row(row)) => {
+                            Ok(StepResult::Row) => {
+                                let row = rows.row().unwrap();
                                 table_rows.push(
                                     row.values
                                         .iter()
-                                        .map(|value| match value {
+                                        .map(|value| match value.to_value() {
                                             Value::Null => self.opts.null_value.clone().cell(),
                                             Value::Integer(i) => i.to_string().cell(),
                                             Value::Float(f) => f.to_string().cell(),
@@ -740,8 +743,11 @@ impl Limbo {
                 let mut found = false;
                 loop {
                     match rows.step()? {
-                        StepResult::Row(row) => {
-                            if let Some(Value::Text(schema)) = row.values.first() {
+                        StepResult::Row => {
+                            let row = rows.row().unwrap();
+                            if let Some(Value::Text(schema)) =
+                                row.values.first().map(|v| v.to_value())
+                            {
                                 let _ = self.write_fmt(format_args!("{};", schema));
                                 found = true;
                             }
@@ -797,8 +803,11 @@ impl Limbo {
                 let mut tables = String::new();
                 loop {
                     match rows.step()? {
-                        StepResult::Row(row) => {
-                            if let Some(Value::Text(table)) = row.values.first() {
+                        StepResult::Row => {
+                            let row = rows.row().unwrap();
+                            if let Some(Value::Text(table)) =
+                                row.values.first().map(|v| v.to_value())
+                            {
                                 tables.push_str(table);
                                 tables.push(' ');
                             }

--- a/cli/import.rs
+++ b/cli/import.rs
@@ -107,7 +107,7 @@ impl<'a> ImportFile<'a> {
                                             self.writer.write_all("database is busy\n".as_bytes());
                                         break;
                                     }
-                                    limbo_core::StepResult::Row(_) => todo!(),
+                                    limbo_core::StepResult::Row => todo!(),
                                 }
                             }
                         }

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -61,9 +61,7 @@ fn bench(criterion: &mut Criterion) {
             b.iter(|| {
                 loop {
                     match stmt.step().unwrap() {
-                        limbo_core::StepResult::Row(row) => {
-                            black_box(row);
-                        }
+                        limbo_core::StepResult::Row => {}
                         limbo_core::StepResult::IO => {
                             let _ = io.run_once();
                         }
@@ -107,9 +105,7 @@ fn bench(criterion: &mut Criterion) {
         b.iter(|| {
             loop {
                 match stmt.step().unwrap() {
-                    limbo_core::StepResult::Row(row) => {
-                        black_box(row);
-                    }
+                    limbo_core::StepResult::Row => {}
                     limbo_core::StepResult::IO => {
                         let _ = io.run_once();
                     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -468,7 +468,7 @@ impl Statement {
         self.state.interrupt();
     }
 
-    pub fn step(&mut self) -> Result<StepResult<'_>> {
+    pub fn step(&mut self) -> Result<StepResult> {
         self.program.step(&mut self.state, self.pager.clone())
     }
 
@@ -495,18 +495,15 @@ impl Statement {
     pub fn reset(&mut self) {
         self.state.reset();
     }
-}
 
-pub type StepResult<'a> = vdbe::StepResult<'a>;
-
-pub type Row<'a> = types::Record<'a>;
-
-impl<'a> Row<'a> {
-    pub fn get<T: types::FromValue<'a> + 'a>(&self, idx: usize) -> Result<T> {
-        let value = &self.values[idx];
-        T::from_value(value)
+    pub fn row(&self) -> Option<&Row> {
+        self.state.result_row.as_ref()
     }
 }
+
+pub type Row = types::OwnedRecord;
+
+pub type StepResult = vdbe::StepResult;
 
 pub(crate) struct SymbolTable {
     pub functions: HashMap<String, Rc<function::ExternalFunc>>,

--- a/core/util.rs
+++ b/core/util.rs
@@ -34,7 +34,8 @@ pub fn parse_schema_rows(
         let mut automatic_indexes = Vec::new();
         loop {
             match rows.step()? {
-                StepResult::Row(row) => {
+                StepResult::Row => {
+                    let row = rows.row().unwrap();
                     let ty = row.get::<&str>(0)?;
                     if ty != "table" && ty != "index" {
                         continue;

--- a/perf/latency/limbo/src/main.rs
+++ b/perf/latency/limbo/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
                         let row = rows.step().unwrap();
                         match row {
                             limbo_core::StepResult::Row(_) => {
+                                let row = statement.row();
                                 count += 1;
                             }
                             limbo_core::StepResult::IO => yield,

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -416,13 +416,15 @@ impl Interaction {
             let mut out = Vec::new();
             while let Ok(row) = rows.step() {
                 match row {
-                    StepResult::Row(row) => {
+                    StepResult::Row => {
+                        let row = rows.row().unwrap();
                         let mut r = Vec::new();
                         for el in &row.values {
-                            let v = match el {
+                            let v = el.to_value();
+                            let v = match v {
                                 limbo_core::Value::Null => Value::Null,
-                                limbo_core::Value::Integer(i) => Value::Integer(*i),
-                                limbo_core::Value::Float(f) => Value::Float(*f),
+                                limbo_core::Value::Integer(i) => Value::Integer(i),
+                                limbo_core::Value::Float(f) => Value::Float(f),
                                 limbo_core::Value::Text(t) => Value::Text(t.to_string()),
                                 limbo_core::Value::Blob(b) => Value::Blob(b.to_vec()),
                             };

--- a/tests/integration/functions/test_function_rowid.rs
+++ b/tests/integration/functions/test_function_rowid.rs
@@ -28,8 +28,9 @@ fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
     if let Some(ref mut rows) = select_query {
         loop {
             match rows.step()? {
-                StepResult::Row(row) => {
-                    if let Value::Integer(id) = row.values[0] {
+                StepResult::Row => {
+                    let row = rows.row().unwrap();
+                    if let Value::Integer(id) = row.values[0].to_value() {
                         assert_eq!(id, 1, "First insert should have rowid 1");
                     }
                 }
@@ -63,8 +64,9 @@ fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
     match conn.query("SELECT last_insert_rowid()") {
         Ok(Some(ref mut rows)) => loop {
             match rows.step()? {
-                StepResult::Row(row) => {
-                    if let Value::Integer(id) = row.values[0] {
+                StepResult::Row => {
+                    let row = rows.row().unwrap();
+                    if let Value::Integer(id) = row.values[0].to_value() {
                         last_id = id;
                     }
                 }
@@ -108,8 +110,9 @@ fn test_integer_primary_key() -> anyhow::Result<()> {
     let mut select_query = conn.query("SELECT * FROM test_rowid")?.unwrap();
     loop {
         match select_query.step()? {
-            StepResult::Row(row) => {
-                if let Value::Integer(id) = row.values[0] {
+            StepResult::Row => {
+                let row = select_query.row().unwrap();
+                if let Value::Integer(id) = row.values[0].to_value() {
                     rowids.push(id);
                 }
             }

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -48,17 +48,20 @@ mod tests {
         let result = stmt.step().unwrap();
         let row = loop {
             match result {
-                limbo_core::StepResult::Row(row) => break row,
+                limbo_core::StepResult::Row => {
+                    let row = stmt.row().unwrap();
+                    break row;
+                }
                 limbo_core::StepResult::IO => continue,
                 r => panic!("unexpected result {:?}: expecting single row", r),
             }
         };
         row.values
             .iter()
-            .map(|x| match x {
+            .map(|x| match x.to_value() {
                 limbo_core::Value::Null => rusqlite::types::Value::Null,
-                limbo_core::Value::Integer(x) => rusqlite::types::Value::Integer(*x),
-                limbo_core::Value::Float(x) => rusqlite::types::Value::Real(*x),
+                limbo_core::Value::Integer(x) => rusqlite::types::Value::Integer(x),
+                limbo_core::Value::Float(x) => rusqlite::types::Value::Real(x),
                 limbo_core::Value::Text(x) => rusqlite::types::Value::Text(x.to_string()),
                 limbo_core::Value::Blob(x) => rusqlite::types::Value::Blob(x.to_vec()),
             })

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -13,8 +13,9 @@ fn test_statement_reset_bind() -> anyhow::Result<()> {
 
     loop {
         match stmt.step()? {
-            StepResult::Row(row) => {
-                assert_eq!(row.values[0], Value::Integer(1));
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                assert_eq!(row.values[0].to_value(), Value::Integer(1));
             }
             StepResult::IO => tmp_db.io.run_once()?,
             _ => break,
@@ -27,8 +28,9 @@ fn test_statement_reset_bind() -> anyhow::Result<()> {
 
     loop {
         match stmt.step()? {
-            StepResult::Row(row) => {
-                assert_eq!(row.values[0], Value::Integer(2));
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                assert_eq!(row.values[0].to_value(), Value::Integer(2));
             }
             StepResult::IO => tmp_db.io.run_once()?,
             _ => break,
@@ -59,24 +61,25 @@ fn test_statement_bind() -> anyhow::Result<()> {
 
     loop {
         match stmt.step()? {
-            StepResult::Row(row) => {
-                if let Value::Text(s) = row.values[0] {
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                if let Value::Text(s) = row.values[0].to_value() {
                     assert_eq!(s, "hello")
                 }
 
-                if let Value::Text(s) = row.values[1] {
+                if let Value::Text(s) = row.values[1].to_value() {
                     assert_eq!(s, "hello")
                 }
 
-                if let Value::Integer(i) = row.values[2] {
+                if let Value::Integer(i) = row.values[2].to_value() {
                     assert_eq!(i, 42)
                 }
 
-                if let Value::Blob(v) = row.values[3] {
+                if let Value::Blob(v) = row.values[3].to_value() {
                     assert_eq!(v, &vec![0x1 as u8, 0x2, 0x3])
                 }
 
-                if let Value::Float(f) = row.values[4] {
+                if let Value::Float(f) = row.values[4].to_value() {
                     assert_eq!(f, 0.5)
                 }
             }

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -39,9 +39,11 @@ pub(crate) fn execute_and_get_strings(
     let stmt = Rc::new(RefCell::new(statement));
     let mut result = Vec::new();
 
-    while let Ok(step_result) = stmt.borrow_mut().step() {
+    let mut stmt = stmt.borrow_mut();
+    while let Ok(step_result) = stmt.step() {
         match step_result {
-            StepResult::Row(row) => {
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
                 for el in &row.values {
                     result.push(format!("{el}"));
                 }
@@ -65,12 +67,15 @@ pub(crate) fn execute_and_get_ints(
     let stmt = Rc::new(RefCell::new(statement));
     let mut result = Vec::new();
 
-    while let Ok(step_result) = stmt.borrow_mut().step() {
+    let mut stmt = stmt.borrow_mut();
+    while let Ok(step_result) = stmt.step() {
         match step_result {
-            StepResult::Row(row) => {
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
                 for value in &row.values {
+                    let value = value.to_value();
                     let out = match value {
-                        Value::Integer(i) => *i,
+                        Value::Integer(i) => i,
                         _ => {
                             return Err(LimboError::ConversionError(format!(
                                 "cannot convert {value} to int"


### PR DESCRIPTION
Move result row to `ProgramState` to mimic what SQLite does where `Vdbe` struct has a `pResultRow` member. This makes it easier to deal with result lifetime, but more importantly, eventually lazily parse values at the edges of the API.