### PR TITLE
Rework io_uring feature

### DIFF
--- a/bindings/go/Cargo.toml
+++ b/bindings/go/Cargo.toml
@@ -17,7 +17,7 @@ io_uring = ["limbo_core/io_uring"]
 
 
 [dependencies]
-limbo_core = { path = "../../core/" }
+limbo_core = { path = "../../core" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-limbo_core = { path = "../../core/", features = ["io_uring"] }
+limbo_core = { path = "../../core", features = ["io_uring"] }

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 path = "rs_src/lib.rs"
 
 [dependencies]
-limbo_core = { path = "../../core" }
+limbo_core = { path = "../../core", features = ["io_uring"] }
 jni = "0.21.1"
 thiserror = "2.0.9"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -16,7 +16,7 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 anyhow = "1.0"
-limbo_core = { path = "../../core" }
+limbo_core = { path = "../../core", features = ["io_uring"] }
 pyo3 = { version = "0.22.4", features = ["anyhow"] }
 
 [build-dependencies]

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-limbo_core = { path = "../../core" }
+limbo_core = { path = "../../core", features = ["io_uring"] }
 thiserror = "2.0.9"
 
 [dev-dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,4 +31,5 @@ csv = "1.3.1"
 miette = { version = "7.4.0", features = ["fancy"] }
 
 [features]
+default = ["io_uring"]
 io_uring = ["limbo_core/io_uring"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ name = "limbo_core"
 path = "lib.rs"
 
 [features]
-default = ["fs", "json", "uuid", "io_uring", "time"]
+default = ["fs", "json", "uuid", "time"]
 fs = []
 json = [
     "dep:jsonb",

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -153,6 +153,7 @@ impl Database {
     }
 
     pub fn register_builtins(&self) -> Result<(), String> {
+        #[allow(unused_variables)]
         let ext_api = self.build_limbo_ext();
         #[cfg(feature = "uuid")]
         if unsafe { !limbo_uuid::register_extension_static(&ext_api).is_ok() } {

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -166,14 +166,17 @@ impl Buffer {
 cfg_block! {
     #[cfg(all(target_os = "linux", feature = "io_uring"))] {
         mod io_uring;
+        #[cfg(feature = "fs")]
         pub use io_uring::UringIO;
         mod unix;
+        #[cfg(feature = "fs")]
         pub use unix::UnixIO;
         pub use io_uring::UringIO as PlatformIO;
     }
 
     #[cfg(any(all(target_os = "linux",not(feature = "io_uring")), target_os = "macos"))] {
         mod unix;
+        #[cfg(feature = "fs")]
         pub use unix::UnixIO;
         pub use unix::UnixIO as PlatformIO;
     }

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -22,6 +22,7 @@ pub struct UnixIO {
 }
 
 impl UnixIO {
+    #[cfg(feature = "fs")]
     pub fn new() -> Result<Self> {
         debug!("Using IO backend 'syscall'");
         Ok(Self {

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -1,4 +1,6 @@
-use crate::{error::LimboError, io::Completion, Buffer, Result};
+#[cfg(feature = "fs")]
+use crate::error::LimboError;
+use crate::{io::Completion, Buffer, Result};
 use std::{cell::RefCell, rc::Rc};
 
 /// DatabaseStorage is an interface a database file that consists of pages.

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -159,6 +159,7 @@ macro_rules! expect_arguments_min {
     }};
 }
 
+#[allow(unused_macros)]
 macro_rules! expect_arguments_even {
     (
         $args:expr,


### PR DESCRIPTION
This makes io_uring the default in CLI, but makes it non-default in core. Before, if one built CLI without io_uring, core still built with it as it was a default feature. To accommodate for the change, all bindings have been updated to select the feature, except for WASM which has a separate fs implementation.

This also adds some #[cfg] and #[allow] to silence unused-* warnings, which I discovered when testing with different features disabled.