### PR TITLE
Extensions: Improve API with better error handling, fix paths in proc macros

### DIFF
--- a/extensions/core/README.md
+++ b/extensions/core/README.md
@@ -95,6 +95,9 @@ impl AggFunc for Percentile {
     /// The state to track during the steps
     type State = (Vec<f64>, Option<f64>, Option<String>); // Tracks the values, Percentile, and errors
 
+    /// Define your error type, must impl Display
+    type Error = String;
+
     /// Define the name you wish to call your function by. 
     /// e.g. SELECT percentile(value, 40);
      const NAME: &str = "percentile";
@@ -129,15 +132,15 @@ impl AggFunc for Percentile {
     }
     /// A function to finalize the state into a value to be returned as a result
     /// or an error (if you chose to track an error state as well)
-    fn finalize(state: Self::State) -> Value {
+    fn finalize(state: Self::State) -> Result<Value, Self::Error> {
         let (mut values, p_value, error) = state;
 
         if let Some(error) = error {
-            return Value::custom_error(error);
+            return Err(error);
         }
 
         if values.is_empty() {
-            return Value::null();
+            return Ok(Value::null());
         }
 
         values.sort_by(|a, b| a.partial_cmp(b).unwrap());
@@ -145,7 +148,7 @@ impl AggFunc for Percentile {
         let p = p_value.unwrap();
         let index = (p * (n - 1.0) / 100.0).floor() as usize;
 
-        Value::from_float(values[index])
+        Ok(Value::from_float(values[index]))
     }
 }
 ```
@@ -161,21 +164,21 @@ struct CsvVTable;
 
 impl VTabModule for CsvVTable {
     type VCursor = CsvCursor;
+    /// Define your error type. Must impl Display and match VCursor::Error
+    type Error = &'static str;
     /// Declare the name for your virtual table
     const NAME: &'static str = "csv_data";
 
-    /// Declare the table schema and call `api.declare_virtual_table` with the schema sql.
-    fn connect(api: &ExtensionApi) -> ResultCode {
-        let sql = "CREATE TABLE csv_data(
+    fn init_sql() -> &'static str {
+        "CREATE TABLE csv_data(
             name TEXT,
             age TEXT,
             city TEXT
-        )";
-        api.declare_virtual_table(Self::NAME, sql)
+        )"
     }
 
     /// Open to return a new cursor: In this simple example, the CSV file is read completely into memory on connect.
-    fn open() -> Self::VCursor {
+    fn open() -> Result<Self::VCursor, Self::Error> {
         // Read CSV file contents from "data.csv"
         let csv_content = fs::read_to_string("data.csv").unwrap_or_default();
         // For simplicity, we'll ignore the header row.
@@ -188,7 +191,7 @@ impl VTabModule for CsvVTable {
                     .collect()
             })
             .collect();
-        CsvCursor { rows, index: 0 }
+        Ok(CsvCursor { rows, index: 0 })
     }
 
     /// Filter through result columns. (not used in this simple example)
@@ -197,7 +200,7 @@ impl VTabModule for CsvVTable {
     }
 
     /// Return the value for the column at the given index in the current row.
-    fn column(cursor: &Self::VCursor, idx: u32) -> Value {
+    fn column(cursor: &Self::VCursor, idx: u32) -> Result<Value, Self::Error> {
         cursor.column(idx)
     }
 
@@ -226,6 +229,8 @@ struct CsvCursor {
 
 /// Implement the VTabCursor trait for your cursor type
 impl VTabCursor for CsvCursor {
+    type Error = &'static str;
+
     fn next(&mut self) -> ResultCode {
         CsvCursor::next(self)
     }
@@ -234,12 +239,12 @@ impl VTabCursor for CsvCursor {
         self.index >= self.rows.len()
     }
 
-    fn column(&self, idx: u32) -> Value {
+    fn column(&self, idx: u32) -> Result<Value, Self::Error> {
         let row = &self.rows[self.index];
         if (idx as usize) < row.len() {
-            Value::from_text(&row[idx as usize])
+            Ok(Value::from_text(&row[idx as usize]))
         } else {
-            Value::null()
+            Ok(Value::null())
         }
     }
 

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -1,38 +1,18 @@
 mod types;
 pub use limbo_macros::{register_extension, scalar, AggregateDerive, VTabModuleDerive};
-use std::os::raw::{c_char, c_void};
+use std::{
+    fmt::Display,
+    os::raw::{c_char, c_void},
+};
 pub use types::{ResultCode, Value, ValueType};
 
 #[repr(C)]
 pub struct ExtensionApi {
     pub ctx: *mut c_void,
-
-    pub register_scalar_function: unsafe extern "C" fn(
-        ctx: *mut c_void,
-        name: *const c_char,
-        func: ScalarFunction,
-    ) -> ResultCode,
-
-    pub register_aggregate_function: unsafe extern "C" fn(
-        ctx: *mut c_void,
-        name: *const c_char,
-        args: i32,
-        init_func: InitAggFunction,
-        step_func: StepFunction,
-        finalize_func: FinalizeFunction,
-    ) -> ResultCode,
-
-    pub register_module: unsafe extern "C" fn(
-        ctx: *mut c_void,
-        name: *const c_char,
-        module: VTabModuleImpl,
-    ) -> ResultCode,
-
-    pub declare_vtab: unsafe extern "C" fn(
-        ctx: *mut c_void,
-        name: *const c_char,
-        sql: *const c_char,
-    ) -> ResultCode,
+    pub register_scalar_function: RegisterScalarFn,
+    pub register_aggregate_function: RegisterAggFn,
+    pub register_module: RegisterModuleFn,
+    pub declare_vtab: DeclareVTabFn,
 }
 
 impl ExtensionApi {
@@ -48,15 +28,33 @@ impl ExtensionApi {
 }
 
 pub type ExtensionEntryPoint = unsafe extern "C" fn(api: *const ExtensionApi) -> ResultCode;
+
 pub type ScalarFunction = unsafe extern "C" fn(argc: i32, *const Value) -> Value;
+
+pub type DeclareVTabFn =
+    unsafe extern "C" fn(ctx: *mut c_void, name: *const c_char, sql: *const c_char) -> ResultCode;
+
+pub type RegisterScalarFn =
+    unsafe extern "C" fn(ctx: *mut c_void, name: *const c_char, func: ScalarFunction) -> ResultCode;
+
+pub type RegisterAggFn = unsafe extern "C" fn(
+    ctx: *mut c_void,
+    name: *const c_char,
+    args: i32,
+    init: InitAggFunction,
+    step: StepFunction,
+    finalize: FinalizeFunction,
+) -> ResultCode;
+
+pub type RegisterModuleFn = unsafe extern "C" fn(
+    ctx: *mut c_void,
+    name: *const c_char,
+    module: VTabModuleImpl,
+) -> ResultCode;
 
 pub type InitAggFunction = unsafe extern "C" fn() -> *mut AggCtx;
 pub type StepFunction = unsafe extern "C" fn(ctx: *mut AggCtx, argc: i32, argv: *const Value);
 pub type FinalizeFunction = unsafe extern "C" fn(ctx: *mut AggCtx) -> Value;
-
-pub trait Scalar {
-    fn call(&self, args: &[Value]) -> Value;
-}
 
 #[repr(C)]
 pub struct AggCtx {
@@ -65,11 +63,12 @@ pub struct AggCtx {
 
 pub trait AggFunc {
     type State: Default;
+    type Error: Display;
     const NAME: &'static str;
     const ARGS: i32;
 
     fn step(state: &mut Self::State, args: &[Value]);
-    fn finalize(state: Self::State) -> Value;
+    fn finalize(state: Self::State) -> Result<Value, Self::Error>;
 }
 
 #[repr(C)]
@@ -98,13 +97,14 @@ pub type VtabFnNext = unsafe extern "C" fn(cursor: *mut c_void) -> ResultCode;
 pub type VtabFnEof = unsafe extern "C" fn(cursor: *mut c_void) -> bool;
 
 pub trait VTabModule: 'static {
-    type VCursor: VTabCursor;
+    type VCursor: VTabCursor<Error = Self::Error>;
     const NAME: &'static str;
+    type Error: std::fmt::Display;
 
-    fn connect(api: &ExtensionApi) -> ResultCode;
-    fn open() -> Self::VCursor;
+    fn init_sql() -> &'static str;
+    fn open() -> Result<Self::VCursor, Self::Error>;
     fn filter(cursor: &mut Self::VCursor, arg_count: i32, args: &[Value]) -> ResultCode;
-    fn column(cursor: &Self::VCursor, idx: u32) -> Value;
+    fn column(cursor: &Self::VCursor, idx: u32) -> Result<Value, Self::Error>;
     fn next(cursor: &mut Self::VCursor) -> ResultCode;
     fn eof(cursor: &Self::VCursor) -> bool;
 }
@@ -112,7 +112,7 @@ pub trait VTabModule: 'static {
 pub trait VTabCursor: Sized {
     type Error: std::fmt::Display;
     fn rowid(&self) -> i64;
-    fn column(&self, idx: u32) -> Value;
+    fn column(&self, idx: u32) -> Result<Value, Self::Error>;
     fn eof(&self) -> bool;
     fn next(&mut self) -> ResultCode;
 }


### PR DESCRIPTION
This PR aims to improve the experience library authors have when writing extensions for limbo by offering more idiomatic Rust error handling, changing the common areas where errors may be propagated to Result types and declaring associated Error types in the traits of Aggregates and Virtual table extensions.

This PR also fixes many paths in the proc macros where full paths must be used to ensure compatability and namespacing is consistent across systems.