### PR TITLE
Implement SQLite balancing algorithm

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -229,8 +229,8 @@ pub fn maybe_init_database_file(file: &Rc<dyn File>, io: &Arc<dyn IO>) -> Result
             btree_init_page(
                 &page1,
                 storage::sqlite3_ondisk::PageType::TableLeaf,
-                &db_header,
                 DATABASE_HEADER_SIZE,
+                db_header.page_size - db_header.reserved_space as u16,
             );
 
             let contents = page1.get().contents.as_mut().unwrap();

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2392,7 +2392,7 @@ fn free_cell_range(page: &mut PageContent, mut offset: u16, len: u16, usable_spa
         pc
     };
 
-    if offset < page.cell_content_area() {
+    if offset <= page.cell_content_area() {
         page.write_u16(PAGE_HEADER_OFFSET_FIRST_FREEBLOCK, pc);
         page.write_u16(PAGE_HEADER_OFFSET_CELL_CONTENT_AREA, offset + len);
     } else {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2854,17 +2854,23 @@ mod tests {
         assert_eq!(buf, payload);
     }
 
-    fn add_record(page: &mut PageContent, record: OwnedRecord, db: &Arc<Database>) -> Vec<u8> {
+    fn add_record(
+        id: usize,
+        pos: usize,
+        page: &mut PageContent,
+        record: OwnedRecord,
+        db: &Arc<Database>,
+    ) -> Vec<u8> {
         let mut payload: Vec<u8> = Vec::new();
         fill_cell_payload(
             page.page_type(),
-            Some(1),
+            Some(id as u64),
             &mut payload,
             &record,
             4096,
             db.pager.clone(),
         );
-        insert_into_cell(page, &payload, 0, 4096);
+        insert_into_cell(page, &payload, pos, 4096);
         payload
     }
 
@@ -2875,7 +2881,7 @@ mod tests {
         let page = page.get_contents();
         let header_size = 8;
         let record = OwnedRecord::new([OwnedValue::Integer(1)].to_vec());
-        let payload = add_record(page, record, &db);
+        let payload = add_record(1, 0, page, record, &db);
         assert_eq!(page.cell_count(), 1);
         let free = compute_free_space(page, 4096);
         assert_eq!(free, 4096 - payload.len() as u16 - 2 - header_size);
@@ -2894,8 +2900,8 @@ mod tests {
         let mut total_size = 0;
         let mut payloads = Vec::new();
         for i in 0..10 {
-            let record = OwnedRecord::new([OwnedValue::Integer(1)].to_vec());
-            let payload = add_record(page, record, &db);
+            let record = OwnedRecord::new([OwnedValue::Integer(i as i64)].to_vec());
+            let payload = add_record(i, i, page, record, &db);
             assert_eq!(page.cell_count(), i + 1);
             let free = compute_free_space(page, 4096);
             total_size += payload.len() as u16 + 2;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1507,9 +1507,9 @@ impl BTreeCursor {
                     let (cell_pointer_offset, _) = contents.cell_pointer_array_offset_and_size();
                     // change cell pointers
                     for cell_idx in 0..contents.cell_count() {
-                        let cell_pointer_offset = cell_pointer_offset + (2 * cell_idx) - offset;
-                        let pc = contents.read_u16(cell_pointer_offset);
-                        contents.write_u16(cell_pointer_offset, pc - offset as u16);
+                        let cell_pointer_offset = cell_pointer_offset + (2 * cell_idx);
+                        let pc = contents.read_u16_no_offset(cell_pointer_offset);
+                        contents.write_u16_no_offset(cell_pointer_offset, pc as u16);
                     }
 
                     contents.offset = 0;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3553,7 +3553,6 @@ mod tests {
         let mut total_size = 0;
         let mut cells = Vec::new();
         let usable_space = 4096;
-        let total_cells = 10;
         let mut i = 1000;
         let seed = thread_rng().gen();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -3633,12 +3632,12 @@ mod tests {
 
         let record = Record::new(
             [
-                OwnedValue::Integer(0 as i64),
+                OwnedValue::Integer(0),
                 OwnedValue::Text(Text::new("aaaaaaaa")),
             ]
             .to_vec(),
         );
-        let payload = add_record(0, 0, page, record, &db);
+        let _ = add_record(0, 0, page, record, &db);
 
         assert_eq!(page.cell_count(), 1);
         drop_cell(page, 0, usable_space).unwrap();
@@ -3668,19 +3667,19 @@ mod tests {
 
         let record = Record::new(
             [
-                OwnedValue::Integer(0 as i64),
+                OwnedValue::Integer(0),
                 OwnedValue::Text(Text::new("aaaaaaaa")),
             ]
             .to_vec(),
         );
-        let payload = add_record(0, 0, page, record, &db);
+        let _ = add_record(0, 0, page, record, &db);
 
-        for i in 0..100 {
+        for _ in 0..100 {
             assert_eq!(page.cell_count(), 1);
             drop_cell(page, 0, usable_space).unwrap();
             assert_eq!(page.cell_count(), 0);
 
-            let record = Record::new([OwnedValue::Integer(0 as i64)].to_vec());
+            let record = Record::new([OwnedValue::Integer(0)].to_vec());
             let payload = add_record(0, 0, page, record, &db);
             assert_eq!(page.cell_count(), 1);
 
@@ -3703,11 +3702,11 @@ mod tests {
         let page = page.get_contents();
         let usable_space = 4096;
 
-        let record = Record::new([OwnedValue::Integer(0 as i64)].to_vec());
+        let record = Record::new([OwnedValue::Integer(0)].to_vec());
         let payload = add_record(0, 0, page, record, &db);
-        let record = Record::new([OwnedValue::Integer(1 as i64)].to_vec());
+        let record = Record::new([OwnedValue::Integer(1)].to_vec());
         let _ = add_record(1, 1, page, record, &db);
-        let record = Record::new([OwnedValue::Integer(2 as i64)].to_vec());
+        let record = Record::new([OwnedValue::Integer(2)].to_vec());
         let _ = add_record(2, 2, page, record, &db);
 
         drop_cell(page, 1, usable_space).unwrap();
@@ -3724,21 +3723,21 @@ mod tests {
         let page = page.get_contents();
         let usable_space = 4096;
 
-        let record = Record::new([OwnedValue::Integer(0 as i64)].to_vec());
+        let record = Record::new([OwnedValue::Integer(0)].to_vec());
         let _ = add_record(0, 0, page, record, &db);
 
-        let record = Record::new([OwnedValue::Integer(0 as i64)].to_vec());
+        let record = Record::new([OwnedValue::Integer(0)].to_vec());
         let _ = add_record(0, 0, page, record, &db);
         drop_cell(page, 0, usable_space).unwrap();
 
         defragment_page(page, usable_space);
 
-        let record = Record::new([OwnedValue::Integer(0 as i64)].to_vec());
+        let record = Record::new([OwnedValue::Integer(0)].to_vec());
         let _ = add_record(0, 1, page, record, &db);
 
         drop_cell(page, 0, usable_space).unwrap();
 
-        let record = Record::new([OwnedValue::Integer(0 as i64)].to_vec());
+        let record = Record::new([OwnedValue::Integer(0)].to_vec());
         let _ = add_record(0, 1, page, record, &db);
     }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2098,16 +2098,16 @@ fn find_free_cell(page_ref: &PageContent, usable_space: u16, amount: usize) -> R
                     page_ref.write_u8(PAGE_HEADER_OFFSET_FRAGMENTED_BYTES_COUNT, frag);
                 }
                 pc += new_size as usize;
-                return Ok(pc);
             }
+            return Ok(pc);
         }
         prev_pc = pc;
+        pc = next as usize;
         if pc <= prev_pc && pc != 0 {
             return Err(LimboError::Corrupt(
                 "Free list not in ascending order".into(),
             ));
         }
-        pc = next as usize;
     }
     if pc > maxpc + amount - 4 {
         return Err(LimboError::Corrupt(

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1124,7 +1124,7 @@ impl BTreeCursor {
                         cell_array.cells.push(to_static_buf(cell_buf));
                     }
                     // Insert overflow cells into correct place
-                    let mut offset = total_cells_inserted;
+                    let offset = total_cells_inserted;
                     assert!(
                         old_page_contents.overflow_cells.len() <= 1,
                         "todo: check this works for more than one overflow cell"
@@ -1399,8 +1399,8 @@ impl BTreeCursor {
                 }
                 // TODO: update pages
                 let mut done = vec![false; sibling_count_new];
-                for i in (1 as i64 - sibling_count_new as i64)..sibling_count_new as i64 {
-                    let page_idx = i.abs() as usize;
+                for i in (1 - sibling_count_new as i64)..sibling_count_new as i64 {
+                    let page_idx = i.unsigned_abs() as usize;
                     if done[page_idx] {
                         continue;
                     }
@@ -2001,15 +2001,6 @@ impl PageStack {
         page
     }
 
-    /// Get the parent page of the current page.
-    fn parent(&self) -> PageRef {
-        let current = *self.current_page.borrow();
-        self.stack.borrow()[current as usize - 1]
-            .as_ref()
-            .unwrap()
-            .clone()
-    }
-
     /// Current page pointer being used
     fn current(&self) -> usize {
         *self.current_page.borrow() as usize
@@ -2254,7 +2245,7 @@ fn page_free_array(
     }
     Ok(number_of_cells_removed)
 }
-pub fn page_insert_array(
+fn page_insert_array(
     page: &mut PageContent,
     first: usize,
     count: usize,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1360,12 +1360,11 @@ impl BTreeCursor {
                         .write_u32(PAGE_HEADER_OFFSET_RIGHTMOST_PTR, right_pointer);
                 }
                 // TODO: pointer map update (vacuum support)
-                // TODO: insert divider cells in parent
                 for i in 0..sibling_count_new - 1
                 /* do not take last page */
                 {
                     let divider_cell_idx = cell_array.cell_count(i);
-                    let divider_cell = &mut cell_array.cells[divider_cell_idx];
+                    let mut divider_cell = &mut cell_array.cells[divider_cell_idx];
                     let page = &pages_to_balance_new[i];
                     // FIXME: dont use auxiliary space, could be done without allocations
                     let mut new_divider_cell = Vec::new();
@@ -1379,6 +1378,7 @@ impl BTreeCursor {
                         // FIXME: not needed conversion
                         // FIXME: need to update cell size in order to free correctly?
                         // insert into cell with correct range should be enough
+                        divider_cell = &mut cell_array.cells[divider_cell_idx - 1];
                         let (_, n_bytes_payload) = read_varint(divider_cell)?;
                         let (rowid, _) = read_varint(&divider_cell[n_bytes_payload..])?;
                         new_divider_cell.extend_from_slice(&(page.get().id as u32).to_be_bytes());

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1822,7 +1822,6 @@ impl BTreeCursor {
         };
         return_if_io!(self.move_to(SeekKey::TableRowId(*int_key as u64), SeekOp::EQ));
         let page = self.stack.top();
-        dbg!(page.get().id);
         // TODO(pere): request load
         return_if_locked!(page);
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -56,6 +56,10 @@ impl Page {
         unsafe { &mut *self.inner.get() }
     }
 
+    pub fn get_contents(&self) -> &mut PageContent {
+        self.get().contents.as_mut().unwrap()
+    }
+
     pub fn is_uptodate(&self) -> bool {
         self.get().flags.load(Ordering::SeqCst) & PAGE_UPTODATE != 0
     }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -534,6 +534,16 @@ impl PageContent {
         }
     }
 
+    pub fn rightmost_pointer_raw(&self) -> Option<*mut u8> {
+        match self.page_type() {
+            PageType::IndexInterior | PageType::TableInterior => {
+                Some(unsafe { self.as_ptr().as_mut_ptr().add(self.offset + 8) })
+            }
+            PageType::IndexLeaf => None,
+            PageType::TableLeaf => None,
+        }
+    }
+
     pub fn cell_get(
         &self,
         idx: usize,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -462,7 +462,7 @@ impl PageContent {
     }
 
     pub fn write_u16_no_offset(&self, pos: usize, value: u16) {
-        log::debug!("write_u16(pos={}, value={})", pos, value);
+        tracing::debug!("write_u16(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
         buf[pos..pos + 2].copy_from_slice(&value.to_be_bytes());
     }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -439,6 +439,11 @@ impl PageContent {
         u16::from_be_bytes([buf[self.offset + pos], buf[self.offset + pos + 1]])
     }
 
+    pub fn read_u16_no_offset(&self, pos: usize) -> u16 {
+        let buf = self.as_ptr();
+        u16::from_be_bytes([buf[pos], buf[pos + 1]])
+    }
+
     pub fn read_u32(&self, pos: usize) -> u32 {
         let buf = self.as_ptr();
         read_u32(buf, self.offset + pos)
@@ -454,6 +459,12 @@ impl PageContent {
         tracing::debug!("write_u16(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
         buf[self.offset + pos..self.offset + pos + 2].copy_from_slice(&value.to_be_bytes());
+    }
+
+    pub fn write_u16_no_offset(&self, pos: usize, value: u16) {
+        log::debug!("write_u16(pos={}, value={})", pos, value);
+        let buf = self.as_ptr();
+        buf[pos..pos + 2].copy_from_slice(&value.to_be_bytes());
     }
 
     pub fn write_u32(&self, pos: usize, value: u32) {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -441,12 +441,7 @@ impl PageContent {
 
     pub fn read_u32(&self, pos: usize) -> u32 {
         let buf = self.as_ptr();
-        u32::from_be_bytes([
-            buf[self.offset + pos],
-            buf[self.offset + pos + 1],
-            buf[self.offset + pos + 2],
-            buf[self.offset + pos + 3],
-        ])
+        read_u32(buf, self.offset + pos)
     }
 
     pub fn write_u8(&self, pos: usize, value: u8) {
@@ -1382,6 +1377,10 @@ impl WalHeader {
     pub fn as_bytes(&self) -> &[u8] {
         unsafe { std::mem::transmute::<&WalHeader, &[u8; size_of::<WalHeader>()]>(self) }
     }
+}
+
+pub fn read_u32(buf: &[u8], pos: usize) -> u32 {
+    u32::from_be_bytes([buf[pos], buf[pos + 1], buf[pos + 2], buf[pos + 3]])
 }
 
 #[cfg(test)]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -600,10 +600,10 @@ impl PageContent {
     ) -> (usize, usize) {
         let buf = self.as_ptr();
         let ncells = self.cell_count();
-        let cell_pointer_array_start = self.header_size();
+        let (cell_pointer_array_start, _) = self.cell_pointer_array_offset_and_size();
         assert!(idx < ncells, "cell_get: idx out of bounds");
         let cell_pointer = cell_pointer_array_start + (idx * 2); // pointers are 2 bytes each
-        let cell_pointer = self.read_u16(cell_pointer) as usize;
+        let cell_pointer = self.read_u16_no_offset(cell_pointer) as usize;
         let start = cell_pointer;
         let len = match self.page_type() {
             PageType::IndexInterior => {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -579,7 +579,7 @@ impl PageContent {
         (self.offset + header_size, self.cell_pointer_array_size())
     }
 
-    /* Get region of a cell's payload */
+    /// Get region of a cell's payload
     pub fn cell_get_raw_region(
         &self,
         idx: usize,
@@ -893,6 +893,7 @@ fn read_payload(unread: &[u8], payload_size: usize, pager: Rc<Pager>) -> (Vec<u8
             assert!(left_to_read > 0);
             let page;
             loop {
+                // FIXME(pere): this looks terrible, what did i do lmao
                 let page_ref = pager.read_page(next_overflow as usize);
                 if let Ok(p) = page_ref {
                     page = p;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2467,6 +2467,9 @@ impl Program {
                         _ => unreachable!("Not a record! Cannot insert a non record value."),
                     };
                     let key = &state.registers[*key_reg];
+                    // NOTE(pere): Sending moved_before == true is okay because we moved before but
+                    // if we were to set to false after starting a balance procedure, it might
+                    // leave undefined state.
                     return_if_io!(cursor.insert(key, record, true));
                     state.pc += 1;
                 }


### PR DESCRIPTION
Beep boop.

What happened you ask? I removed the dumb balancing algorithm I implemented in favor of SQLite's implementation based on B*Tree[1] where a page is 2/3 full instead of 1/2. It also tries to balance a page by taking a maximum 3 pages and distributing cells evenly between them.

I've made some changes that are somewhat related:
* Moved most operations on pages out of BTreeCursor because those operations are based on a page, not on a cursor, and it makes it easier to test.
* Fixed `write_u16` and `read_u16` cases that didn't need a implicit offset calculation. Added: `write_u16_no_offset` and `read_u16_no_offset` to counter this. 
* Added some tests with fuzz testing too.
* Fixed some important actions like: `compute_free_space`, `defragment_page` and `drop_cell`. 



[1] https://dl.acm.org/doi/10.1145/356770.356776