### PR TITLE
Streamline dependencies to build for all wasm targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,6 @@ dependencies = [
  "limbo_series",
  "limbo_time",
  "limbo_uuid",
- "log",
  "miette",
  "mimalloc",
  "parking_lot",
@@ -3094,19 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -3114,9 +3101,6 @@ name = "tracing-core"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,10 +1017,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1452,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "julian_day_converter"
-version = "0.3.4"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5c45e06fa273ed7800f954d1cb6054b9b07115b370da56185f506700c0e3aa"
+checksum = "1aa5652b85ab018289638c6b924db618da9edd2ddfff7fa0ec38a8b51a9192d3"
 dependencies = [
  "chrono",
 ]

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -17,6 +17,7 @@ limbo_core = { path = "../../core", default-features = false }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3"
+getrandom = { version = "0.2.15", features = ["js"] }
 
 [features]
 web = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,7 +46,6 @@ cfg_block = "0.1.1"
 fallible-iterator = "0.3.0"
 hex = "0.4.3"
 libc = "0.2.155"
-log = "0.4.20"
 sqlite3-parser = { path = "../vendored/sqlite3-parser" }
 thiserror = "1.0.61"
 getrandom = { version = "0.2.15" }
@@ -70,7 +69,7 @@ limbo_series = { path = "../extensions/series", optional = true, features = ["st
 miette = "7.4.0"
 strum = "0.26"
 parking_lot = "0.12.3"
-tracing = "0.1.41"
+tracing = { version = "0.1.41", default-features = false }
 crossbeam-skiplist = "0.1.3"
 ryu = "1.0.19"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,11 +16,7 @@ path = "lib.rs"
 [features]
 default = ["fs", "json", "uuid", "time"]
 fs = []
-json = [
-    "dep:jsonb",
-    "dep:pest",
-    "dep:pest_derive",
-]
+json = ["dep:jsonb", "dep:pest", "dep:pest_derive", "dep:serde", "dep:indexmap"]
 uuid = ["limbo_uuid/static"]
 io_uring = ["dep:io-uring", "rustix/io_uring"]
 percentile = ["limbo_percentile/static"]
@@ -54,8 +50,8 @@ regex-syntax = { version = "0.8.5", default-features = false, features = ["unico
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 julian_day_converter = "0.4.4"
 jsonb = { version = "0.4.4", optional = true }
-indexmap = { version = "2.2.6", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
+indexmap = { version = "2.2.6", features = ["serde"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 pest = { version = "2.0", optional = true }
 pest_derive = { version = "2.0", optional = true }
 rand = "0.8.5"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,11 +49,12 @@ libc = "0.2.155"
 log = "0.4.20"
 sqlite3-parser = { path = "../vendored/sqlite3-parser" }
 thiserror = "1.0.61"
-getrandom = { version = "0.2.15", features = ["js"] }
+getrandom = { version = "0.2.15" }
 regex = "1.11.1"
 regex-syntax = { version = "0.8.5", default-features = false, features = ["unicode"] }
-chrono = "0.4.38"
 julian_day_converter = "0.3.2"
+chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
+julian_day_converter = "0.4.4"
 jsonb = { version = "0.4.4", optional = true }
 indexmap = { version = "2.2.6", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -75,7 +76,7 @@ crossbeam-skiplist = "0.1.3"
 ryu = "1.0.19"
 
 [build-dependencies]
-chrono = "0.4.38"
+chrono = { version = "0.4.38", default-features = false }
 built = { version = "0.7.5", features = ["git2", "chrono"] }
 
 [target.'cfg(not(target_family = "windows"))'.dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,6 @@ thiserror = "1.0.61"
 getrandom = { version = "0.2.15" }
 regex = "1.11.1"
 regex-syntax = { version = "0.8.5", default-features = false, features = ["unicode"] }
-julian_day_converter = "0.3.2"
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 julian_day_converter = "0.4.4"
 jsonb = { version = "0.4.4", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,7 @@ default = ["fs", "json", "uuid", "time"]
 fs = []
 json = ["dep:jsonb", "dep:pest", "dep:pest_derive", "dep:serde", "dep:indexmap"]
 uuid = ["limbo_uuid/static"]
-io_uring = ["dep:io-uring", "rustix/io_uring"]
+io_uring = ["dep:io-uring", "rustix/io_uring", "dep:libc"]
 percentile = ["limbo_percentile/static"]
 regexp = ["limbo_regexp/static"]
 time = ["limbo_time/static"]
@@ -41,7 +41,7 @@ limbo_ext = { path = "../extensions/core" }
 cfg_block = "0.1.1"
 fallible-iterator = "0.3.0"
 hex = "0.4.3"
-libc = "0.2.155"
+libc = { version = "0.2.155", optional = true }
 sqlite3-parser = { path = "../vendored/sqlite3-parser" }
 thiserror = "1.0.61"
 getrandom = { version = "0.2.15" }

--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -1536,11 +1536,13 @@ mod tests {
     #[allow(deprecated)]
     #[test]
     fn test_apply_modifier_julianday() {
+        use julian_day_converter::*;
+
         let dt = create_datetime(2000, 1, 1, 12, 0, 0);
-        let julian_day = julian_day_converter::datetime_to_julian_day(&dt.to_string()).unwrap();
+        let julian_day = &dt.to_jd();
         let mut dt_result = NaiveDateTime::default();
-        if let Ok(result) = julian_day_converter::julian_day_to_datetime(julian_day) {
-            dt_result = result;
+        if let Some(ndt) = JulianDay::from_jd(*julian_day) {
+            dt_result = ndt;
         }
         assert_eq!(dt_result, dt);
     }

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -1,8 +1,8 @@
 use crate::{Completion, File, LimboError, OpenFlags, Result, IO};
-use log::{debug, trace};
 use std::cell::RefCell;
 use std::io::{Read, Seek, Write};
 use std::rc::Rc;
+use tracing::{debug, trace};
 
 pub struct GenericIO {}
 

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -1,6 +1,5 @@
 use super::{common, Completion, File, OpenFlags, IO};
 use crate::{LimboError, Result};
-use log::{debug, trace};
 use rustix::fs::{self, FlockOperation, OFlags};
 use rustix::io_uring::iovec;
 use std::cell::RefCell;
@@ -10,6 +9,7 @@ use std::os::fd::AsFd;
 use std::os::unix::io::AsRawFd;
 use std::rc::Rc;
 use thiserror::Error;
+use tracing::{debug, trace};
 
 const MAX_IOVECS: u32 = 128;
 const SQPOLL_IDLE: u32 = 1000;

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -1,13 +1,13 @@
 use super::{Buffer, Completion, File, OpenFlags, IO};
 use crate::Result;
 
-use log::debug;
 use std::{
     cell::{Cell, RefCell, UnsafeCell},
     collections::BTreeMap,
     rc::Rc,
     sync::Arc,
 };
+use tracing::debug;
 
 pub struct MemoryIO {
     pages: UnsafeCell<BTreeMap<usize, MemPage>>,

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -3,7 +3,6 @@ use crate::io::common;
 use crate::Result;
 
 use super::{Completion, File, OpenFlags, IO};
-use log::{debug, trace};
 use polling::{Event, Events, Poller};
 use rustix::{
     fd::{AsFd, AsRawFd},
@@ -14,6 +13,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::{ErrorKind, Read, Seek, Write};
 use std::rc::Rc;
+use tracing::{debug, trace};
 
 pub struct UnixIO {
     poller: Rc<RefCell<Poller>>,

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -1,8 +1,8 @@
 use crate::{Completion, File, LimboError, OpenFlags, Result, IO};
-use log::{debug, trace};
 use std::cell::RefCell;
 use std::io::{Read, Seek, Write};
 use std::rc::Rc;
+use tracing::{debug, trace};
 
 pub struct WindowsIO {}
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -28,7 +28,6 @@ use libloading::{Library, Symbol};
 #[cfg(not(target_family = "wasm"))]
 use limbo_ext::{ExtensionApi, ExtensionEntryPoint};
 use limbo_ext::{ResultCode, VTabModuleImpl, Value as ExtValue};
-use log::trace;
 use parking_lot::RwLock;
 use schema::{Column, Schema};
 use sqlite3_parser::{ast, ast::Cmd, lexer::sql::Parser};
@@ -272,7 +271,7 @@ pub struct Connection {
 impl Connection {
     pub fn prepare(self: &Rc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
         let sql = sql.as_ref();
-        trace!("Preparing: {}", sql);
+        tracing::trace!("Preparing: {}", sql);
         let db = &self.db;
         let mut parser = Parser::new(sql.as_bytes());
         let syms = &db.syms.borrow();
@@ -301,7 +300,7 @@ impl Connection {
 
     pub fn query(self: &Rc<Connection>, sql: impl AsRef<str>) -> Result<Option<Statement>> {
         let sql = sql.as_ref();
-        trace!("Querying: {}", sql);
+        tracing::trace!("Querying: {}", sql);
         let mut parser = Parser::new(sql.as_bytes());
         let cmd = parser.next()?;
         match cmd {

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,28 +1,16 @@
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{MvStore, Result, Row, RowID};
 use std::fmt::Debug;
 
 #[derive(Debug)]
-pub struct ScanCursor<
-    'a,
-    Clock: LogicalClock,
-    T: Sync + Send + Clone + Serialize + DeserializeOwned + Debug,
-> {
+pub struct ScanCursor<'a, Clock: LogicalClock, T: Sync + Send + Clone + Debug> {
     pub db: &'a MvStore<Clock, T>,
     pub row_ids: Vec<RowID>,
     pub index: usize,
     tx_id: u64,
 }
 
-impl<
-        'a,
-        Clock: LogicalClock,
-        T: Sync + Send + Clone + Serialize + DeserializeOwned + Debug + 'static,
-    > ScanCursor<'a, Clock, T>
-{
+impl<'a, Clock: LogicalClock, T: Sync + Send + Clone + Debug + 'static> ScanCursor<'a, Clock, T> {
     pub fn new(
         db: &'a MvStore<Clock, T>,
         tx_id: u64,

--- a/core/parameters.rs
+++ b/core/parameters.rs
@@ -79,7 +79,7 @@ impl Parameters {
             "" => {
                 let index = self.next_index();
                 self.list.push(Parameter::Anonymous(index));
-                log::trace!("anonymous parameter at {index}");
+                tracing::trace!("anonymous parameter at {index}");
                 index
             }
             name if name.starts_with(['$', ':', '@', '#']) => {
@@ -91,13 +91,13 @@ impl Parameters {
                     Some(t) => {
                         let index = t.index();
                         self.list.push(t.clone());
-                        log::trace!("named parameter at {index} as {name}");
+                        tracing::trace!("named parameter at {index} as {name}");
                         index
                     }
                     None => {
                         let index = self.next_index();
                         self.list.push(Parameter::Named(name.to_owned(), index));
-                        log::trace!("named parameter at {index} as {name}");
+                        tracing::trace!("named parameter at {index} as {name}");
                         index
                     }
                 }
@@ -109,7 +109,7 @@ impl Parameters {
                     self.index = index.checked_add(1).unwrap();
                 }
                 self.list.push(Parameter::Indexed(index));
-                log::trace!("indexed parameter at {index}");
+                tracing::trace!("indexed parameter at {index}");
                 index
             }
         }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2,7 +2,6 @@ use crate::VirtualTable;
 use crate::{util::normalize_ident, Result};
 use core::fmt;
 use fallible_iterator::FallibleIterator;
-use log::trace;
 use sqlite3_parser::ast::{Expr, Literal, TableOptions};
 use sqlite3_parser::{
     ast::{Cmd, CreateTableBody, QualifiedName, ResultColumn, Stmt},
@@ -10,6 +9,7 @@ use sqlite3_parser::{
 };
 use std::collections::HashMap;
 use std::rc::Rc;
+use tracing::trace;
 
 pub struct Schema {
     pub tables: HashMap<String, Rc<BTreeTable>>,

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, collections::HashMap, ptr::NonNull};
 
-use log::debug;
+use tracing::debug;
 
 use super::pager::PageRef;
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4,13 +4,13 @@ use crate::storage::database::DatabaseStorage;
 use crate::storage::sqlite3_ondisk::{self, DatabaseHeader, PageContent};
 use crate::storage::wal::{CheckpointResult, Wal};
 use crate::{Buffer, LimboError, Result};
-use log::trace;
 use parking_lot::RwLock;
 use std::cell::{RefCell, UnsafeCell};
 use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use tracing::trace;
 
 use super::page_cache::{DumbLruPageCache, PageCacheKey};
 use super::wal::{CheckpointMode, CheckpointStatus};
@@ -113,7 +113,7 @@ impl Page {
     }
 
     pub fn clear_loaded(&self) {
-        log::debug!("clear loaded {}", self.get().id);
+        tracing::debug!("clear loaded {}", self.get().id);
         self.get().flags.fetch_and(!PAGE_LOADED, Ordering::SeqCst);
     }
 }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -48,12 +48,12 @@ use crate::storage::database::DatabaseStorage;
 use crate::storage::pager::Pager;
 use crate::types::{OwnedValue, Record, Text, TextSubtype};
 use crate::{File, Result};
-use log::trace;
 use parking_lot::RwLock;
 use std::cell::RefCell;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
+use tracing::trace;
 
 use super::pager::PageRef;
 
@@ -322,7 +322,7 @@ pub fn begin_write_database_header(header: &DatabaseHeader, pager: &Pager) -> Re
     let write_complete = Box::new(move |bytes_written: i32| {
         let buf_len = buffer_to_copy_in_cb.borrow().len();
         if bytes_written < buf_len as i32 {
-            log::error!("wrote({bytes_written}) less than expected({buf_len})");
+            tracing::error!("wrote({bytes_written}) less than expected({buf_len})");
         }
         // finish_read_database_header(buf, header).unwrap();
     });
@@ -450,19 +450,19 @@ impl PageContent {
     }
 
     pub fn write_u8(&self, pos: usize, value: u8) {
-        log::debug!("write_u8(pos={}, value={})", pos, value);
+        tracing::debug!("write_u8(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
         buf[self.offset + pos] = value;
     }
 
     pub fn write_u16(&self, pos: usize, value: u16) {
-        log::debug!("write_u16(pos={}, value={})", pos, value);
+        tracing::debug!("write_u16(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
         buf[self.offset + pos..self.offset + pos + 2].copy_from_slice(&value.to_be_bytes());
     }
 
     pub fn write_u32(&self, pos: usize, value: u32) {
-        log::debug!("write_u32(pos={}, value={})", pos, value);
+        tracing::debug!("write_u32(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
         buf[self.offset + pos..self.offset + pos + 4].copy_from_slice(&value.to_be_bytes());
     }
@@ -542,7 +542,7 @@ impl PageContent {
         payload_overflow_threshold_min: usize,
         usable_size: usize,
     ) -> Result<BTreeCell> {
-        log::debug!("cell_get(idx={})", idx);
+        tracing::debug!("cell_get(idx={})", idx);
         let buf = self.as_ptr();
 
         let ncells = self.cell_count();
@@ -729,7 +729,7 @@ pub fn begin_write_btree_page(
 
             page_finish.clear_dirty();
             if bytes_written < buf_len as i32 {
-                log::error!("wrote({bytes_written}) less than expected({buf_len})");
+                tracing::error!("wrote({bytes_written}) less than expected({buf_len})");
             }
         })
     };
@@ -1256,7 +1256,7 @@ pub fn begin_write_wal_frame(
 
             page_finish.clear_dirty();
             if bytes_written < buf_len as i32 {
-                log::error!("wrote({bytes_written}) less than expected({buf_len})");
+                tracing::error!("wrote({bytes_written}) less than expected({buf_len})");
             }
         })
     };
@@ -1287,7 +1287,7 @@ pub fn begin_write_wal_header(io: &Rc<dyn File>, header: &WalHeader) -> Result<(
     let write_complete = {
         Box::new(move |bytes_written: i32| {
             if bytes_written < WAL_HEADER_SIZE as i32 {
-                log::error!(
+                tracing::error!(
                     "wal header wrote({bytes_written}) less than expected({WAL_HEADER_SIZE})"
                 );
             }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1,5 +1,5 @@
-use log::{debug, trace};
 use std::collections::HashMap;
+use tracing::{debug, trace};
 
 use parking_lot::RwLock;
 use std::fmt::Formatter;
@@ -720,7 +720,7 @@ impl WalFileShared {
                 Ok(header) => header,
                 Err(err) => panic!("Couldn't read header page: {:?}", err),
             };
-            log::info!("recover not implemented yet");
+            tracing::info!("recover not implemented yet");
             // TODO: Return a completion instead.
             io.run_once()?;
             wal_header

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1131,7 +1131,7 @@ impl Program {
                             )));
                         }
                     }
-                    log::trace!("Halt auto_commit {}", self.auto_commit);
+                    tracing::trace!("Halt auto_commit {}", self.auto_commit);
                     let connection = self
                         .connection
                         .upgrade()
@@ -1177,14 +1177,14 @@ impl Program {
 
                     if updated && matches!(current_state, TransactionState::None) {
                         if let LimboResult::Busy = pager.begin_read_tx()? {
-                            log::trace!("begin_read_tx busy");
+                            tracing::trace!("begin_read_tx busy");
                             return Ok(StepResult::Busy);
                         }
                     }
 
                     if updated && matches!(new_transaction_state, TransactionState::Write) {
                         if let LimboResult::Busy = pager.begin_write_tx()? {
-                            log::trace!("begin_write_tx busy");
+                            tracing::trace!("begin_write_tx busy");
                             return Ok(StepResult::Busy);
                         }
                     }
@@ -2789,10 +2789,10 @@ fn make_owned_record(registers: &[OwnedValue], start_reg: &usize, count: &usize)
 }
 
 fn trace_insn(program: &Program, addr: InsnReference, insn: &Insn) {
-    if !log::log_enabled!(log::Level::Trace) {
+    if !tracing::enabled!(tracing::Level::TRACE) {
         return;
     }
-    log::trace!(
+    tracing::trace!(
         "{}",
         explain::insn_to_str(
             program,


### PR DESCRIPTION
In order [experimentally compile](https://github.com/DougAnderson444/wit-limbo) `limbo_core` to a [wasm component](https://component-model.bytecodealliance.org/), limbo needed to have no reliance on `js`, `js-sys`, `wasm-bindgen`, et al. (for those who aren't familiar, there are many `wasm` runtimes and not all of them play nice with `wasm-bindgen`)

This PR simply cleans up the dependencies, and puts them behind optional flags and whatnot in order to enable this. Both `log` and `tracing` were being used, so I reduced this only to `tracing`.

End result is limbo can be used like this: https://github.com/DougAnderson444/wit-limbo 

We can open a discussion on the possibilities that running limbo as a wasm component can offer, including potentially using composable components to implement the sqlite runtime extensions, as well as giving us a clean interface for PlatformIO operations -- define them once, implement many ways on various platforms. I'm new to limbo, but it looks like current extension are Rust based deps and features flags, whereas sqlite is runtime, right? What if limbo was runtime extensible too?

The WIT interface is largely sync (though I believe wasmtime has an async feature), but in my limited exposure to limbo so far a lot of the wasm seems sync already anyway. Again, topic for further discussion.

Suffice to say, aligning these deps in this way paves the road for further experiments and possibilities.

Related: https://github.com/neilg63/julian_day_converter/pull/2
Related: https://github.com/tursodatabase/limbo/issues/950
Closes: https://github.com/tursodatabase/limbo/issues/950