### PR TITLE
Fix (btree) `clear_overflow_page`

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1,14 +1,10 @@
-<<<<<<< HEAD
 use tracing::debug;
 
-=======
->>>>>>> d7863400 (Added comments and changed logging to trace.)
 use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::{
     read_btree_cell, read_varint, BTreeCell, DatabaseHeader, PageContent, PageType,
     TableInteriorCell, TableLeafCell,
 };
-use log::debug;
 
 use crate::types::{CursorResult, OwnedValue, Record, SeekKey, SeekOp};
 use crate::{LimboError, Result};
@@ -2412,10 +2408,10 @@ fn to_static_buf(buf: &[u8]) -> &'static [u8] {
 
 #[cfg(test)]
 mod tests {
-    use log::trace;
     use rand_chacha::rand_core::RngCore;
     use rand_chacha::rand_core::SeedableRng;
     use rand_chacha::ChaCha8Rng;
+    use tracing::trace;
 
     use super::*;
     use crate::io::{Buffer, Completion, MemoryIO, OpenFlags, IO};

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2226,8 +2226,14 @@ impl BTreeCursor {
 
         // Calculate expected overflow pages
         let overflow_page_size = self.usable_space() - 4;
-        let n_overflow =
-            (payload_len - local_size + overflow_page_size).div_ceil(overflow_page_size);
+
+        #[allow(clippy::manual_div_ceil)] // don't remove this. Ignore clippy.
+        let n_overflow = (payload_len - local_size + overflow_page_size - 1) / (overflow_page_size);
+        println!(
+            "payload_len - local_size + overflow_page_size: {:?}",
+            payload_len - local_size + overflow_page_size
+        );
+        println!("overflow page size: {:?}", overflow_page_size);
         if n_overflow == 0 {
             return Err(LimboError::Corrupt("Invalid overflow calculation".into()));
         }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -714,7 +714,7 @@ impl BTreeCursor {
                     .state
                     .mut_write_info()
                     .expect("can't insert while counting");
-                write_info.state.clone()
+                write_info.state
             };
             match write_state {
                 WriteState::Start => {
@@ -778,7 +778,7 @@ impl BTreeCursor {
             };
         };
         self.state = CursorState::None;
-        return ret;
+        ret
     }
 
     /// Insert a record into a cell.
@@ -1216,7 +1216,7 @@ impl BTreeCursor {
                 let (page_type, current_idx) = {
                     let current_page = self.stack.top();
                     let contents = current_page.get().contents.as_ref().unwrap();
-                    (contents.page_type().clone(), current_page.get().id)
+                    (contents.page_type(), current_page.get().id)
                 };
 
                 parent.set_dirty();
@@ -1231,8 +1231,8 @@ impl BTreeCursor {
                     let cell = parent_contents.cell_get(
                         cell_idx,
                         self.pager.clone(),
-                        self.payload_overflow_threshold_max(page_type.clone()),
-                        self.payload_overflow_threshold_min(page_type.clone()),
+                        self.payload_overflow_threshold_max(page_type),
+                        self.payload_overflow_threshold_min(page_type),
                         self.usable_space(),
                     )?;
                     let found = match cell {
@@ -1244,8 +1244,8 @@ impl BTreeCursor {
                     if found {
                         let (start, _len) = parent_contents.cell_get_raw_region(
                             cell_idx,
-                            self.payload_overflow_threshold_max(page_type.clone()),
-                            self.payload_overflow_threshold_min(page_type.clone()),
+                            self.payload_overflow_threshold_max(page_type),
+                            self.payload_overflow_threshold_min(page_type),
                             self.usable_space(),
                         );
                         right_pointer = start;
@@ -1731,7 +1731,7 @@ impl BTreeCursor {
             write_varint_to_vec(record_buf.len() as u64, cell_payload);
         }
 
-        let payload_overflow_threshold_max = self.payload_overflow_threshold_max(page_type.clone());
+        let payload_overflow_threshold_max = self.payload_overflow_threshold_max(page_type);
         debug!(
             "fill_cell_payload(record_size={}, payload_overflow_threshold_max={})",
             record_buf.len(),
@@ -2213,8 +2213,8 @@ impl BTreeCursor {
         payload_len: usize,
         page_type: PageType,
     ) -> Result<Option<usize>> {
-        let max_local = self.payload_overflow_threshold_max(page_type.clone());
-        let min_local = self.payload_overflow_threshold_min(page_type.clone());
+        let max_local = self.payload_overflow_threshold_max(page_type);
+        let min_local = self.payload_overflow_threshold_min(page_type);
         let usable_size = self.usable_space();
 
         let (_, local_size) = payload_overflows(payload_len, max_local, min_local, usable_size);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2229,15 +2229,6 @@ impl BTreeCursor {
 
         #[allow(clippy::manual_div_ceil)] // don't remove this. Ignore clippy.
         let n_overflow = (payload_len - local_size + overflow_page_size - 1) / (overflow_page_size);
-        println!(
-            "payload_len - local_size + overflow_page_size: {:?}",
-            payload_len - local_size + overflow_page_size
-        );
-        println!("overflow page size: {:?}", overflow_page_size);
-        if n_overflow == 0 {
-            return Err(LimboError::Corrupt("Invalid overflow calculation".into()));
-        }
-
         Ok(Some(n_overflow))
     }
 }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2216,10 +2216,6 @@ impl BTreeCursor {
     ) -> Result<(usize, usize)> {
         let max_local = self.payload_overflow_threshold_max(page_type);
         let min_local = self.payload_overflow_threshold_min(page_type);
-        println!("min_local: {}", min_local);
-        println!("max_local: {}", max_local);
-        println!("payload_len: {}", payload_len);
-        println!("usable_space: {}", self.usable_space());
 
         // This matches btreeParseCellAdjustSizeForOverflow logic
         let n_local = if payload_len <= max_local {
@@ -2872,7 +2868,7 @@ mod tests {
         let usable_size = cursor.usable_space();
 
         // Create a large payload that will definitely trigger overflow
-        let large_payload = vec![b'A'; max_local + usable_size];
+        let large_payload = vec![b'A'; max_local + usable_size + 900];
 
         // Setup overflow pages (2, 3, 4) with linking
         let mut current_page = 2u32;


### PR DESCRIPTION
This PR fixes bugs in `clear_overflow_page` implementation.

- Added a correct way to get cell size information.
- Added basic delete fuzzer.
- Removed clones from different copy types and fixed some clippy warnings.
