### PR TITLE
Json path refine

### DIFF
--- a/core/json/json_path.pest
+++ b/core/json/json_path.pest
@@ -1,8 +1,0 @@
-negative_index_indicator = ${ "#-" }
-array_offset = ${ ASCII_DIGIT+ }
-array_locator = ${ "[" ~ negative_index_indicator? ~ array_offset ~ "]" }
-relaxed_array_locator = ${ negative_index_indicator? ~ array_offset }
-
-root = ${ "$" }
-json_path_key = ${ identifier | string | ASCII_DIGIT+ }
-path = ${ SOI ~ root ~ (array_locator | "." ~ json_path_key)* ~ EOI }

--- a/core/json/json_path.rs
+++ b/core/json/json_path.rs
@@ -1,80 +1,177 @@
-use pest::Parser as P;
-use pest_derive::Parser;
+use crate::bail_parse_error;
+use std::borrow::Cow;
 
-#[derive(Parser)]
-#[grammar = "json/json.pest"]
-#[grammar = "json/json_path.pest"]
-struct Parser;
+/// You have to know your PP state
+#[derive(Clone, Debug, PartialEq)]
+enum PPState {
+    Start,
+    AfterRoot,
+    InKey,
+    InArrayIndex,
+    ExpectDotOrBracket,
+}
+
+enum ArrayIndexState {
+    Start,
+    AfterHash,
+    CollectingNumbers,
+    IsMax,
+}
 
 /// Describes a JSON path, which is a sequence of keys and/or array locators.
 #[derive(Clone, Debug)]
-pub struct JsonPath {
-    pub elements: Vec<PathElement>,
+pub struct JsonPath<'a> {
+    pub elements: Vec<PathElement<'a>>,
 }
 
 /// PathElement describes a single element of a JSON path.
 #[derive(Clone, Debug, PartialEq)]
