### PR TITLE
Expose types in Wal

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -9,7 +9,7 @@ mod json;
 pub mod mvcc;
 mod parameters;
 mod pseudo;
-mod result;
+pub mod result;
 mod schema;
 mod storage;
 mod translate;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -44,6 +44,7 @@ use storage::page_cache::DumbLruPageCache;
 use storage::pager::allocate_page;
 pub use storage::pager::PageRef;
 use storage::sqlite3_ondisk::{DatabaseHeader, DATABASE_HEADER_SIZE};
+pub use storage::wal::CheckpointMode;
 pub use storage::wal::WalFile;
 pub use storage::wal::WalFileShared;
 use types::OwnedValue;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -42,6 +42,7 @@ use storage::btree::btree_init_page;
 use storage::database::FileStorage;
 use storage::page_cache::DumbLruPageCache;
 use storage::pager::allocate_page;
+pub use storage::pager::PageRef;
 use storage::sqlite3_ondisk::{DatabaseHeader, DATABASE_HEADER_SIZE};
 pub use storage::wal::WalFile;
 pub use storage::wal::WalFileShared;


### PR DESCRIPTION
We expose Wal trait as public, but there are three types in its signature that are private.

Notice I chose to expose limbo_core::result instead of limbo_core::result::LimboResult, since LimboResult is the only type in that module.