### PR TITLE
cli: Add column names in Pretty mode

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -2,7 +2,7 @@ use crate::{
     import::{ImportFile, IMPORT_HELP},
     opcodes_dictionary::OPCODE_DESCRIPTIONS,
 };
-use cli_table::{Cell, Table};
+use cli_table::{Cell, Style, Table};
 use limbo_core::{Database, LimboError, Statement, StepResult, Value};
 
 use clap::{Parser, ValueEnum};
@@ -670,6 +670,16 @@ impl Limbo {
                         return Ok(());
                     }
                     let mut table_rows: Vec<Vec<_>> = vec![];
+                    if rows.num_columns() > 0 {
+                        let columns = (0..rows.num_columns())
+                            .map(|i| {
+                                rows.get_column_name(i)
+                                    .map(|name| name.cell().bold(true))
+                                    .unwrap_or_else(|| " ".cell())
+                            })
+                            .collect::<Vec<_>>();
+                        table_rows.push(columns);
+                    }
                     loop {
                         match rows.step() {
                             Ok(StepResult::Row) => {


### PR DESCRIPTION
This is especially useful if you frequently run SQL query like `SELECT * ...`.

## Before
```
limbo> .mode pretty
limbo> select 123 as column1, 'Hello world' as column_2;
+-----+-------------+
| 123 | Hello world |
+-----+-------------+
```
## After
```
limbo> .mode pretty
limbo> select 123 as column1, 'Hello world' as column_2;
+---------+-------------+
| column1 | column_2    |
+---------+-------------+
| 123     | Hello world |
+---------+-------------+
```

---
In the future, if limbo adds a method like `.decl_type()`, we can also display the data type.

###### DuckDB
```
D select 123 as column1, 'Hello world' as column_2;
┌─────────┬─────────────┐
│ column1 │  column_2   │
│  int32  │   varchar   │
├─────────┼─────────────┤
│   123   │ Hello world │
└─────────┴─────────────┘
```

