### PR TITLE
Fix not evaling constant conditions when no tables in query

### DIFF
--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -237,7 +237,7 @@ pub fn open_loop(
                 // E.g. SELECT foo FROM (SELECT bar as foo FROM t1) sub WHERE sub.foo > 10
                 for cond in predicates
                     .iter()
-                    .filter(|cond| cond.eval_at_loop == table_index)
+                    .filter(|cond| cond.should_eval_at_loop(table_index))
                 {
                     let jump_target_when_true = program.allocate_label();
                     let condition_metadata = ConditionMetadata {
@@ -311,7 +311,7 @@ pub fn open_loop(
 
                 for cond in predicates
                     .iter()
-                    .filter(|cond| cond.eval_at_loop == table_index)
+                    .filter(|cond| cond.should_eval_at_loop(table_index))
                 {
                     let jump_target_when_true = program.allocate_label();
                     let condition_metadata = ConditionMetadata {
@@ -483,7 +483,7 @@ pub fn open_loop(
                 }
                 for cond in predicates
                     .iter()
-                    .filter(|cond| cond.eval_at_loop == table_index)
+                    .filter(|cond| cond.should_eval_at_loop(table_index))
                 {
                     let jump_target_when_true = program.allocate_label();
                     let condition_metadata = ConditionMetadata {

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -499,7 +499,7 @@ pub fn try_extract_index_search_expression(
     table_reference: &TableReference,
     available_indexes: &HashMap<String, Vec<Rc<Index>>>,
 ) -> Result<Option<Search>> {
-    if cond.eval_at_loop != table_index {
+    if !cond.should_eval_at_loop(table_index) {
         return Ok(None);
     }
     match &mut cond.expr {
@@ -512,7 +512,7 @@ pub fn try_extract_index_search_expression(
                             cmp_expr: WhereTerm {
                                 expr: rhs_owned,
                                 from_outer_join: cond.from_outer_join,
-                                eval_at_loop: cond.eval_at_loop,
+                                eval_at: cond.eval_at,
                             },
                         }));
                     }
@@ -526,7 +526,7 @@ pub fn try_extract_index_search_expression(
                             cmp_expr: WhereTerm {
                                 expr: rhs_owned,
                                 from_outer_join: cond.from_outer_join,
-                                eval_at_loop: cond.eval_at_loop,
+                                eval_at: cond.eval_at,
                             },
                         }));
                     }
@@ -542,7 +542,7 @@ pub fn try_extract_index_search_expression(
                             cmp_expr: WhereTerm {
                                 expr: lhs_owned,
                                 from_outer_join: cond.from_outer_join,
-                                eval_at_loop: cond.eval_at_loop,
+                                eval_at: cond.eval_at,
                             },
                         }));
                     }
@@ -556,7 +556,7 @@ pub fn try_extract_index_search_expression(
                             cmp_expr: WhereTerm {
                                 expr: lhs_owned,
                                 from_outer_join: cond.from_outer_join,
-                                eval_at_loop: cond.eval_at_loop,
+                                eval_at: cond.eval_at,
                             },
                         }));
                     }
@@ -580,7 +580,7 @@ pub fn try_extract_index_search_expression(
                             cmp_expr: WhereTerm {
                                 expr: rhs_owned,
                                 from_outer_join: cond.from_outer_join,
-                                eval_at_loop: cond.eval_at_loop,
+                                eval_at: cond.eval_at,
                             },
                         }));
                     }
@@ -604,7 +604,7 @@ pub fn try_extract_index_search_expression(
                             cmp_expr: WhereTerm {
                                 expr: lhs_owned,
                                 from_outer_join: cond.from_outer_join,
-                                eval_at_loop: cond.eval_at_loop,
+                                eval_at: cond.eval_at,
                             },
                         }));
                     }

--- a/testing/where.test
+++ b/testing/where.test
@@ -564,3 +564,11 @@ do_execsql_test where-binary-bitwise-and {
 do_execsql_test where-binary-bitwise-or {
     select count(*) from users where 2 | 1;
 } {10000}
+
+do_execsql_test where-constant-condition-no-tables {
+    select 1 where 1 IS NULL;
+} {}
+
+do_execsql_test where-constant-condition-no-tables-2 {
+    select 1 where 1 IS NOT NULL;
+} {1}


### PR DESCRIPTION
This PR is extracted from the sqlite fuzzing exploration effort in https://github.com/tursodatabase/limbo/pull/1021

---

We were not evaluating constant conditions (e.g '1 IS NULL') when there were no tables referenced in the query, because our WHERE term evaluation was based on "during which loop" to evaluate them. However, when there are no tables, there are no loops, so they were never evaluated.