### PR TITLE
Fix substr

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2202,7 +2202,11 @@ impl Program {
                             ScalarFunc::Substr | ScalarFunc::Substring => {
                                 let str_value = &state.registers[*start_reg];
                                 let start_value = &state.registers[*start_reg + 1];
-                                let length_value = &state.registers[*start_reg + 2];
+                                let length_value = if func.arg_count == 3 {
+                                    Some(&state.registers[*start_reg + 2])
+                                } else {
+                                    None
+                                };
                                 let result = exec_substring(str_value, start_value, length_value);
                                 state.registers[*dest] = result;
                             }
@@ -3238,39 +3242,31 @@ fn exec_nullif(first_value: &OwnedValue, second_value: &OwnedValue) -> OwnedValu
 fn exec_substring(
     str_value: &OwnedValue,
     start_value: &OwnedValue,
-    length_value: &OwnedValue,
+    length_value: Option<&OwnedValue>,
 ) -> OwnedValue {
-    if let (OwnedValue::Text(str), OwnedValue::Integer(start), OwnedValue::Integer(length)) =
-        (str_value, start_value, length_value)
-    {
-        let start = *start as usize;
-        let str_len = str.as_str().len();
+    if let (OwnedValue::Text(str), OwnedValue::Integer(start)) = (str_value, start_value) {
+        let str_len = str.as_str().len() as i64;
 
-        if start > str_len {
-            return OwnedValue::build_text("");
-        }
-
-        let start_idx = start - 1;
-        let end = if *length != -1 {
-            start_idx + *length as usize
+        // The left-most character of X is number 1.
+        // If Y is negative then the first character of the substring is found by counting from the right rather than the left.
+        let first_position = if *start < 0 {
+            str_len.saturating_sub((*start).abs())
         } else {
-            str_len
+            *start - 1
         };
-        let substring = &str.as_str()[start_idx..end.min(str_len)];
-
-        OwnedValue::build_text(substring)
-    } else if let (OwnedValue::Text(str), OwnedValue::Integer(start)) = (str_value, start_value) {
-        let start = *start as usize;
-        let str_len = str.as_str().len();
-
-        if start > str_len {
-            return OwnedValue::build_text("");
-        }
-
-        let start_idx = start - 1;
-        let substring = &str.as_str()[start_idx..str_len];
-
-        OwnedValue::build_text(substring)
+        // If Z is negative then the abs(Z) characters preceding the Y-th character are returned.
+        let last_position = match length_value {
+            Some(OwnedValue::Integer(length)) => first_position + *length,
+            _ => str_len,
+        };
+        let (start, end) = if first_position <= last_position {
+            (first_position, last_position)
+        } else {
+            (last_position, first_position)
+        };
+        OwnedValue::build_text(
+            &str.as_str()[start.clamp(-0, str_len) as usize..end.clamp(0, str_len) as usize],
+        )
     } else {
         OwnedValue::Null
     }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -4341,7 +4341,7 @@ mod tests {
         let length_value = OwnedValue::Integer(3);
         let expected_val = OwnedValue::build_text("lim");
         assert_eq!(
-            exec_substring(&str_value, &start_value, &length_value),
+            exec_substring(&str_value, &start_value, Some(&length_value)),
             expected_val
         );
 
@@ -4350,7 +4350,7 @@ mod tests {
         let length_value = OwnedValue::Integer(10);
         let expected_val = OwnedValue::build_text("limbo");
         assert_eq!(
-            exec_substring(&str_value, &start_value, &length_value),
+            exec_substring(&str_value, &start_value, Some(&length_value)),
             expected_val
         );
 
@@ -4359,7 +4359,7 @@ mod tests {
         let length_value = OwnedValue::Integer(3);
         let expected_val = OwnedValue::build_text("");
         assert_eq!(
-            exec_substring(&str_value, &start_value, &length_value),
+            exec_substring(&str_value, &start_value, Some(&length_value)),
             expected_val
         );
 
@@ -4368,7 +4368,7 @@ mod tests {
         let length_value = OwnedValue::Null;
         let expected_val = OwnedValue::build_text("mbo");
         assert_eq!(
-            exec_substring(&str_value, &start_value, &length_value),
+            exec_substring(&str_value, &start_value, Some(&length_value)),
             expected_val
         );
 
@@ -4377,7 +4377,7 @@ mod tests {
         let length_value = OwnedValue::Null;
         let expected_val = OwnedValue::build_text("");
         assert_eq!(
-            exec_substring(&str_value, &start_value, &length_value),
+            exec_substring(&str_value, &start_value, Some(&length_value)),
             expected_val
         );
     }

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -535,6 +535,21 @@ do_execsql_test substr-2-args {
   SELECT substr('limbo', 3);
 } {mbo}
 
+do_execsql_test substr-cases {
+  SELECT substr('limbo', 0);
+  SELECT substr('limbo', 0, 3);
+  SELECT substr('limbo', -2);
+  SELECT substr('limbo', -2, 1);
+  SELECT substr('limbo', -10, 7);
+  SELECT substr('limbo', 10, -7);
+} {limbo
+li
+bo
+b
+li
+mbo
+}
+
 do_execsql_test substring-3-args {
   SELECT substring('limbo', 1, 3);
 } {lim}


### PR DESCRIPTION
Align `substr` implementation with SQLite spec (https://www.sqlite.org/lang_corefunc.html#substr):


> The substr(X,Y,Z) function returns a substring of input string X that begins with the Y-th character and which is Z characters long. If Z is omitted then substr(X,Y) returns all characters through the end of the string X beginning with the Y-th. The left-most character of X is number 1. If Y is negative then the first character of the substring is found by counting from the right rather than the left. If Z is negative then the abs(Z) characters preceding the Y-th character are returned. If X is a string then characters indices refer to actual UTF-8 characters. If X is a BLOB then the indices refer to bytes. 