### PR TITLE
core: make "result" module public, because it is needed to implement …

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -9,7 +9,7 @@ mod json;
 pub mod mvcc;
 mod parameters;
 mod pseudo;
-mod result;
+pub mod result;
 mod schema;
 mod storage;
 mod translate;


### PR DESCRIPTION
…trait Wal, which is public