### PR TITLE
Initial support for WITH clauses (common table expressions)

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -86,7 +86,7 @@ The current status of Limbo is:
 | UPDATE                    | No      |                                                                                   |
 | UPSERT                    | No      |                                                                                   |
 | VACUUM                    | No      |                                                                                   |
-| WITH clause               | No      |                                                                                   |
+| WITH clause               | Partial | No RECURSIVE, no MATERIALIZED, only SELECT supported in CTEs                      |
 
 #### [PRAGMA](https://www.sqlite.org/pragma.html)
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -345,6 +345,7 @@ impl Connection {
                             &self.schema.borrow(),
                             *select,
                             &self.db.syms.borrow(),
+                            None,
                         )?;
                         optimize_plan(&mut plan, &self.schema.borrow())?;
                         println!("{}", plan);

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1,7 +1,7 @@
 use super::{
     plan::{
-        Aggregate, JoinInfo, Operation, Plan, ResultSetColumn, SelectQueryType, TableReference,
-        WhereTerm,
+        Aggregate, JoinInfo, Operation, Plan, ResultSetColumn, SelectPlan, SelectQueryType,
+        TableReference, WhereTerm,
     },
     select::prepare_select_plan,
     SymbolTable,
@@ -13,7 +13,9 @@ use crate::{
     vdbe::BranchOffset,
     Result, VirtualTable,
 };
-use sqlite3_parser::ast::{self, Expr, FromClause, JoinType, Limit, UnaryOperator};
+use sqlite3_parser::ast::{
+    self, Expr, FromClause, JoinType, Limit, Materialized, UnaryOperator, With,
+};
 
 pub const ROWID: &str = "rowid";
 
@@ -278,46 +280,92 @@ pub fn bind_column_references(
     }
 }
 
