### PR TITLE
Integrate MVCC

### DIFF
--- a/bindings/go/rs_src/lib.rs
+++ b/bindings/go/rs_src/lib.rs
@@ -25,7 +25,7 @@ pub unsafe extern "C" fn db_open(path: *const c_char) -> *mut c_void {
         p if p.contains(":memory:") => Arc::new(limbo_core::MemoryIO::new()),
         _ => Arc::new(limbo_core::PlatformIO::new().expect("Failed to create IO")),
     };
-    let db = Database::open_file(io.clone(), path);
+    let db = Database::open_file(io.clone(), path, false);
     match db {
         Ok(db) => {
             let conn = db.connect().unwrap();

--- a/bindings/java/rs_src/limbo_db.rs
+++ b/bindings/java/rs_src/limbo_db.rs
@@ -67,7 +67,7 @@ pub extern "system" fn Java_tech_turso_core_LimboDB_openUtf8<'local>(
         }
     };
 
-    let db = match Database::open_file(io.clone(), &path) {
+    let db = match Database::open_file(io.clone(), &path, false) {
         Ok(db) => db,
         Err(e) => {
             set_err_msg_and_throw_exception(&mut env, obj, LIMBO_ETC, e.to_string());

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -277,7 +277,7 @@ pub fn connect(path: &str) -> Result<Connection> {
         io: Arc<dyn limbo_core::IO>,
         path: &str,
     ) -> std::result::Result<Arc<limbo_core::Database>, PyErr> {
-        limbo_core::Database::open_file(io, path).map_err(|e| {
+        limbo_core::Database::open_file(io, path, false).map_err(|e| {
             PyErr::new::<DatabaseError, _>(format!("Failed to open database: {:?}", e))
         })
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -42,12 +42,12 @@ impl Builder {
         match self.path.as_str() {
             ":memory:" => {
                 let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::MemoryIO::new());
-                let db = limbo_core::Database::open_file(io, self.path.as_str())?;
+                let db = limbo_core::Database::open_file(io, self.path.as_str(), false)?;
                 Ok(Database { inner: db })
             }
             path => {
                 let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::PlatformIO::new()?);
-                let db = limbo_core::Database::open_file(io, path)?;
+                let db = limbo_core::Database::open_file(io, path, false)?;
                 Ok(Database { inner: db })
             }
         }

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -32,7 +32,7 @@ impl Database {
         let wal_path = format!("{}-wal", path);
         let wal_shared = WalFileShared::open_shared(&io, wal_path.as_str(), page_size).unwrap();
 
-        let db = limbo_core::Database::open(io, page_io, wal_shared).unwrap();
+        let db = limbo_core::Database::open(io, page_io, wal_shared, false).unwrap();
         let conn = db.connect().unwrap();
         Database { db, conn }
     }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -51,6 +51,8 @@ pub struct Opts {
         \t'io-uring' when built for Linux with feature 'io_uring'\n"
     )]
     pub io: Io,
+    #[clap(long, help = "Enable experimental MVCC feature")]
+    pub experimental_mvcc: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -210,7 +212,7 @@ impl<'a> Limbo<'a> {
                 _path => get_io(DbLocation::Path, opts.io)?,
             }
         };
-        let db = Database::open_file(io.clone(), &db_file)?;
+        let db = Database::open_file(io.clone(), &db_file, opts.experimental_mvcc)?;
         let conn = db.connect().unwrap();
         let h = LimboHelper::new(conn.clone(), io.clone());
         rl.set_helper(Some(h));
@@ -412,7 +414,7 @@ impl<'a> Limbo<'a> {
             }
         };
         self.io = Arc::clone(&io);
-        let db = Database::open_file(self.io.clone(), path)?;
+        let db = Database::open_file(self.io.clone(), path, self.opts.experimental_mvcc)?;
         self.conn = db.connect().unwrap();
         self.opts.db_file = path.to_string();
         Ok(())

--- a/cli/input.rs
+++ b/cli/input.rs
@@ -65,6 +65,7 @@ pub struct Settings {
     pub echo: bool,
     pub is_stdout: bool,
     pub io: Io,
+    pub experimental_mvcc: bool,
 }
 
 impl From<&Opts> for Settings {
@@ -80,6 +81,7 @@ impl From<&Opts> for Settings {
                 .as_ref()
                 .map_or(":memory:".to_string(), |p| p.to_string_lossy().to_string()),
             io: opts.io,
+            experimental_mvcc: opts.experimental_mvcc,
         }
     }
 }

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -18,7 +18,7 @@ fn bench(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let queries = [

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -85,6 +85,8 @@ enum TransactionState {
 
 pub(crate) type MvStore = crate::mvcc::MvStore<crate::mvcc::LocalClock>;
 
+pub(crate) type MvCursor = crate::mvcc::cursor::ScanCursor<crate::mvcc::LocalClock>;
+
 pub struct Database {
     mv_store: Option<Rc<MvStore>>,
     schema: Arc<RwLock<Schema>>,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -162,7 +162,7 @@ impl Database {
                 .try_write()
                 .expect("lock on schema should succeed first try");
             let syms = conn.syms.borrow();
-            parse_schema_rows(rows, &mut schema, io, syms.deref())?;
+            parse_schema_rows(rows, &mut schema, io, syms.deref(), None)?;
         }
         Ok(db)
     }
@@ -525,6 +525,10 @@ impl Statement {
             mv_store,
             pager,
         }
+    }
+
+    pub fn set_mv_tx_id(&mut self, mv_tx_id: Option<u64>) {
+        self.state.mv_tx_id = mv_tx_id;
     }
 
     pub fn interrupt(&mut self) {

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -22,6 +22,10 @@ impl<Clock: LogicalClock> ScanCursor<Clock> {
         })
     }
 
+    pub fn insert(&self, row: Row) -> Result<()> {
+        self.db.insert(self.tx_id, row)
+    }
+
     pub fn current_row_id(&self) -> Option<RowID> {
         if self.index >= self.row_ids.len() {
             return None;

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,17 +1,18 @@
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{MvStore, Result, Row, RowID};
 use std::fmt::Debug;
+use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct ScanCursor<'a, Clock: LogicalClock> {
-    pub db: &'a MvStore<Clock>,
+pub struct ScanCursor<Clock: LogicalClock> {
+    pub db: Rc<MvStore<Clock>>,
     pub row_ids: Vec<RowID>,
     pub index: usize,
     tx_id: u64,
 }
 
-impl<'a, Clock: LogicalClock> ScanCursor<'a, Clock> {
-    pub fn new(db: &'a MvStore<Clock>, tx_id: u64, table_id: u64) -> Result<ScanCursor<'a, Clock>> {
+impl<Clock: LogicalClock> ScanCursor<Clock> {
+    pub fn new(db: Rc<MvStore<Clock>>, tx_id: u64, table_id: u64) -> Result<ScanCursor<Clock>> {
         let row_ids = db.scan_row_ids_for_table(table_id)?;
         Ok(Self {
             db,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -17,11 +17,23 @@ pub struct RowID {
     pub row_id: u64,
 }
 
+impl RowID {
+    pub fn new(table_id: u64, row_id: u64) -> Self {
+        Self { table_id, row_id }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 
 pub struct Row {
     pub id: RowID,
     pub data: Vec<u8>,
+}
+
+impl Row {
+    pub fn new(id: RowID, data: Vec<u8>) -> Self {
+        Self { id, data }
+    }
 }
 
 /// A row version.

--- a/core/mvcc/mod.rs
+++ b/core/mvcc/mod.rs
@@ -37,6 +37,9 @@ pub mod database;
 pub mod errors;
 pub mod persistent_storage;
 
+pub use clock::LocalClock;
+pub use database::MvStore;
+
 #[cfg(test)]
 mod tests {
     use crate::mvcc::clock::LocalClock;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4,6 +4,7 @@ use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::{
     read_varint, BTreeCell, PageContent, PageType, TableInteriorCell, TableLeafCell,
 };
+use crate::MvCursor;
 
 use crate::types::{CursorResult, OwnedValue, Record, SeekKey, SeekOp};
 use crate::{return_corrupt, LimboError, Result};
@@ -135,6 +136,9 @@ impl CursorState {
 }
 
 pub struct BTreeCursor {
+    /// The multi-version cursor that is used to read and write to the database file.
+    mv_cursor: Option<Rc<RefCell<MvCursor>>>,
+    /// The pager that is used to read and write to the database file.
     pager: Rc<Pager>,
     /// Page id of the root page used to go back up fast.
     root_page: usize,
@@ -178,8 +182,13 @@ struct CellArray {
 }
 
 impl BTreeCursor {
-    pub fn new(pager: Rc<Pager>, root_page: usize) -> Self {
+    pub fn new(
+        mv_cursor: Option<Rc<RefCell<MvCursor>>>,
+        pager: Rc<Pager>,
+        root_page: usize,
+    ) -> Self {
         Self {
+            mv_cursor,
             pager,
             root_page,
             rowid: Cell::new(None),
@@ -198,6 +207,10 @@ impl BTreeCursor {
     /// Check if the table is empty.
     /// This is done by checking if the root page has no cells.
     fn is_empty_table(&self) -> Result<CursorResult<bool>> {
+        if let Some(mv_cursor) = &self.mv_cursor {
+            let mv_cursor = mv_cursor.borrow();
+            return Ok(CursorResult::Ok(mv_cursor.is_empty()));
+        }
         let page = self.pager.read_page(self.root_page)?;
         return_if_locked!(page);
 
@@ -290,6 +303,19 @@ impl BTreeCursor {
         &mut self,
         predicate: Option<(SeekKey<'_>, SeekOp)>,
     ) -> Result<CursorResult<(Option<u64>, Option<Record>)>> {
+        if let Some(mv_cursor) = &self.mv_cursor {
+            let mut mv_cursor = mv_cursor.borrow_mut();
+            let rowid = mv_cursor.current_row_id();
+            match rowid {
+                Some(rowid) => {
+                    let record = mv_cursor.current_row().unwrap().unwrap();
+                    let record: Record = crate::storage::sqlite3_ondisk::read_record(&record.data)?;
+                    mv_cursor.forward();
+                    return Ok(CursorResult::Ok((Some(rowid.row_id), Some(record))));
+                }
+                None => return Ok(CursorResult::Ok((None, None))),
+            }
+        }
         loop {
             let mem_page_rc = self.stack.top();
             let cell_idx = self.stack.current_cell_index() as usize;
@@ -592,6 +618,7 @@ impl BTreeCursor {
     }
 
     pub fn move_to(&mut self, key: SeekKey<'_>, cmp: SeekOp) -> Result<CursorResult<()>> {
+        assert!(self.mv_cursor.is_none());
         // For a table with N rows, we can find any row by row id in O(log(N)) time by starting at the root page and following the B-tree pointers.
         // B-trees consist of interior pages and leaf pages. Interior pages contain pointers to other pages, while leaf pages contain the actual row data.
         //
@@ -1592,15 +1619,22 @@ impl BTreeCursor {
     }
 
     pub fn rewind(&mut self) -> Result<CursorResult<()>> {
-        self.move_to_root();
+        if let Some(_) = &self.mv_cursor {
+            let (rowid, record) = return_if_io!(self.get_next_record(None));
+            self.rowid.replace(rowid);
+            self.record.replace(record);
+        } else {
+            self.move_to_root();
 
-        let (rowid, record) = return_if_io!(self.get_next_record(None));
-        self.rowid.replace(rowid);
-        self.record.replace(record);
+            let (rowid, record) = return_if_io!(self.get_next_record(None));
+            self.rowid.replace(rowid);
+            self.record.replace(record);
+        }
         Ok(CursorResult::Ok(()))
     }
 
     pub fn last(&mut self) -> Result<CursorResult<()>> {
+        assert!(self.mv_cursor.is_none());
         match self.move_to_rightmost()? {
             CursorResult::Ok(_) => self.prev(),
             CursorResult::IO => Ok(CursorResult::IO),
@@ -1615,6 +1649,7 @@ impl BTreeCursor {
     }
 
     pub fn prev(&mut self) -> Result<CursorResult<()>> {
+        assert!(self.mv_cursor.is_none());
         match self.get_prev_record()? {
             CursorResult::Ok((rowid, record)) => {
                 self.rowid.replace(rowid);
@@ -1631,10 +1666,15 @@ impl BTreeCursor {
     }
 
     pub fn rowid(&self) -> Result<Option<u64>> {
+        if let Some(mv_cursor) = &self.mv_cursor {
+            let mv_cursor = mv_cursor.borrow();
+            return Ok(mv_cursor.current_row_id().map(|rowid| rowid.row_id));
+        }
         Ok(self.rowid.get())
     }
 
     pub fn seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> Result<CursorResult<bool>> {
+        assert!(self.mv_cursor.is_none());
         let (rowid, record) = return_if_io!(self.do_seek(key, op));
         self.rowid.replace(rowid);
         self.record.replace(record);
@@ -1648,23 +1688,35 @@ impl BTreeCursor {
     pub fn insert(
         &mut self,
         key: &OwnedValue,
-        _record: &Record,
+        record: &Record,
         moved_before: bool, /* Indicate whether it's necessary to traverse to find the leaf page */
     ) -> Result<CursorResult<()>> {
         let int_key = match key {
             OwnedValue::Integer(i) => i,
             _ => unreachable!("btree tables are indexed by integers!"),
         };
-        if !moved_before {
-            return_if_io!(self.move_to(SeekKey::TableRowId(*int_key as u64), SeekOp::EQ));
-        }
-
-        return_if_io!(self.insert_into_page(key, _record));
-        self.rowid.replace(Some(*int_key as u64));
+        match &self.mv_cursor {
+            Some(mv_cursor) => {
+                let row_id =
+                    crate::mvcc::database::RowID::new(self.table_id() as u64, *int_key as u64);
+                let mut record_buf = Vec::new();
+                record.serialize(&mut record_buf);
+                let row = crate::mvcc::database::Row::new(row_id, record_buf);
+                mv_cursor.borrow_mut().insert(row).unwrap();
+            }
+            None => {
+                if !moved_before {
+                    return_if_io!(self.move_to(SeekKey::TableRowId(*int_key as u64), SeekOp::EQ));
+                }
+                return_if_io!(self.insert_into_page(key, record));
+                self.rowid.replace(Some(*int_key as u64));
+            }
+        };
         Ok(CursorResult::Ok(()))
     }
 
     pub fn delete(&mut self) -> Result<CursorResult<()>> {
+        assert!(self.mv_cursor.is_none());
         let page = self.stack.top();
         return_if_locked!(page);
 
@@ -1808,6 +1860,7 @@ impl BTreeCursor {
     }
 
     pub fn exists(&mut self, key: &OwnedValue) -> Result<CursorResult<bool>> {
+        assert!(self.mv_cursor.is_none());
         let int_key = match key {
             OwnedValue::Integer(i) => i,
             _ => unreachable!("btree tables are indexed by integers!"),
@@ -1926,6 +1979,10 @@ impl BTreeCursor {
         }
 
         Ok(Some(n_overflow))
+    }
+
+    pub fn table_id(&self) -> usize {
+        self.root_page
     }
 }
 
@@ -2905,7 +2962,7 @@ mod tests {
     }
 
     fn validate_btree(pager: Rc<Pager>, page_idx: usize) -> (usize, bool) {
-        let cursor = BTreeCursor::new(pager.clone(), page_idx);
+        let cursor = BTreeCursor::new(None, pager.clone(), page_idx);
         let page = pager.read_page(page_idx).unwrap();
         let page = page.get();
         let contents = page.contents.as_ref().unwrap();
@@ -2969,7 +3026,7 @@ mod tests {
     }
 
     fn format_btree(pager: Rc<Pager>, page_idx: usize, depth: usize) -> String {
-        let cursor = BTreeCursor::new(pager.clone(), page_idx);
+        let cursor = BTreeCursor::new(None, pager.clone(), page_idx);
         let page = pager.read_page(page_idx).unwrap();
         let page = page.get();
         let contents = page.contents.as_ref().unwrap();
@@ -3100,7 +3157,7 @@ mod tests {
             .as_slice(),
         ] {
             let (pager, root_page) = empty_btree();
-            let mut cursor = BTreeCursor::new(pager.clone(), root_page);
+            let mut cursor = BTreeCursor::new(None, pager.clone(), root_page);
             for (key, size) in sequence.iter() {
                 run_until_done(
                     || {
@@ -3151,7 +3208,7 @@ mod tests {
         tracing::info!("super seed: {}", seed);
         for _ in 0..attempts {
             let (pager, root_page) = empty_btree();
-            let mut cursor = BTreeCursor::new(pager.clone(), root_page);
+            let mut cursor = BTreeCursor::new(None, pager.clone(), root_page);
             let mut keys = Vec::new();
             let seed = rng.next_u64();
             tracing::info!("seed: {}", seed);
@@ -3332,7 +3389,7 @@ mod tests {
     #[ignore]
     pub fn test_clear_overflow_pages() -> Result<()> {
         let (pager, db_header) = setup_test_env(5);
-        let cursor = BTreeCursor::new(pager.clone(), 1);
+        let cursor = BTreeCursor::new(None, pager.clone(), 1);
 
         let max_local = payload_overflow_threshold_max(PageType::TableLeaf, 4096);
         let usable_size = cursor.usable_space();
@@ -3430,7 +3487,7 @@ mod tests {
     #[test]
     pub fn test_clear_overflow_pages_no_overflow() -> Result<()> {
         let (pager, db_header) = setup_test_env(5);
-        let cursor = BTreeCursor::new(pager.clone(), 1);
+        let cursor = BTreeCursor::new(None, pager.clone(), 1);
 
         let small_payload = vec![b'A'; 10];
 
@@ -3869,7 +3926,7 @@ mod tests {
         let (pager, root_page) = empty_btree();
         let mut keys = Vec::new();
         for i in 0..10000 {
-            let mut cursor = BTreeCursor::new(pager.clone(), root_page);
+            let mut cursor = BTreeCursor::new(None, pager.clone(), root_page);
             tracing::info!("INSERT INTO t VALUES ({});", i,);
             let key = OwnedValue::Integer(i);
             let value = Record::new(vec![OwnedValue::Integer(i)]);
@@ -3893,7 +3950,7 @@ mod tests {
             format_btree(pager.clone(), root_page, 0)
         );
         for key in keys.iter() {
-            let mut cursor = BTreeCursor::new(pager.clone(), root_page);
+            let mut cursor = BTreeCursor::new(None, pager.clone(), root_page);
             let key = OwnedValue::Integer(*key);
             let exists = run_until_done(|| cursor.exists(&key), pager.deref()).unwrap();
             assert!(exists, "key not found {}", key);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2811,7 +2811,7 @@ mod tests {
                 .unwrap();
         }
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), path.to_str().unwrap()).unwrap();
+        let db = Database::open_file(io.clone(), path.to_str().unwrap(), false).unwrap();
 
         db
     }

--- a/core/util.rs
+++ b/core/util.rs
@@ -41,8 +41,10 @@ pub fn parse_schema_rows(
     schema: &mut Schema,
     io: Arc<dyn IO>,
     syms: &SymbolTable,
+    mv_tx_id: Option<u64>,
 ) -> Result<()> {
     if let Some(mut rows) = rows {
+        rows.set_mv_tx_id(mv_tx_id);
         let mut automatic_indexes = Vec::new();
         loop {
             match rows.step()? {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -235,7 +235,7 @@ pub struct ProgramState {
     deferred_seek: Option<(CursorID, CursorID)>,
     ended_coroutine: Bitfield<4>, // flag to indicate that a coroutine has ended (key is the yield register. currently we assume that the yield register is always between 0-255, YOLO)
     regex_cache: RegexCache,
-    mv_tx_id: Option<crate::mvcc::database::TxID>,
+    pub(crate) mv_tx_id: Option<crate::mvcc::database::TxID>,
     interrupted: bool,
     parameters: HashMap<NonZero<usize>, OwnedValue>,
     halt_state: Option<HaltState>,
@@ -3034,6 +3034,7 @@ impl Program {
                         &mut schema,
                         conn.pager.io.clone(),
                         &conn.syms.borrow(),
+                        state.mv_tx_id,
                     )?;
                     state.pc += 1;
                 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3137,11 +3137,14 @@ impl Program {
     ) -> Result<StepResult> {
         if let Some(mv_store) = mv_store {
             let conn = self.connection.upgrade().unwrap();
-            let mut mv_transactions = conn.mv_transactions.borrow_mut();
-            for tx_id in mv_transactions.iter() {
-                mv_store.commit_tx(*tx_id).unwrap();
+            let auto_commit = *conn.auto_commit.borrow();
+            if auto_commit {
+                let mut mv_transactions = conn.mv_transactions.borrow_mut();
+                for tx_id in mv_transactions.iter() {
+                    mv_store.commit_tx(*tx_id).unwrap();
+                }
+                mv_transactions.clear();
             }
-            mv_transactions.clear();
             return Ok(StepResult::Done);
         } else {
             let connection = self

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -308,8 +308,12 @@ fn doublecheck(
 ) {
     {
         let mut env_ = env.lock().unwrap();
-        env_.db =
-            Database::open_file(env_.io.clone(), paths.doublecheck_db.to_str().unwrap()).unwrap();
+        env_.db = Database::open_file(
+            env_.io.clone(),
+            paths.doublecheck_db.to_str().unwrap(),
+            false,
+        )
+        .unwrap();
     }
 
     // Run the simulation again

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -87,7 +87,7 @@ impl SimulatorEnv {
             std::fs::remove_file(db_path).unwrap();
         }
 
-        let db = match Database::open_file(io.clone(), db_path.to_str().unwrap()) {
+        let db = match Database::open_file(io.clone(), db_path.to_str().unwrap(), false) {
             Ok(db) => db,
             Err(e) => {
                 panic!("error opening simulator test file {:?}: {:?}", db_path, e);

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn sqlite3_open(
             Err(_) => return SQLITE_MISUSE,
         },
     };
-    match limbo_core::Database::open_file(io, filename) {
+    match limbo_core::Database::open_file(io, filename, false) {
         Ok(db) => {
             let conn = db.connect().unwrap();
             *db_out = Box::leak(Box::new(sqlite3::new(db, conn)));

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -42,7 +42,7 @@ impl TempDatabase {
 
     pub fn connect_limbo(&self) -> Rc<limbo_core::Connection> {
         log::debug!("conneting to limbo");
-        let db = Database::open_file(self.io.clone(), self.path.to_str().unwrap()).unwrap();
+        let db = Database::open_file(self.io.clone(), self.path.to_str().unwrap(), false).unwrap();
 
         let conn = db.connect().unwrap();
         log::debug!("connected to limbo");
@@ -51,7 +51,7 @@ impl TempDatabase {
 
     pub fn limbo_database(&self) -> Arc<limbo_core::Database> {
         log::debug!("conneting to limbo");
-        Database::open_file(self.io.clone(), self.path.to_str().unwrap()).unwrap()
+        Database::open_file(self.io.clone(), self.path.to_str().unwrap(), false).unwrap()
     }
 }
 


### PR DESCRIPTION
This pull request integrates MVCC with the VDBE.

The long term plan is to implement SQLite `BEGIN CONCURRENT` by introducing a "MV store" abstraction (that implements the Hekaton in-memory MVCC index) above the pager. Traditional SQLite transactions use the pager and the WAL, but MV store has its own transaction path that updates the in-memory multi-versioned index. If a key does not exist in the MVCC index, we read records from the pager. When a MVCC transaction commits, we emit WAL entries.

In this pull request, we wire up the MVCC transaction machinery to VDBE and multi-version cursor to the b-tree cursor. Currently, the database either runs in normal b-tree mode or in in-memory MVCC, but we need to explore if we can make it a hybrid solution where you can read from both MVCC index and B-Tree. Note that this pull request also does not add logical logging to a file, which is something we'll defer for later.