### PR TITLE
Implement the legacy_file_format pragma

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -139,7 +139,7 @@ Limbo aims to be fully compatible with SQLite, with opt-in features not supporte
 | PRAGMA journal_mode              | Yes        |                                              |
 | PRAGMA journal_size_limit        | No         |                                              |
 | PRAGMA legacy_alter_table        | No         |                                              |
-| PRAGMA legacy_file_format        | No         |                                              |
+| PRAGMA legacy_file_format        | Yes        |                                              |
 | PRAGMA locking_mode              | No         |                                              |
 | PRAGMA max_page_count            | No         |                                              |
 | PRAGMA mmap_size                 | No         |                                              |

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -140,6 +140,7 @@ fn update_pragma(
             query_pragma(PragmaName::JournalMode, schema, None, header, program)?;
             Ok(())
         }
+        PragmaName::LegacyFileFormat => Ok(()),
         PragmaName::WalCheckpoint => {
             query_pragma(PragmaName::WalCheckpoint, schema, None, header, program)?;
             Ok(())
@@ -181,6 +182,7 @@ fn query_pragma(
             program.emit_string8("wal".into(), register);
             program.emit_result_row(register, 1);
         }
+        PragmaName::LegacyFileFormat => {}
         PragmaName::WalCheckpoint => {
             // Checkpoint uses 3 registers: P1, P2, P3. Ref Insn::Checkpoint for more info.
             // Allocate two more here as one was allocated at the top.

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1618,6 +1618,8 @@ pub enum PragmaName {
     CacheSize,
     /// `journal_mode` pragma
     JournalMode,
+    /// Noop as per SQLite docs
+    LegacyFileFormat,
     /// Return the total number of pages in the database file.
     PageCount,
     /// returns information about the columns of a table


### PR DESCRIPTION
easy implementation, sqlite claims it is a noop now

"This pragma no longer functions. It has become a no-op. The capabilities formerly provided by PRAGMA legacy_file_format are now available using the SQLITE_DBCONFIG_LEGACY_FILE_FORMAT option to the sqlite3_db_config() C-language interface."