### PR TITLE
Performance improvements for Unix I/O backend

### DIFF
--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -242,10 +242,7 @@ impl File for UringFile {
     }
 
     fn pread(&self, pos: usize, c: Completion) -> Result<()> {
-        let r = match c {
-            Completion::Read(ref r) => r,
-            _ => unreachable!(),
-        };
+        let r = c.as_read();
         trace!("pread(pos = {}, length = {})", pos, r.buf().len());
         let fd = io_uring::types::Fd(self.file.as_raw_fd());
         let mut io = self.io.borrow_mut();

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -79,10 +79,7 @@ impl File for MemoryFile {
     }
 
     fn pread(&self, pos: usize, c: Completion) -> Result<()> {
-        let r = match &c {
-            Completion::Read(ref r) => r,
-            _ => unreachable!(),
-        };
+        let r = c.as_read();
         let buf_len = r.buf().len();
         if buf_len == 0 {
             c.complete(0);

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -59,26 +59,9 @@ impl Completion {
 
     /// only call this method if you are sure that the completion is
     /// a ReadCompletion, panics otherwise
-    pub fn read(&self) -> &ReadCompletion {
+    pub fn as_read(&self) -> &ReadCompletion {
         match self {
             Self::Read(ref r) => r,
-            _ => unreachable!(),
-        }
-    }
-    /// only call this method if you are sure that the completion is
-    /// a WriteCompletion, panics otherwise
-    pub fn write(&self) -> &WriteCompletion {
-        match self {
-            Self::Write(ref w) => w,
-            _ => unreachable!(),
-        }
-    }
-    ///
-    /// only call this method if you are sure that the completion is
-    /// a SyncCompletion, panics otherwise
-    pub fn sync(&self) -> &SyncCompletion {
-        match self {
-            Self::Sync(ref s) => s,
             _ => unreachable!(),
         }
     }

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -56,6 +56,32 @@ impl Completion {
             Self::Sync(s) => s.complete(result), // fix
         }
     }
+
+    /// only call this method if you are sure that the completion is
+    /// a ReadCompletion, panics otherwise
+    pub fn read(&self) -> &ReadCompletion {
+        match self {
+            Self::Read(ref r) => r,
+            _ => unreachable!(),
+        }
+    }
+    /// only call this method if you are sure that the completion is
+    /// a WriteCompletion, panics otherwise
+    pub fn write(&self) -> &WriteCompletion {
+        match self {
+            Self::Write(ref w) => w,
+            _ => unreachable!(),
+        }
+    }
+    ///
+    /// only call this method if you are sure that the completion is
+    /// a SyncCompletion, panics otherwise
+    pub fn sync(&self) -> &SyncCompletion {
+        match self {
+            Self::Sync(ref s) => s,
+            _ => unreachable!(),
+        }
+    }
 }
 
 pub struct WriteCompletion {

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -58,10 +58,7 @@ impl File for WindowsFile {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         {
-            let r = match c {
-                Completion::Read(ref r) => r,
-                _ => unreachable!(),
-            };
+            let r = c.as_read();
             let mut buf = r.buf_mut();
             let buf = buf.as_mut_slice();
             file.read_exact(buf)?;


### PR DESCRIPTION
This PR reworks the unix I/O backend, removing runtime reference counting/borrow checking and optimizing away the hashmap in favor of a static array, with an unlikely fallback vec.

The only reason the fallback vec is there is because unlike the `io_uring` module, we cannot simply index into the array with the fd  as the OS could theoretically give us a fd up to I believe 1024 so keeping an array of that size for a few elements is unnecessary.