-fn parse_from_clause_table(
+fn parse_from_clause_table<'a>(
     schema: &Schema,
     table: ast::SelectTable,
-    cur_table_index: usize,
+    scope: &mut Scope<'a>,
     syms: &SymbolTable,
-) -> Result<TableReference> {
+) -> Result<()> {
     match table {
         ast::SelectTable::Table(qualified_name, maybe_alias, _) => {
             let normalized_qualified_name = normalize_ident(qualified_name.name.0.as_str());
-            let Some(table) = schema.get_table(&normalized_qualified_name) else {
-                crate::bail_parse_error!("Table {} not found", normalized_qualified_name);
+            // Check if the FROM clause table is referring to a CTE in the current scope.
+            if let Some(cte) = scope
+                .ctes
+                .iter()
+                .find(|cte| cte.name == normalized_qualified_name)
+            {
+                // CTE can be rewritten as a subquery.
+                // TODO: find a way not to clone the CTE plan here.
+                let cte_table =
+                    TableReference::new_subquery(cte.name.clone(), cte.plan.clone(), None);
+                scope.tables.push(cte_table);
+                return Ok(());
             };
-            let alias = maybe_alias
-                .map(|a| match a {
-                    ast::As::As(id) => id,
-                    ast::As::Elided(id) => id,
-                })
-                .map(|a| a.0);
-            Ok(TableReference {
-                op: Operation::Scan { iter_dir: None },
-                table: Table::BTree(table.clone()),
-                identifier: alias.unwrap_or(normalized_qualified_name),
-                join_info: None,
-            })
+            // Check if our top level schema has this table.
+            if let Some(table) = schema.get_table(&normalized_qualified_name) {
+                let alias = maybe_alias
+                    .map(|a| match a {
+                        ast::As::As(id) => id,
+                        ast::As::Elided(id) => id,
+                    })
+                    .map(|a| a.0);
+                scope.tables.push(TableReference {
+                    op: Operation::Scan { iter_dir: None },
+                    table: Table::BTree(table.clone()),
+                    identifier: alias.unwrap_or(normalized_qualified_name),
+                    join_info: None,
+                });
+                return Ok(());
+            };
+
+            // Check if the outer query scope has this table.
+            if let Some(outer_scope) = scope.parent {
+                if let Some(table_ref_idx) = outer_scope
+                    .tables
+                    .iter()
+                    .position(|t| t.identifier == normalized_qualified_name)
+                {
+                    // TODO: avoid cloning the table reference here.
+                    scope.tables.push(outer_scope.tables[table_ref_idx].clone());
+                    return Ok(());
+                }
+                if let Some(cte) = outer_scope
+                    .ctes
+                    .iter()
+                    .find(|cte| cte.name == normalized_qualified_name)
+                {
+                    // TODO: avoid cloning the CTE plan here.
+                    let cte_table =
+                        TableReference::new_subquery(cte.name.clone(), cte.plan.clone(), None);
+                    scope.tables.push(cte_table);
+                    return Ok(());
+                }
+            }
+
+            crate::bail_parse_error!("Table {} not found", normalized_qualified_name);
         }
         ast::SelectTable::Select(subselect, maybe_alias) => {
-            let Plan::Select(mut subplan) = prepare_select_plan(schema, *subselect, syms)? else {
+            let Plan::Select(mut subplan) =
+                prepare_select_plan(schema, *subselect, syms, Some(scope))?
+            else {
                 unreachable!();
             };
             subplan.query_type = SelectQueryType::Subquery {
                 yield_reg: usize::MAX, // will be set later in bytecode emission
                 coroutine_implementation_start: BranchOffset::Placeholder, // will be set later in bytecode emission
             };
+            let cur_table_index = scope.tables.len();
             let identifier = maybe_alias
                 .map(|a| match a {
                     ast::As::As(id) => id.0.clone(),
                     ast::As::Elided(id) => id.0.clone(),
                 })
                 .unwrap_or(format!("subquery_{}", cur_table_index));
-            Ok(TableReference::new_subquery(identifier, subplan, None))
+            scope
+                .tables
+                .push(TableReference::new_subquery(identifier, subplan, None));
+            Ok(())
         }
         ast::SelectTable::TableCall(qualified_name, maybe_args, maybe_alias) => {
             let normalized_name = &normalize_ident(qualified_name.name.0.as_str());
@@ -332,7 +380,7 @@ fn parse_from_clause_table(
                 })
                 .unwrap_or(normalized_name.to_string());
 
-            Ok(TableReference {
+            scope.tables.push(TableReference {
                 op: Operation::Scan { iter_dir: None },
                 join_info: None,
                 table: Table::Virtual(
@@ -346,7 +394,8 @@ fn parse_from_clause_table(
                 )
                 .into(),
                 identifier: alias.clone(),
-            })
+            });
+            Ok(())
         }
         _ => todo!(),
     }
@@ -391,25 +440,85 @@ pub struct Cte {
     /// Currently we only support SELECT queries in CTEs.
     plan: SelectPlan,
 }
+
+pub fn parse_from<'a>(
     schema: &Schema,
     mut from: Option<FromClause>,
     syms: &SymbolTable,
+    with: Option<With>,
     out_where_clause: &mut Vec<WhereTerm>,
+    outer_scope: Option<&'a Scope<'a>>,
 ) -> Result<Vec<TableReference>> {
     if from.as_ref().and_then(|f| f.select.as_ref()).is_none() {
         return Ok(vec![]);
     }
 
+    let mut scope = Scope {
+        tables: vec![],
+        ctes: vec![],
+        parent: outer_scope,
+    };
+
+    if let Some(with) = with {
+        if with.recursive {
+            crate::bail_parse_error!("Recursive CTEs are not yet supported");
+        }
+        for cte in with.ctes {
+            if cte.materialized == Materialized::Yes {
+                crate::bail_parse_error!("Materialized CTEs are not yet supported");
+            }
+            if cte.columns.is_some() {
+                crate::bail_parse_error!("CTE columns are not yet supported");
+            }
+
+            // Check if normalized name conflicts with catalog tables or other CTEs
+            // TODO: sqlite actually allows overriding a catalog table with a CTE.
+            // We should carry over the 'Scope' struct to all of our identifier resolution.
+            let cte_name_normalized = normalize_ident(&cte.tbl_name.0);
+            if schema.get_table(&cte_name_normalized).is_some() {
+                crate::bail_parse_error!(
+                    "CTE name {} conflicts with catalog table name",
+                    cte.tbl_name.0
+                );
+            }
+            if scope
+                .tables
+                .iter()
+                .any(|t| t.identifier == cte_name_normalized)
+            {
+                crate::bail_parse_error!("CTE name {} conflicts with table name", cte.tbl_name.0);
+            }
+            if scope.ctes.iter().any(|c| c.name == cte_name_normalized) {
+                crate::bail_parse_error!("duplicate WITH table name {}", cte.tbl_name.0);
+            }
+
+            // CTE can refer to other CTEs that came before it, plus any schema tables or tables in the outer scope.
+            let cte_plan = prepare_select_plan(schema, *cte.select, syms, Some(&scope))?;
+            let Plan::Select(mut cte_plan) = cte_plan else {
+                crate::bail_parse_error!("Only SELECT queries are currently supported in CTEs");
+            };
+            // CTE can be rewritten as a subquery.
+            cte_plan.query_type = SelectQueryType::Subquery {
+                yield_reg: usize::MAX, // will be set later in bytecode emission
+                coroutine_implementation_start: BranchOffset::Placeholder, // will be set later in bytecode emission
+            };
+            scope.ctes.push(Cte {
+                name: cte_name_normalized,
+                plan: cte_plan,
+            });
+        }
+    }
+
     let mut from_owned = std::mem::take(&mut from).unwrap();
     let select_owned = *std::mem::take(&mut from_owned.select).unwrap();
     let joins_owned = std::mem::take(&mut from_owned.joins).unwrap_or_default();
-    let mut tables = vec![parse_from_clause_table(schema, select_owned, 0, syms)?];
+    parse_from_clause_table(schema, select_owned, &mut scope, syms)?;
 
     for join in joins_owned.into_iter() {
-        parse_join(schema, join, syms, &mut tables, out_where_clause)?;
+        parse_join(schema, join, syms, &mut scope, out_where_clause)?;
     }
 
-    Ok(tables)
+    Ok(scope.tables)
 }
 
 pub fn parse_where(
@@ -489,11 +598,11 @@ fn get_rightmost_table_referenced_in_expr<'a>(predicate: &'a ast::Expr) -> Resul
     Ok(max_table_idx)
 }
 
-fn parse_join(
+fn parse_join<'a>(
     schema: &Schema,
     join: ast::JoinedSelectTable,
     syms: &SymbolTable,
-    tables: &mut Vec<TableReference>,
+    scope: &mut Scope<'a>,
     out_where_clause: &mut Vec<WhereTerm>,
 ) -> Result<()> {
     let ast::JoinedSelectTable {
@@ -502,9 +611,7 @@ fn parse_join(
         constraint,
     } = join;
 
-    let cur_table_index = tables.len();
-    let table = parse_from_clause_table(schema, table, cur_table_index, syms)?;
-    tables.push(table);
+    parse_from_clause_table(schema, table, scope, syms)?;
 
     let (outer, natural) = match join_operator {
         ast::JoinOperator::TypedJoin(Some(join_type)) => {
@@ -522,15 +629,15 @@ fn parse_join(
     }
 
     let constraint = if natural {
-        assert!(tables.len() >= 2);
-        let rightmost_table = tables.last().unwrap();
+        assert!(scope.tables.len() >= 2);
+        let rightmost_table = scope.tables.last().unwrap();
         // NATURAL JOIN is first transformed into a USING join with the common columns
         let right_cols = rightmost_table.columns();
         let mut distinct_names: Option<ast::DistinctNames> = None;
         // TODO: O(n^2) maybe not great for large tables or big multiway joins
         for right_col in right_cols.iter() {
             let mut found_match = false;
-            for left_table in tables.iter().take(tables.len() - 1) {
+            for left_table in scope.tables.iter().take(scope.tables.len() - 1) {
                 for left_col in left_table.columns().iter() {
                     if left_col.name == right_col.name {
                         if let Some(distinct_names) = distinct_names.as_mut() {
@@ -568,10 +675,10 @@ fn parse_join(
                 let mut preds = vec![];
                 break_predicate_at_and_boundaries(expr, &mut preds);
                 for predicate in preds.iter_mut() {
-                    bind_column_references(predicate, tables, None)?;
+                    bind_column_references(predicate, &scope.tables, None)?;
                 }
                 for pred in preds {
-                    let cur_table_idx = tables.len() - 1;
+                    let cur_table_idx = scope.tables.len() - 1;
                     let eval_at_loop = if outer {
                         cur_table_idx
                     } else {
@@ -588,10 +695,10 @@ fn parse_join(
                 // USING join is replaced with a list of equality predicates
                 for distinct_name in distinct_names.iter() {
                     let name_normalized = normalize_ident(distinct_name.0.as_str());
-                    let cur_table_idx = tables.len() - 1;
-                    let left_tables = &tables[..cur_table_idx];
+                    let cur_table_idx = scope.tables.len() - 1;
+                    let left_tables = &scope.tables[..cur_table_idx];
                     assert!(!left_tables.is_empty());
-                    let right_table = tables.last().unwrap();
+                    let right_table = scope.tables.last().unwrap();
                     let mut left_col = None;
                     for (left_table_idx, left_table) in left_tables.iter().enumerate() {
                         left_col = left_table
@@ -658,9 +765,9 @@ fn parse_join(
         }
     }
 
-    assert!(tables.len() >= 2);
-    let last_idx = tables.len() - 1;
-    let rightmost_table = tables.get_mut(last_idx).unwrap();
+    assert!(scope.tables.len() >= 2);
+    let last_idx = scope.tables.len() - 1;
+    let rightmost_table = scope.tables.get_mut(last_idx).unwrap();
     rightmost_table.join_info = Some(JoinInfo { outer, using });
 
     Ok(())

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1,5 +1,6 @@
 use super::emitter::emit_program;
 use super::plan::{select_star, Operation, Search, SelectQueryType};
+use super::planner::Scope;
 use crate::function::{AggFunc, ExtFunc, Func};
 use crate::translate::optimizer::optimize_plan;
 use crate::translate::plan::{Aggregate, Direction, GroupBy, Plan, ResultSetColumn, SelectPlan};
@@ -20,7 +21,7 @@ pub fn translate_select(
     select: ast::Select,
     syms: &SymbolTable,
 ) -> Result<ProgramBuilder> {
-    let mut select_plan = prepare_select_plan(schema, select, syms)?;
+    let mut select_plan = prepare_select_plan(schema, select, syms, None)?;
     optimize_plan(&mut select_plan, schema)?;
     let Plan::Select(ref select) = select_plan else {
         panic!("select_plan is not a SelectPlan");
@@ -36,10 +37,11 @@ pub fn translate_select(
     Ok(program)
 }
 
-pub fn prepare_select_plan(
+pub fn prepare_select_plan<'a>(
     schema: &Schema,
     select: ast::Select,
     syms: &SymbolTable,
+    outer_scope: Option<&'a Scope<'a>>,
 ) -> Result<Plan> {
     match *select.body.select {
         ast::OneSelect::Select {
@@ -56,8 +58,11 @@ pub fn prepare_select_plan(
 
             let mut where_predicates = vec![];
 
+            let with = select.with;
+
             // Parse the FROM clause into a vec of TableReferences. Fold all the join conditions expressions into the WHERE clause.
-            let table_references = parse_from(schema, from, syms, &mut where_predicates)?;
+            let table_references =
+                parse_from(schema, from, syms, with, &mut where_predicates, outer_scope)?;
 
             // Preallocate space for the result columns
             let result_columns = Vec::with_capacity(

--- a/testing/subquery.test
+++ b/testing/subquery.test
@@ -10,11 +10,27 @@ do_execsql_test subquery-inner-filter {
     ) sub;
 } {hat!!!}
 
+do_execsql_test subquery-inner-filter-cte {
+    with sub as (
+        select concat(name, '!!!') as loud_hat 
+        from products where name = 'hat'
+    )
+    select sub.loud_hat from sub;
+} {hat!!!}
+
 do_execsql_test subquery-outer-filter {
     select sub.loud_hat from (
         select concat(name, '!!!') as loud_hat 
         from products
     ) sub where sub.loud_hat = 'hat!!!'
+} {hat!!!}
+
+do_execsql_test subquery-outer-filter-cte {
+    with sub as (
+        select concat(name, '!!!') as loud_hat 
+        from products
+    )
+    select sub.loud_hat from sub where sub.loud_hat = 'hat!!!'
 } {hat!!!}
 
 do_execsql_test subquery-without-alias {
@@ -24,10 +40,25 @@ do_execsql_test subquery-without-alias {
     );
 } {hat!!!}
 
+do_execsql_test subquery-without-alias-cte {
+    with cte as (
+        select concat(name, '!!!') as loud_hat 
+        from products where name = 'hat'
+    )
+    select loud_hat from cte;
+} {hat!!!}
+
 do_execsql_test subquery-no-alias-on-col {
     select price from (
         select * from products where name = 'hat'
     )
+} {79.0}
+
+do_execsql_test subquery-no-alias-on-col-cte {
+    with cte as (
+        select * from products where name = 'hat'
+    )
+    select price from cte
 } {79.0}
 
 do_execsql_test subquery-no-alias-on-col-named {
@@ -36,16 +67,37 @@ do_execsql_test subquery-no-alias-on-col-named {
     )
 } {79.0}
 
+do_execsql_test subquery-no-alias-on-col-named-cte {
+    with cte as (
+        select price from products where name = 'hat'
+    )
+    select price from cte
+} {79.0}
+
 do_execsql_test subquery-select-star {
     select * from (
         select price, price + 1.0, name from products where name = 'hat'
     )
 } {79.0|80.0|hat}
 
+do_execsql_test subquery-select-star-cte {
+    with cte as (
+        select price, price + 1.0, name from products where name = 'hat'
+    )
+    select * from cte
+} {79.0|80.0|hat}
+
 do_execsql_test subquery-select-table-star {
     select sub.* from (
         select price, price + 1.0, name from products where name = 'hat'
     ) sub
+} {79.0|80.0|hat}
+
+do_execsql_test subquery-select-table-star-cte {
+    with sub as (
+        select price, price + 1.0, name from products where name = 'hat'
+    )
+    select sub.* from sub
 } {79.0|80.0|hat}
 
 do_execsql_test nested-subquery {
@@ -55,6 +107,17 @@ do_execsql_test nested-subquery {
             from products where name = 'hat'
         ) nested_sub 
     ) sub;
+} {HAT!!!}
+
+do_execsql_test nested-subquery-cte {
+    with nested_sub as (
+        select concat(name, '!!!') as loud_hat 
+        from products where name = 'hat'
+    ),
+    sub as (
+        select upper(nested_sub.loud_hat) as loudest_hat from nested_sub
+    )
+    select sub.loudest_hat from sub;
 } {HAT!!!}
 
 do_execsql_test subquery-orderby-limit {
@@ -69,6 +132,18 @@ do_execsql_test subquery-orderby-limit {
 BOOTS!!!
 CAP!!!}
 
+do_execsql_test subquery-orderby-limit-cte {
+    with sub as (
+        select concat(name, '!!!') as loud_name 
+        from products 
+        order by name 
+        limit 3
+    )
+    select upper(sub.loud_name) as loudest_name from sub;
+} {ACCESSORIES!!!
+BOOTS!!!
+CAP!!!}
+
 do_execsql_test table-join-subquery {
     select sub.product_name, p.name 
     from products p join (
@@ -77,12 +152,32 @@ do_execsql_test table-join-subquery {
     ) sub on p.name = sub.product_name where p.name = 'hat'
 } {hat|hat}
 
+do_execsql_test table-join-subquery-cte {
+    with sub as (
+        select name as product_name 
+        from products
+    )
+    select sub.product_name, p.name 
+    from products p join sub on p.name = sub.product_name 
+    where p.name = 'hat'
+} {hat|hat}
+
 do_execsql_test subquery-join-table {
     select sub.product_name, p.name
     from (
         select name as product_name 
         from products
     ) sub join products p on sub.product_name = p.name where sub.product_name = 'hat'
+} {hat|hat}
+
+do_execsql_test subquery-join-table-cte {
+    with sub as (
+        select name as product_name 
+        from products
+    )
+    select sub.product_name, p.name
+    from sub join products p on sub.product_name = p.name 
+    where sub.product_name = 'hat'
 } {hat|hat}
 
 do_execsql_test subquery-join-subquery {
@@ -98,6 +193,21 @@ do_execsql_test subquery-join-subquery {
     ) sub2;
 } {"cap|no cap"}
 
+do_execsql_test subquery-join-subquery-cte {
+    with sub1 as (
+        select name as sus_name
+        from products
+        where name = 'cap'
+    ),
+    sub2 as (
+        select concat('no ', name) as truthful_name
+        from products 
+        where name = 'cap'
+    )
+    select sub1.sus_name, sub2.truthful_name
+    from sub1 join sub2;
+} {"cap|no cap"}
+
 do_execsql_test select-star-table-subquery {
     select * 
     from products p join (
@@ -107,6 +217,16 @@ do_execsql_test select-star-table-subquery {
     ) sub on p.name = sub.name;
 } {1|hat|79.0|hat|79.0}
 
+do_execsql_test select-star-table-subquery-cte {
+    with sub as (
+        select name, price 
+        from products
+        where name = 'hat'
+    )
+    select * 
+    from products p join sub on p.name = sub.name;
+} {1|hat|79.0|hat|79.0}
+
 do_execsql_test select-star-subquery-table {
     select * 
     from (
@@ -114,6 +234,16 @@ do_execsql_test select-star-subquery-table {
         from products
         where name = 'hat'
     ) sub join products p on sub.name = p.name;
+} {hat|79.0|1|hat|79.0}
+
+do_execsql_test select-star-subquery-table-cte {
+    with sub as (
+        select name, price 
+        from products
+        where name = 'hat'
+    )
+    select * 
+    from sub join products p on sub.name = p.name;
 } {hat|79.0|1|hat|79.0}
 
 do_execsql_test select-star-subquery-subquery {
@@ -129,6 +259,20 @@ do_execsql_test select-star-subquery-subquery {
     ) sub2 on sub1.price = sub2.price;
 } {hat|79.0|79.0}
 
+do_execsql_test select-star-subquery-subquery-cte {
+    with sub1 as (
+        select name, price 
+        from products
+        where name = 'hat'
+    ),
+    sub2 as (
+        select price
+        from products 
+        where name = 'hat'
+    )
+    select *
+    from sub1 join sub2 on sub1.price = sub2.price;
+} {hat|79.0|79.0}
 
 do_execsql_test subquery-inner-grouping {
     select is_jennifer, person_count
@@ -136,6 +280,16 @@ do_execsql_test subquery-inner-grouping {
         select first_name = 'Jennifer' as is_jennifer, count(1) as person_count from users
         group by first_name = 'Jennifer'
     ) order by person_count asc
+} {1|151
+0|9849}
+
+do_execsql_test subquery-inner-grouping-cte {
+    with cte as (
+        select first_name = 'Jennifer' as is_jennifer, count(1) as person_count from users
+        group by first_name = 'Jennifer'
+    )
+    select is_jennifer, person_count
+    from cte order by person_count asc
 } {1|151
 0|9849}
 
@@ -147,6 +301,15 @@ do_execsql_test subquery-outer-grouping {
 } {1|151
 0|9849}
 
+do_execsql_test subquery-outer-grouping-cte {
+    with cte as (
+        select first_name = 'Jennifer' as is_jennifer from users
+    )
+    select is_jennifer, count(1) as person_count
+    from cte group by is_jennifer order by count(1) asc
+} {1|151
+0|9849}
+
 do_execsql_test subquery-join-using-with-outer-limit {
     SELECT p.name, sub.funny_name 
     FROM products p 
@@ -154,6 +317,19 @@ do_execsql_test subquery-join-using-with-outer-limit {
         select id, concat(name, '-lol') as funny_name 
         from products
     ) sub USING (id) 
+    LIMIT 3;
+} {"hat|hat-lol
+cap|cap-lol
+shirt|shirt-lol"}
+
+do_execsql_test subquery-join-using-with-outer-limit-cte {
+    WITH sub AS (
+        select id, concat(name, '-lol') as funny_name 
+        from products
+    )
+    SELECT p.name, sub.funny_name 
+    FROM products p 
+    JOIN sub USING (id) 
     LIMIT 3;
 } {"hat|hat-lol
 cap|cap-lol
@@ -171,6 +347,19 @@ do_execsql_test subquery-join-using-with-inner-limit {
 cap|cap-lol
 shirt|shirt-lol"}
 
+do_execsql_test subquery-join-using-with-inner-limit-cte {
+    WITH sub AS (
+        select id, concat(name, '-lol') as funny_name 
+        from products
+        limit 3
+    )
+    SELECT p.name, sub.funny_name 
+    FROM products p 
+    JOIN sub USING (id);
+} {"hat|hat-lol
+cap|cap-lol
+shirt|shirt-lol"}
+
 do_execsql_test subquery-join-using-with-both-limits {
     SELECT p.name, sub.funny_name 
     FROM products p 
@@ -179,6 +368,19 @@ do_execsql_test subquery-join-using-with-both-limits {
         from products
         limit 3
     ) sub USING (id)
+    LIMIT 2;
+} {"hat|hat-lol
+cap|cap-lol"}
+
+do_execsql_test subquery-join-using-with-both-limits-cte {
+    WITH sub AS (
+        select id, concat(name, '-lol') as funny_name 
+        from products
+        limit 3
+    )
+    SELECT p.name, sub.funny_name 
+    FROM products p 
+    JOIN sub USING (id)
     LIMIT 2;
 } {"hat|hat-lol
 cap|cap-lol"}
@@ -192,3 +394,20 @@ do_execsql_test subquery-containing-join {
 } {hat|Jamie
 cap|Cindy
 shirt|Tommy}
+
+do_execsql_test subquery-containing-join-cte {
+    with cte as (
+        select p.name as foo, u.first_name as bar 
+        from products p join users u using (id)
+    )
+    select foo, bar 
+    from cte limit 3;
+} {hat|Jamie
+cap|Cindy
+shirt|Tommy}
+
+do_execsql_test subquery-ignore-unused-cte {
+    with unused as (select last_name from users), 
+    sub as (select first_name from users where first_name = 'Jamie' limit 1) 
+    select * from sub;
+} {Jamie}


### PR DESCRIPTION
Adds initial limited support for CTEs.

- No MATERIALIZED
- No RECURSIVE
- No named CTE columns
- Only SELECT statements supported inside CTE

Basically this kind of WITH clause can just be rewritten as a subquery, so this PR adds some plumbing to rewrite them using the existing subquery machinery.

It also introduces the concept of a `Scope` where a child query can refer to its parent, useful for CTEs like:

```
do_execsql_test nested-subquery-cte {
    with nested_sub as (
        select concat(name, '!!!') as loud_hat 
        from products where name = 'hat'
    ),
    sub as (
        select upper(nested_sub.loud_hat) as loudest_hat from nested_sub
    )
    select sub.loudest_hat from sub;
} {HAT!!!}
```

I think we need to expand the use of `Scope` to all of our identifier resolutions (currently we don't explicitly have logic for determining what a given query can see), but I didn't want to bloat the PR too much. Hence, this implementation is probably full of all sorts of bugs, but I've added equivalent tests for ALL the existing subquery tests, rewritten in CTE form.