### PR TITLE
Implement the table_list pragma

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -162,7 +162,7 @@ Limbo aims to be fully compatible with SQLite, with opt-in features not supporte
 | PRAGMA stats                     | No         | Used for testing in SQLite                   |
 | PRAGMA synchronous               | No         |                                              |
 | PRAGMA table_info                | Yes        |                                              |
-| PRAGMA table_list                | No         |                                              |
+| PRAGMA table_list                | Yes        |                                              |
 | PRAGMA table_xinfo               | No         |                                              |
 | PRAGMA temp_store                | No         |                                              |
 | PRAGMA temp_store_directory      | Not Needed | deprecated in SQLite                         |

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -9,6 +9,7 @@ use limbo_sqlite3_parser::{
 };
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::time::Instant;
 use tracing::trace;
 
 pub struct Schema {
@@ -118,6 +119,7 @@ pub struct BTreeTable {
     pub primary_key_column_names: Vec<String>,
     pub columns: Vec<Column>,
     pub has_rowid: bool,
+    pub created_at: Instant,
 }
 
 impl BTreeTable {
@@ -353,6 +355,7 @@ fn create_table(
         has_rowid,
         primary_key_column_names,
         columns: cols,
+        created_at: Instant::now(),
     })
 }
 
@@ -416,6 +419,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
         name: "sqlite_schema".to_string(),
         has_rowid: true,
         primary_key_column_names: vec![],
+        created_at: Instant::now(),
         columns: vec![
             Column {
                 name: Some("type".to_string()),
@@ -920,6 +924,7 @@ mod tests {
             name: "t1".to_string(),
             has_rowid: true,
             primary_key_column_names: vec!["nonexistent".to_string()],
+            created_at: Instant::now(),
             columns: vec![Column {
                 name: Some("a".to_string()),
                 ty: Type::Integer,

--- a/testing/pragma.test
+++ b/testing/pragma.test
@@ -49,3 +49,15 @@ do_execsql_test_on_specific_db "testing/testing_user_version_10.db" pragma-user-
 do_execsql_test_on_specific_db ":memory:" pragma-user-version-default {
   PRAGMA user_version
 } {0}
+
+do_execsql_test_regex pragma-table-list {
+  PRAGMA table_list
+} {^main\|products\|table\|3\|0\|0\nmain\|users\|table\|10\|0\|0\nmain\|sqlite_schema\|table\|5\|0\|0}
+
+do_execsql_test pragma-table-list-equals {
+  PRAGMA table_list=products
+} {main|products|table|3|0|0}
+
+do_execsql_test pragma-table-list-calls {
+  PRAGMA table_list(users)
+} {main|users|table|10|0|0}

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1622,6 +1622,8 @@ pub enum PragmaName {
     PageCount,
     /// returns information about the columns of a table
     TableInfo,
+    /// returns the list of all tables in the database
+    TableList,
     /// Returns the user version of the database file.
     UserVersion,
     /// trigger a checkpoint to run on database(s) if WAL is enabled


### PR DESCRIPTION
SQLite queries the schema tables to implement this, so that tables can be printed out in order. For us, it would be quite cumbersome to do this, so we will just add a timestamp to the table creation.