### PR TITLE
Support numeric column references in GROUP BY

### DIFF
--- a/testing/groupby.test
+++ b/testing/groupby.test
@@ -181,3 +181,7 @@ do_execsql_test column_alias_in_group_by_order_by_having {
   select first_name as fn, count(1) as fn_count from users where fn in ('Wanda', 'Whitney', 'William') group by fn having fn_count > 10 order by fn_count;
 } {Whitney|11
 William|111}
+
+do_execsql_test group_by_column_number {
+  select u.first_name, count(1) from users u group by 1 limit 1;
+} {Aaron|41}


### PR DESCRIPTION
We already supported this for ORDER BY but not GROUP BY - again noticed this when running against some clickbench queries