### PR TITLE
Fix coalesce

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -792,7 +792,8 @@ pub fn translate_expr(
                         lhs: base_reg,
                         rhs: expr_reg,
                         target_pc: next_case_label,
-                        flags: CmpInsFlags::default(),
+                        // A NULL result is considered untrue when evaluating WHEN terms.
+                        flags: CmpInsFlags::default().jump_if_null(),
                     }),
                     // CASE WHEN 0 THEN 0 ELSE 1 becomes ifnot 0 branch to next clause
                     None => program.emit_insn(Insn::IfNot {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -110,10 +110,8 @@ impl ProgramBuilder {
 
     pub fn emit_insn(&mut self, insn: Insn) {
         if let Some(label) = self.next_insn_label {
-            self.label_to_resolved_offset.insert(
-                label.to_label_value() as usize,
-                Some(self.insns.len() as InsnReference),
-            );
+            self.label_to_resolved_offset[label.to_label_value() as usize] =
+                Some(self.insns.len() as InsnReference);
             self.next_insn_label = None;
         }
         self.insns.push(insn);

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -20,7 +20,8 @@ pub struct ProgramBuilder {
     insns: Vec<Insn>,
     // for temporarily storing instructions that will be put after Transaction opcode
     constant_insns: Vec<Insn>,
-    next_insn_label: Option<BranchOffset>,
+    // Vector of labels which must be assigned to next emitted instruction
+    next_insn_labels: Vec<BranchOffset>,
     // Cursors that are referenced by the program. Indexed by CursorID.
     pub cursor_ref: Vec<(Option<String>, CursorType)>,
     /// A vector where index=label number, value=resolved offset. Resolved in build().
@@ -68,7 +69,7 @@ impl ProgramBuilder {
             next_free_register: 1,
             next_free_cursor_id: 0,
             insns: Vec::with_capacity(opts.approx_num_insns),
-            next_insn_label: None,
+            next_insn_labels: Vec::with_capacity(2),
             cursor_ref: Vec::with_capacity(opts.num_cursors),
             constant_insns: Vec::new(),
             label_to_resolved_offset: Vec::with_capacity(opts.approx_num_labels),
@@ -109,10 +110,9 @@ impl ProgramBuilder {
     }
 
     pub fn emit_insn(&mut self, insn: Insn) {
-        if let Some(label) = self.next_insn_label {
+        for label in self.next_insn_labels.drain(..) {
             self.label_to_resolved_offset[label.to_label_value() as usize] =
                 Some(self.insns.len() as InsnReference);
-            self.next_insn_label = None;
         }
         self.insns.push(insn);
     }
@@ -213,7 +213,7 @@ impl ProgramBuilder {
     // Useful when you know you need to jump to "the next part", but the exact offset is unknowable
     // at the time of emitting the instruction.
     pub fn preassign_label_to_next_insn(&mut self, label: BranchOffset) {
-        self.next_insn_label = Some(label);
+        self.next_insn_labels.push(label);
     }
 
     pub fn resolve_label(&mut self, label: BranchOffset, to_offset: BranchOffset) {

--- a/testing/coalesce.test
+++ b/testing/coalesce.test
@@ -11,6 +11,18 @@ do_execsql_test coalesce-2 {
     select coalesce(NULL, NULL, 1);
 } {1}
 
+do_execsql_test coalesce-nested {
+    select coalesce(NULL, coalesce(NULL, NULL));
+} {}
+
+do_execsql_test coalesce-nested-2 {
+    select coalesce(NULL, coalesce(NULL, 2));
+    select coalesce(NULL, coalesce(1, 2));
+    select coalesce(0, coalesce(1, 2));
+} {2
+1
+0}
+
 do_execsql_test coalesce-null {
     select coalesce(NULL, NULL, NULL);
 } {}

--- a/testing/select.test
+++ b/testing/select.test
@@ -108,6 +108,14 @@ do_execsql_test select_base_case_else {
   select case 1 when 0 then 'zero' when 1 then 'one' else 'two' end;
 } {one}
 
+do_execsql_test select_base_case_null_result {
+  select case NULL when 0 then 'first' else 'second' end;
+  select case NULL when NULL then 'first' else 'second' end;
+  select case 0 when 0 then 'first' else 'second' end;
+} {second
+second
+first}
+
 do_execsql_test select_base_case_noelse_null {
   select case 'null else' when 0 then 0 when 1 then 1 end;
 } {}

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -164,6 +164,7 @@ mod tests {
             "SELECT ifnull(0, NOT 0)",
             "SELECT like('a%', 'a') = 1",
             "SELECT CASE ( NULL < NULL ) WHEN ( 0 ) THEN ( NULL ) ELSE ( 2.0 ) END;",
+            "SELECT (COALESCE(0, COALESCE(0, 0)));",
         ] {
             let limbo = limbo_exec_row(&limbo_conn, query);
             let sqlite = sqlite_exec_row(&sqlite_conn, query);
@@ -229,6 +230,14 @@ mod tests {
             .repeat(1..10, "")
             .build();
 
+        let (coalesce_expr, coalesce_expr_builder) = g.create_handle();
+        coalesce_expr_builder
+            .concat("")
+            .push_str("COALESCE(")
+            .push(g.create().concat("").push(expr).repeat(2..5, ",").build())
+            .push_str(")")
+            .build();
+
         let (case_expr, case_expr_builder) = g.create_handle();
         case_expr_builder
             .concat(" ")
@@ -253,6 +262,7 @@ mod tests {
 
         scalar_builder
             .choice()
+            .option(coalesce_expr)
             .option(
                 g.create()
                     .concat("")


### PR DESCRIPTION
Add `COALESCE` function in fuzz test and fix bug (found by fuzzer with `COALESCE`) related to the resolution of labels which needs to be resolved to next emitted instruction.

Before, code assumed that no two labels will need to be resolved to next emitted instruction. But this assumption is wrong (at least in current codegen logic) for example for following expression `COALESCE(0, COALESCE(0, 0))`. Here, both `COALESCE` functions will create label and resolve it to next emitted instruction in the end of generation. So, in this case one of the labels will be actually "orphaned" and never be assigned any position in the emitted code.