### PR TITLE
core/translate: `BEGIN EXCLUSIVE` support

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -46,7 +46,7 @@ The current status of Limbo is:
 | ALTER TABLE               | No      |                                                                                   |
 | ANALYZE                   | No      |                                                                                   |
 | ATTACH DATABASE           | No      |                                                                                   |
-| BEGIN TRANSACTION         | Partial | `BEGIN IMMEDIATE` is only supported mode, transaction names are not supported.    |
+| BEGIN TRANSACTION         | Partial | `BEGIN DEFERRED` is not supported, transaction names are not supported.           |
 | COMMIT TRANSACTION        | Partial | Transaction names are not supported.                                              |
 | CREATE INDEX              | No      |                                                                                   |
 | CREATE TABLE              | Partial |                                                                                   |

--- a/core/translate/transaction.rs
+++ b/core/translate/transaction.rs
@@ -20,10 +20,7 @@ pub fn translate_tx_begin(
         TransactionType::Deferred => {
             bail_parse_error!("BEGIN DEFERRED not supported yet");
         }
-        TransactionType::Exclusive => {
-            bail_parse_error!("BEGIN EXCLUSIVE not supported yet");
-        }
-        TransactionType::Immediate => {
+        TransactionType::Immediate | TransactionType::Exclusive => {
             program.emit_insn(Insn::Transaction { write: true });
             // TODO: Emit transaction instruction on temporary tables when we support them.
             program.emit_insn(Insn::AutoCommit {

--- a/testing/transactions.test
+++ b/testing/transactions.test
@@ -6,3 +6,7 @@ source $testdir/tester.tcl
 do_execsql_test basic-tx-1 {
   BEGIN IMMEDIATE; END
 } {}
+
+do_execsql_test basic-tx-2 {
+  BEGIN EXCLUSIVE; END
+} {}


### PR DESCRIPTION
After reading the fine print, SQLite documentation explains that `BEGIN IMMEDIATE` and `BEGIN EXCLUSIVE` are the same thing in WAL mode:

https://www.sqlite.org/lang_transaction.html

As that's the only mode we support, let's just add code generation for `BEGIN EXCLUSIVE`.

Fixes #1002