### PR TITLE
Fix case and emit

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -792,7 +792,8 @@ pub fn translate_expr(
                         lhs: base_reg,
                         rhs: expr_reg,
                         target_pc: next_case_label,
-                        flags: CmpInsFlags::default(),
+                        // A NULL result is considered untrue when evaluating WHEN terms.
+                        flags: CmpInsFlags::default().jump_if_null(),
                     }),
                     // CASE WHEN 0 THEN 0 ELSE 1 becomes ifnot 0 branch to next clause
                     None => program.emit_insn(Insn::IfNot {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -110,10 +110,8 @@ impl ProgramBuilder {
 
     pub fn emit_insn(&mut self, insn: Insn) {
         if let Some(label) = self.next_insn_label {
-            self.label_to_resolved_offset.insert(
-                label.to_label_value() as usize,
-                Some(self.insns.len() as InsnReference),
-            );
+            self.label_to_resolved_offset[label.to_label_value() as usize] =
+                Some(self.insns.len() as InsnReference);
             self.next_insn_label = None;
         }
         self.insns.push(insn);

--- a/testing/select.test
+++ b/testing/select.test
@@ -108,6 +108,14 @@ do_execsql_test select_base_case_else {
   select case 1 when 0 then 'zero' when 1 then 'one' else 'two' end;
 } {one}
 
+do_execsql_test select_base_case_null_result {
+  select case NULL when 0 then 'first' else 'second' end;
+  select case NULL when NULL then 'first' else 'second' end;
+  select case 0 when 0 then 'first' else 'second' end;
+} {second
+second
+first}
+
 do_execsql_test select_base_case_noelse_null {
   select case 'null else' when 0 then 0 when 1 then 1 end;
 } {}


### PR DESCRIPTION
(after fixing complicated b-tree bugs - I want to end my day with the joy of fixing simple bugs)

This PR fix bug in emit (which was introduced after switch from `HashMap` to `Vec`) and also align `CASE` codegen in case of `NULL` result from `WHEN` clause with SQLite behaviour.