### PR TITLE
Add pretty print AST for debugging AST in CLI 

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -102,6 +102,7 @@ impl std::fmt::Display for OutputMode {
     }
 }
 
+// similar to dbg! but returns a string
 macro_rules! dbg_string {
     ($val:expr) => {{
         format!("{:#?}", $val)
@@ -140,7 +141,7 @@ pub enum Command {
     Import,
     /// Loads an extension library
     LoadExtension,
-    /// Pretty print parsed SQL statement
+    /// Parse and pretty print a SQL statement
     PrettyPrintAst,
 }
 

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -435,7 +435,9 @@ impl Limbo {
         let mut parser = LimboParser::new(sql.as_bytes());
         let cmd = parser.next().map_err(|e| e.to_string())?;
         if let Some(Cmd::Stmt(stmt)) = cmd {
+            let _ = self.writeln("\n=== Input SQL ===");
             let _ = self.writeln(sql);
+            let _ = self.writeln("\n=== AST ===");
             let debug_stmt = dbg_string!(stmt);
             let _ = self.writeln(&debug_stmt);
         }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -182,7 +182,7 @@ impl Command {
             Self::Echo => ".echo on|off",
             Self::Tables => ".tables",
             Self::LoadExtension => ".load",
-            Self::PrettyPrintAst => ".debugast",
+            Self::PrettyPrintAst => ".pprint <\"sql statement\">",
             Self::Import => &IMPORT_HELP,
         }
     }
@@ -207,7 +207,7 @@ impl FromStr for Command {
             ".echo" => Ok(Self::Echo),
             ".import" => Ok(Self::Import),
             ".load" => Ok(Self::LoadExtension),
-            ".debugast" => Ok(Self::PrettyPrintAst),
+            ".pprint" => Ok(Self::PrettyPrintAst),
             _ => Err("Unknown command".to_string()),
         }
     }
@@ -986,6 +986,7 @@ Special Commands:
 .open <database_file>      Open and connect to a database file.
 .output <mode>             Change the output mode. Available modes are 'raw' and 'pretty'.
 .schema <table_name>       Show the schema of the specified table.
+.pprint <"sql statement">  Pretty print the SQL statement.
 .tables <pattern>          List names of tables matching LIKE pattern TABLE
 .opcodes                   Display all the opcodes defined by the virtual machine
 .cd <directory>            Change the current working directory.

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -435,7 +435,7 @@ impl Limbo {
         let mut parser = LimboParser::new(sql.as_bytes());
         let cmd = parser.next().map_err(|e| e.to_string())?;
         if let Some(Cmd::Stmt(stmt)) = cmd {
-            println!("{}", sql);
+            let _ = self.writeln(sql);
             let debug_stmt = dbg_string!(stmt);
             let _ = self.writeln(&debug_stmt);
         }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -22,7 +22,7 @@ mod vector;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use fallible_iterator::FallibleIterator;
+pub use fallible_iterator::FallibleIterator;
 #[cfg(not(target_family = "wasm"))]
 use libloading::{Library, Symbol};
 #[cfg(not(target_family = "wasm"))]
@@ -31,7 +31,7 @@ use limbo_ext::{ResultCode, VTabModuleImpl, Value as ExtValue};
 use log::trace;
 use parking_lot::RwLock;
 use schema::{Column, Schema};
-use sqlite3_parser::{ast, ast::Cmd, lexer::sql::Parser};
+pub use sqlite3_parser::{ast, ast::Cmd, lexer::sql::Parser};
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::HashMap;


### PR DESCRIPTION
Why: @alpaylan wanted a way to pretty print AST in CLI for debugging purposes.

Usage and output:

```sql
Limbo v0.0.14
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database
limbo> .pprint "SELECT 1;"

=== Input SQL ===
SELECT 1;

=== AST ===
Select(
    Select {
        with: None,
        body: SelectBody {
            select: Select(
                SelectInner {
                    distinctness: None,
                    columns: [
                        Expr(
                            Literal(
                                Numeric(
                                    "1",
                                ),
                            ),
                            None,
                        ),
                    ],
                    from: None,
                    where_clause: None,
                    group_by: None,
                    window_clause: None,
                },
            ),
            compounds: None,
        },
        order_by: None,
        limit: None,
    },
)
limbo> 
```
