### PR TITLE
simulator: add delete support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,8 @@ dependencies = [
  "notify",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "regex",
+ "regex-syntax",
  "serde",
  "serde_json",
  "tempfile",

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -14,7 +14,10 @@ use crate::{
 
 use crate::generation::{frequency, Arbitrary, ArbitraryFrom};
 
-use super::property::{remaining, Property};
+use super::{
+    property::{remaining, Property},
+    table,
+};
 
 pub(crate) type ResultSet = Result<Vec<Vec<Value>>>;
 
@@ -303,7 +306,15 @@ impl Interactions {
                                     .unwrap();
                                 table.rows.extend(values);
                             }
-                            Query::Delete(_) => todo!(),
+                            Query::Delete(delete) => {
+                                let table = env
+                                    .tables
+                                    .iter_mut()
+                                    .find(|t| t.name == delete.table)
+                                    .unwrap();
+                                let t2 = &table.clone();
+                                table.rows.retain_mut(|r| delete.predicate.test(r, t2));
+                            }
                             Query::Select(_) => {}
                         },
                         Interaction::Assertion(_) => {}

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -113,7 +113,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &Remaining)> for Query {
                     Box::new(|rng| Self::Insert(Insert::arbitrary_from(rng, env))),
                 ),
                 (
-                    0.0,
+                    remaining.write,
                     Box::new(|rng| Self::Delete(Delete::arbitrary_from(rng, env))),
                 ),
             ],

--- a/simulator/model/query.rs
+++ b/simulator/model/query.rs
@@ -288,7 +288,7 @@ pub(crate) struct Delete {
 
 impl Delete {
     pub(crate) fn shadow(&self, _env: &mut SimulatorEnv) -> Vec<Vec<Value>> {
-        todo!()
+        vec![]
     }
 }
 

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -31,7 +31,8 @@ impl InteractionPlan {
             if let Interactions::Property(p) = interaction {
                 match p {
                     Property::InsertValuesSelect { queries, .. }
-                    | Property::DoubleCreateFailure { queries, .. } => {
+                    | Property::DoubleCreateFailure { queries, .. }
+                    | Property::DeleteSelect { queries, .. } => {
                         queries.clear();
                     }
                     Property::SelectLimit { .. } => {}


### PR DESCRIPTION
This PR enables the generation of delete statements in the simulator. There is still some work to do(I would like to add delete a specific property).

This version currently hits a corruption error with seed `3270937128460682661`, if anyone could debug it and let me know if it's the generation that's wrong or the delete code has a bug, I would be very grateful.