-pub enum PathElement {
+pub enum PathElement<'a> {
     /// Root element: '$'
     Root(),
     /// JSON key
-    Key(String),
+    Key(Cow<'a, str>),
     /// Array locator, eg. [2], [#-5]
     ArrayLocator(i32),
 }
 
+type IsMaxNumber = bool;
+
+fn collect_num(current: i32, adding: i32, negative: bool) -> (i32, IsMaxNumber) {
+    let mut is_max = false;
+    let current = if negative {
+        current
+            .checked_mul(10)
+            .and_then(|n| n.checked_sub(adding))
+            .unwrap_or_else(|| {
+                is_max = true;
+                i32::MIN
+            })
+    } else {
+        current
+            .checked_mul(10)
+            .and_then(|n| n.checked_add(adding))
+            .unwrap_or_else(|| {
+                is_max = true;
+                i32::MAX
+            })
+    };
+    (current, is_max)
+}
+
 /// Parses path into a Vec of Strings, where each string is a key or an array locator.
-pub fn json_path(path: &str) -> crate::Result<JsonPath> {
-    let parsed = Parser::parse(Rule::path, path);
+pub fn json_path<'a>(path: &'a str) -> crate::Result<JsonPath<'a>> {
+    let mut parser_state = PPState::Start;
+    let mut index_state = ArrayIndexState::Start;
 
-    if let Ok(mut parsed) = parsed {
-        let mut result = vec![];
-        let parsed = parsed.next().unwrap();
-        for pair in parsed.into_inner() {
-            match pair.as_rule() {
-                Rule::EOI => (),
-                Rule::root => result.push(PathElement::Root()),
-                Rule::json_path_key => result.push(PathElement::Key(pair.as_str().to_string())),
-                Rule::array_locator => {
-                    let mut array_locator = pair.into_inner();
-                    let index_or_negative_indicator = array_locator.next().unwrap();
+    let mut key_start = 0;
+    let mut index_buffer = 0;
 
-                    match index_or_negative_indicator.as_rule() {
-                        Rule::negative_index_indicator => {
-                            let negative_offset = array_locator.next().unwrap();
-                            // TODO: sqlite is able to parse arbitrarily big numbers, but they
-                            //  always get overflown and cast to i32. Handle this.
-                            let parsed = negative_offset
-                                .as_str()
-                                .parse::<i128>()
-                                .unwrap_or(i128::MAX);
-
-                            result.push(PathElement::ArrayLocator(-parsed as i32));
+    let mut path_components = Vec::with_capacity(5);
+    let mut path_iter = path.char_indices();
+    while let Some(ch) = path_iter.next() {
+        let ch_len = ch.1.len_utf8();
+        match parser_state {
+            PPState::Start => match ch {
+                (_, '$') => {
+                    path_components.push(PathElement::Root());
+                    parser_state = PPState::AfterRoot
+                }
+                (_, _) => bail_parse_error!("Bad json path: {}", path),
+            },
+            PPState::AfterRoot => match ch {
+                (idx, '.') => {
+                    parser_state = PPState::InKey;
+                    key_start = idx + ch_len;
+                }
+                (_, '[') => {
+                    index_state = ArrayIndexState::Start;
+                    parser_state = PPState::InArrayIndex;
+                    index_buffer = 0;
+                }
+                (_, _) => bail_parse_error!("Bad json path: {}", path),
+            },
+            PPState::InKey => match ch {
+                (idx, '.' | '[') => {
+                    let key_end = idx;
+                    if key_end > key_start {
+                        let key = &path[key_start..key_end];
+                        if ch.1 == '[' {
+                            index_state = ArrayIndexState::Start;
+                            parser_state = PPState::InArrayIndex;
+                            index_buffer = 0;
+                        } else {
+                            key_start = idx + ch_len;
                         }
-                        Rule::array_offset => {
-                            let array_offset = index_or_negative_indicator.as_str();
-                            // TODO: sqlite is able to parse arbitrarily big numbers, but they
-                            //  always get overflown and cast to i32. Handle this.
-                            let parsed = array_offset.parse::<i128>().unwrap_or(i128::MAX);
-
-                            result.push(PathElement::ArrayLocator(parsed as i32));
-                        }
-                        _ => unreachable!(
-                            "Unexpected rule: {:?}",
-                            index_or_negative_indicator.as_rule()
-                        ),
+                        path_components.push(PathElement::Key(Cow::Borrowed(key)));
+                    } else {
+                        unreachable!()
                     }
                 }
-                _ => {
-                    unreachable!("Unexpected rule: {:?}", pair.as_rule());
+                (_, _) => continue,
+            },
+            PPState::InArrayIndex => {
+                let (_, c) = ch;
+
+                match (&index_state, c) {
+                    (ArrayIndexState::Start, '#') => index_state = ArrayIndexState::AfterHash,
+                    (ArrayIndexState::Start, '0'..='9') => {
+                        index_buffer = c.to_digit(10).unwrap() as i32;
+                        index_state = ArrayIndexState::CollectingNumbers;
+                    }
+                    (ArrayIndexState::AfterHash, '-') => {
+                        if let Some((_, next_c)) = path_iter.next() {
+                            if next_c.is_ascii_digit() {
+                                index_buffer = -(next_c.to_digit(10).unwrap() as i32);
+                                index_state = ArrayIndexState::CollectingNumbers;
+                            } else {
+                                bail_parse_error!("Bad json path: {}", path);
+                            }
+                        } else {
+                            bail_parse_error!("Bad json path: {}", path);
+                        }
+                    }
+                    (ArrayIndexState::CollectingNumbers, '0'..='9') => {
+                        let (new_num, is_max) = collect_num(
+                            index_buffer,
+                            c.to_digit(10).unwrap() as i32,
+                            index_buffer < 0,
+                        );
+                        if is_max {
+                            index_state = ArrayIndexState::IsMax;
+                            index_buffer = new_num;
+                        }
+                    }
+                    (ArrayIndexState::IsMax, '0'..='9') => continue,
+                    (ArrayIndexState::CollectingNumbers | ArrayIndexState::IsMax, ']') => {
+                        parser_state = PPState::ExpectDotOrBracket;
+                        path_components.push(PathElement::ArrayLocator(index_buffer))
+                    }
+                    (_, _) => bail_parse_error!("Bad json path: {}", path),
                 }
             }
+            PPState::ExpectDotOrBracket => match ch {
+                (idx, '.') => {
+                    key_start = idx + ch_len;
+                    parser_state = PPState::InKey;
+                }
+                (_, '[') => {
+                    index_state = ArrayIndexState::Start;
+                    parser_state = PPState::InArrayIndex;
+                    index_buffer = 0;
+                }
+                (_, _) => bail_parse_error!("Bad json path: {}", path),
+            },
         }
-
-        Ok(JsonPath { elements: result })
-    } else {
-        crate::bail_constraint_error!("JSON path error near: {:?}", path.to_string());
     }
+    if parser_state == PPState::InKey && key_start < path.len() {
+        let key = &path[key_start..];
+        path_components.push(PathElement::Key(Cow::Borrowed(key)));
+    }
+
+    Ok(JsonPath {
+        elements: path_components,
+    })
 }
 
 #[cfg(test)]
@@ -93,7 +190,7 @@ mod tests {
         let path = json_path("$.x").unwrap();
         assert_eq!(path.elements.len(), 2);
         assert_eq!(path.elements[0], PathElement::Root());
-        assert_eq!(path.elements[1], PathElement::Key("x".to_string()));
+        assert_eq!(path.elements[1], PathElement::Key(Cow::Borrowed("x")));
     }
 
     #[test]
@@ -135,9 +232,9 @@ mod tests {
         let path = json_path("$.store.book[0].title").unwrap();
         assert_eq!(path.elements.len(), 5);
         assert_eq!(path.elements[0], PathElement::Root());
-        assert_eq!(path.elements[1], PathElement::Key("store".to_string()));
-        assert_eq!(path.elements[2], PathElement::Key("book".to_string()));
+        assert_eq!(path.elements[1], PathElement::Key(Cow::Borrowed("store")));
+        assert_eq!(path.elements[2], PathElement::Key(Cow::Borrowed("book")));
         assert_eq!(path.elements[3], PathElement::ArrayLocator(0));
-        assert_eq!(path.elements[4], PathElement::Key("title".to_string()));
+        assert_eq!(path.elements[4], PathElement::Key(Cow::Borrowed("title")));
     }
 }

--- a/core/json/json_path.rs
+++ b/core/json/json_path.rs
@@ -41,7 +41,6 @@ type IsMaxNumber = bool;
 
 fn collect_num(current: i128, adding: i128, negative: bool) -> (i128, IsMaxNumber) {
     let ten = 10i128;
-    let adding = adding as i128;
 
     let result = if negative {
         current.saturating_mul(ten).saturating_sub(adding)
@@ -230,12 +229,12 @@ fn handle_quoted_key<'a>(
     Ok(())
 }
 
-fn handle_array_index<'a>(
+fn handle_array_index(
     ch: (usize, char),
     parser_state: &mut PPState,
     index_state: &mut ArrayIndexState,
     index_buffer: &mut i128,
-    path_components: &mut Vec<PathElement<'a>>,
+    path_components: &mut Vec<PathElement<'_>>,
     path_iter: &mut std::str::CharIndices,
     path: &str,
 ) -> crate::Result<()> {

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -16,7 +16,6 @@ use jsonb::Error as JsonbError;
 use ser::to_string_pretty;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::rc::Rc;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(untagged)]
@@ -406,16 +405,16 @@ fn json_extract_single<'a>(
             },
             PathElement::ArrayLocator(idx) => match current_element {
                 Val::Array(array) => {
-                    let mut idx = *idx;
+                    if let Some(mut idx) = *idx {
+                        if idx < 0 {
+                            idx += array.len() as i32;
+                        }
 
-                    if idx < 0 {
-                        idx += array.len() as i32;
-                    }
-
-                    if idx < array.len() as i32 {
-                        current_element = &array[idx as usize];
-                    } else {
-                        return Ok(None);
+                        if idx < array.len() as i32 {
+                            current_element = &array[idx as usize];
+                        } else {
+                            return Ok(None);
+                        }
                     }
                 }
                 _ => return Ok(None),
@@ -449,7 +448,10 @@ fn json_path_from_owned_value(path: &OwnedValue, strict: bool) -> crate::Result<
             }
             OwnedValue::Null => return Ok(None),
             OwnedValue::Integer(i) => JsonPath {
-                elements: vec![PathElement::Root(), PathElement::ArrayLocator(*i as i32)],
+                elements: vec![
+                    PathElement::Root(),
+                    PathElement::ArrayLocator(Some(*i as i32)),
+                ],
             },
             OwnedValue::Float(f) => JsonPath {
                 elements: vec![
@@ -485,8 +487,9 @@ fn find_target<'a>(json: &'a mut Val, path: &JsonPath) -> Option<Target<'a>> {
             PathElement::ArrayLocator(index) => match current {
                 Val::Array(arr) => {
                     if let Some(index) = match index {
-                        i if *i < 0 => arr.len().checked_sub(i.unsigned_abs() as usize),
-                        i => ((*i as usize) < arr.len()).then_some(*i as usize),
+                        Some(i) if *i < 0 => arr.len().checked_sub(i.unsigned_abs() as usize),
+                        Some(i) => ((*i as usize) < arr.len()).then_some(*i as usize),
+                        None => Some(arr.len()),
                     } {
                         if is_last {
                             return Some(Target::Array(arr, index));
@@ -538,8 +541,9 @@ fn find_or_create_target<'a>(json: &'a mut Val, path: &JsonPath) -> Option<Targe
             PathElement::ArrayLocator(index) => match current {
                 Val::Array(arr) => {
                     if let Some(index) = match index {
-                        i if *i < 0 => arr.len().checked_sub(i.unsigned_abs() as usize),
-                        i => Some(*i as usize),
+                        Some(i) if *i < 0 => arr.len().checked_sub(i.unsigned_abs() as usize),
+                        Some(i) => Some(*i as usize),
+                        None => Some(arr.len()),
                     } {
                         if is_last {
                             if index == arr.len() {
@@ -1224,7 +1228,7 @@ mod tests {
             Val::String("second".to_string()),
         ]);
         let path = JsonPath {
-            elements: vec![PathElement::ArrayLocator(0)],
+            elements: vec![PathElement::ArrayLocator(Some(0))],
         };
 
         match find_target(&mut val, &path) {
@@ -1240,7 +1244,7 @@ mod tests {
             Val::String("second".to_string()),
         ]);
         let path = JsonPath {
-            elements: vec![PathElement::ArrayLocator(-1)],
+            elements: vec![PathElement::ArrayLocator(Some(-1))],
         };
 
         match find_target(&mut val, &path) {
@@ -1282,7 +1286,7 @@ mod tests {
     fn test_mutate_json() {
         let mut val = Val::Array(vec![Val::String("test".to_string())]);
         let path = JsonPath {
-            elements: vec![PathElement::ArrayLocator(0)],
+            elements: vec![PathElement::ArrayLocator(Some(0))],
         };
 
         let result = mutate_json_by_path(&mut val, path, |target| match target {
@@ -1301,7 +1305,7 @@ mod tests {
     fn test_mutate_json_none() {
         let mut val = Val::Array(vec![]);
         let path = JsonPath {
-            elements: vec![PathElement::ArrayLocator(0)],
+            elements: vec![PathElement::ArrayLocator(Some(0))],
         };
 
         let result: Option<()> = mutate_json_by_path(&mut val, path, |_| {
@@ -1387,7 +1391,7 @@ mod tests {
 
         let result = result.unwrap();
         match &result.elements[..] {
-            [PathElement::Root(), PathElement::ArrayLocator(index)] if *index == 3 => {}
+            [PathElement::Root(), PathElement::ArrayLocator(index)] if *index == Some(3) => {}
             _ => panic!("Expected root and array locator"),
         }
     }

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -394,7 +394,7 @@ fn json_extract_single<'a>(
             PathElement::Root() => {
                 current_element = json;
             }
-            PathElement::Key(key) => match current_element {
+            PathElement::Key(key, _) => match current_element {
                 Val::Object(map) => {
                     if let Some((_, value)) = map.iter().find(|(k, _)| k == key) {
                         current_element = value;
@@ -442,7 +442,7 @@ fn json_path_from_owned_value(path: &OwnedValue, strict: bool) -> crate::Result<
                     JsonPath {
                         elements: vec![
                             PathElement::Root(),
-                            PathElement::Key(Cow::Borrowed(t.as_str())),
+                            PathElement::Key(Cow::Borrowed(t.as_str()), false),
                         ],
                     }
                 }
@@ -454,7 +454,7 @@ fn json_path_from_owned_value(path: &OwnedValue, strict: bool) -> crate::Result<
             OwnedValue::Float(f) => JsonPath {
                 elements: vec![
                     PathElement::Root(),
-                    PathElement::Key(Cow::Owned(f.to_string())),
+                    PathElement::Key(Cow::Owned(f.to_string()), false),
                 ],
             },
             _ => crate::bail_constraint_error!("JSON path error near: {:?}", path.to_string()),
@@ -501,7 +501,7 @@ fn find_target<'a>(json: &'a mut Val, path: &JsonPath) -> Option<Target<'a>> {
                     return None;
                 }
             },
-            PathElement::Key(key) => match current {
+            PathElement::Key(key, _) => match current {
                 Val::Object(obj) => {
                     if let Some(pos) = &obj
                         .iter()
@@ -577,7 +577,7 @@ fn find_or_create_target<'a>(json: &'a mut Val, path: &JsonPath) -> Option<Targe
                     *current = Val::Array(vec![]);
                 }
             },
-            PathElement::Key(key) => match current {
+            PathElement::Key(key, _) => match current {
                 Val::Object(obj) => {
                     if let Some(pos) = &obj
                         .iter()
@@ -1253,7 +1253,7 @@ mod tests {
     fn test_find_target_object() {
         let mut val = Val::Object(vec![("key".to_string(), Val::String("value".to_string()))]);
         let path = JsonPath {
-            elements: vec![PathElement::Key(Cow::Borrowed("key"))],
+            elements: vec![PathElement::Key(Cow::Borrowed("key"), false)],
         };
 
         match find_target(&mut val, &path) {
@@ -1269,7 +1269,7 @@ mod tests {
             ("key".to_string(), Val::String("value".to_string())),
         ]);
         let path = JsonPath {
-            elements: vec![PathElement::Key(Cow::Borrowed("key"))],
+            elements: vec![PathElement::Key(Cow::Borrowed("key"), false)],
         };
 
         match find_target(&mut val, &path) {
@@ -1364,7 +1364,7 @@ mod tests {
 
         let result = result.unwrap();
         match &result.elements[..] {
-            [PathElement::Root(), PathElement::Key(field)] if *field == "field" => {}
+            [PathElement::Root(), PathElement::Key(field, false)] if *field == "field" => {}
             _ => panic!("Expected root and field"),
         }
     }
@@ -1433,7 +1433,7 @@ mod tests {
 
         let result = result.unwrap();
         match &result.elements[..] {
-            [PathElement::Root(), PathElement::Key(field)] if *field == "1.23" => {}
+            [PathElement::Root(), PathElement::Key(field, false)] if *field == "1.23" => {}
             _ => panic!("Expected root and field"),
         }
     }

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -225,7 +225,7 @@ pub fn json_arrow_shift_extract(
     }
 
     let json = get_json_value(value)?;
-    let extracted = json_extract_single(&json, path, false)?.unwrap_or_else(|| &Val::Null);
+    let extracted = json_extract_single(&json, path, false)?.unwrap_or(&Val::Null);
 
     convert_json_to_db_type(extracted, true)
 }
@@ -242,7 +242,7 @@ pub fn json_extract(value: &OwnedValue, paths: &[OwnedValue]) -> crate::Result<O
         return Ok(OwnedValue::Null);
     } else if paths.len() == 1 {
         let json = get_json_value(value)?;
-        let extracted = json_extract_single(&json, &paths[0], true)?.unwrap_or_else(|| &Val::Null);
+        let extracted = json_extract_single(&json, &paths[0], true)?.unwrap_or(&Val::Null);
 
         return convert_json_to_db_type(extracted, false);
     }
@@ -256,8 +256,7 @@ pub fn json_extract(value: &OwnedValue, paths: &[OwnedValue]) -> crate::Result<O
                 return Ok(OwnedValue::Null);
             }
             _ => {
-                let extracted =
-                    json_extract_single(&json, path, true)?.unwrap_or_else(|| &Val::Null);
+                let extracted = json_extract_single(&json, path, true)?.unwrap_or(&Val::Null);
 
                 if paths.len() == 1 && extracted == &Val::Null {
                     return Ok(OwnedValue::Null);


### PR DESCRIPTION
Hey! I've rebuilt the JSON path parser to make it easier to maintain and catch more edge cases. 

Main stuff:
- Removed pest dependency in favor of hand-written parser
- Better memory usage (pre-allocates space, use Cow)
- Handles quoted keys properly now
- Added tests for weird edge cases
- Added PPState (Shoutout ThePrimeagen)