### PR TITLE
doc: Use `limbo_cli` as package instead for running limbo cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Examples of contributing
 To build and run `limbo` cli: 
 
 ```shell 
-cargo run --package limbo --bin limbo database.db
+cargo run --bin limbo database.db
 ```
 
 Run tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Examples of contributing
 To build and run `limbo` cli: 
 
 ```shell 
-cargo run --bin limbo database.db
+cargo run --package limbo_cli --bin limbo database.db
 ```
 
 Run tests:


### PR DESCRIPTION
I found invalid option while reading CONTRIBUTING.md and trying some commands in it.

error:

```
$ cargo run --package limbo --bin limbo database.db
error: no bin target named `limbo`.

$ rustc --version
rustc 1.83.0 (90b35a623 2024-11-26)
```

ref: https://github.com/tursodatabase/limbo/blob/291637cc7120303fd7337c342cf5dbc9363faa85/cli/Cargo.toml#L17