### PR TITLE
Replace hashmap for io_uring pending ops with static array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,8 @@ dependencies = [
  "notify",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "regex",
+ "regex-syntax",
  "serde",
  "serde_json",
  "tempfile",


### PR DESCRIPTION
Since we are already round robin'ing our `iovecs` in the same way, and the map will never be larger than MAX_IOVECS, we can remove the cost of hashing and keep o(1) lookups.