### PR TITLE
select: fix bug with referring to a mixed-case alias

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -135,7 +135,7 @@ pub fn bind_column_references(
                 for result_column in result_columns.iter() {
                     if result_column
                         .name(referenced_tables)
-                        .map_or(false, |name| name == &normalized_id)
+                        .map_or(false, |name| name.eq_ignore_ascii_case(&normalized_id))
                     {
                         *expr = result_column.expr.clone();
                         return Ok(());

--- a/testing/orderby.test
+++ b/testing/orderby.test
@@ -137,3 +137,7 @@ Carolyn|118
 Katelyn|40
 Erik|88
 Collin|15}
+
+do_execsql_test case-insensitive-alias {
+    select u.first_name as fF, count(1) > 0 as cC from users u where fF = 'Jamie' group by fF order by cC;
+} {Jamie|1}


### PR DESCRIPTION
was running some clickbench queries against limbo and noticed this one