### PR TITLE
Add some missing supported features in WHERE clause

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -272,7 +272,7 @@ pub fn translate_condition_expr(
                 }
             }
         }
-        ast::Expr::Literal(_) | ast::Expr::Cast { .. } => {
+        ast::Expr::Literal(_) | ast::Expr::Cast { .. } | ast::Expr::FunctionCall { .. }  => {
             let reg = program.alloc_register();
             translate_expr(program, Some(referenced_tables), expr, reg, resolver)?;
             emit_cond_jump(program, condition_metadata, reg);

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -276,7 +276,8 @@ pub fn translate_condition_expr(
         | ast::Expr::Cast { .. }
         | ast::Expr::FunctionCall { .. }
         | ast::Expr::Column { .. }
-        | ast::Expr::RowId { .. } => {
+        | ast::Expr::RowId { .. }
+        | ast::Expr::Case { .. } => {
             let reg = program.alloc_register();
             translate_expr(program, Some(referenced_tables), expr, reg, resolver)?;
             emit_cond_jump(program, condition_metadata, reg);

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -272,7 +272,10 @@ pub fn translate_condition_expr(
                 }
             }
         }
-        ast::Expr::Literal(_) | ast::Expr::Cast { .. } | ast::Expr::FunctionCall { .. }  => {
+        ast::Expr::Literal(_)
+        | ast::Expr::Cast { .. }
+        | ast::Expr::FunctionCall { .. }
+        | ast::Expr::Column { .. } => {
             let reg = program.alloc_register();
             translate_expr(program, Some(referenced_tables), expr, reg, resolver)?;
             emit_cond_jump(program, condition_metadata, reg);

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -275,7 +275,8 @@ pub fn translate_condition_expr(
         ast::Expr::Literal(_)
         | ast::Expr::Cast { .. }
         | ast::Expr::FunctionCall { .. }
-        | ast::Expr::Column { .. } => {
+        | ast::Expr::Column { .. }
+        | ast::Expr::RowId { .. } => {
             let reg = program.alloc_register();
             translate_expr(program, Some(referenced_tables), expr, reg, resolver)?;
             emit_cond_jump(program, condition_metadata, reg);

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -2144,6 +2144,10 @@ pub fn translate_expr(
     }
 }
 
+/// The base logic for translating LIKE and GLOB expressions.
+/// The logic for handling "NOT LIKE" is different depending on whether the expression
+/// is a conditional jump or not. This is why the caller handles the "NOT LIKE" behavior;
+/// see [translate_condition_expr] and [translate_expr] for implementations.
 fn translate_like_base(
     program: &mut ProgramBuilder,
     referenced_tables: Option<&[TableReference]>,

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -367,7 +367,6 @@ impl Optimizable for ast::Expr {
     fn check_constant(&self) -> Result<Option<ConstantPredicate>> {
         match self {
             Self::Literal(lit) => match lit {
-                ast::Literal::Null => Ok(Some(ConstantPredicate::AlwaysFalse)),
                 ast::Literal::Numeric(b) => {
                     if let Ok(int_value) = b.parse::<i64>() {
                         return Ok(Some(if int_value == 0 {

--- a/testing/select.test
+++ b/testing/select.test
@@ -151,3 +151,12 @@ do_execsql_test select_bin_shl {
 -997623670|-1995247340|-1021566638080|-1071190259091374080
 997623670|1995247340|1021566638080|1071190259091374080
 -997623670|-1995247340|-1021566638080|-1071190259091374080}
+
+# Test LIKE in SELECT position
+do_execsql_test select-like-expression {
+    select 'bar' like 'bar%'
+} {1}
+
+do_execsql_test select-not-like-expression {
+    select 'bar' not like 'bar%'
+} {0}

--- a/testing/where.test
+++ b/testing/where.test
@@ -472,3 +472,95 @@ foreach {operator} {
     # NULL comparison AND id=1
     do_execsql_test where-binary-one-operand-null-and-$operator "select first_name from users where first_name $operator NULL AND id = 1" {}
 }
+
+# Test literals in WHERE clause
+do_execsql_test where-literal-string {
+    select count(*) from users where 'yes';
+} {0}
+
+# FIXME: should return 0
+#do_execsql_test where-literal-number {
+#    select count(*) from users where x'DEADBEEF';
+#} {0}
+
+# Test CAST in WHERE clause
+do_execsql_test where-cast-string-to-int {
+    select count(*) from users where cast('1' as integer);
+} {10000}
+
+do_execsql_test where-cast-float-to-int {
+    select count(*) from users where cast('0' as integer);
+} {0}
+
+# Test FunctionCall in WHERE clause
+do_execsql_test where-function-length {
+    select count(*) from users where length(first_name);
+} {10000}
+
+# Test CASE in WHERE clause
+do_execsql_test where-case-simple {
+    select count(*) from users where 
+    case when age > 0 then 1 else 0 end;
+} {10000}
+
+do_execsql_test where-case-searched {
+    select count(*) from users where 
+    case age 
+        when 0 then 0
+        else 1
+    end;
+} {10000}
+
+# Test unary operators in WHERE clause
+do_execsql_test where-unary-not {
+    select count(*) from users where not (id = 1);
+} {9999}
+
+do_execsql_test where-unary-plus {
+    select count(*) from users where +1;
+} {10000}
+
+do_execsql_test where-unary-minus {
+    select count(*) from users where -1;
+} {10000}
+
+do_execsql_test where-unary-bitnot {
+    select count(*) from users where ~1;
+} {10000}
+
+# Test binary math operators in WHERE clause
+do_execsql_test where-binary-add {
+    select count(*) from users where 1 + 1;
+} {10000}
+
+do_execsql_test where-binary-subtract {
+    select count(*) from users where 2 - 1;
+} {10000}
+
+do_execsql_test where-binary-multiply {
+    select count(*) from users where 2 * 1;
+} {10000}
+
+do_execsql_test where-binary-divide {
+    select count(*) from users where 2 / 2;
+} {10000}
+
+do_execsql_test where-binary-modulo {
+    select count(*) from users where 3 % 2;
+} {10000}
+
+do_execsql_test where-binary-shift-left {
+    select count(*) from users where 1 << 1;
+} {10000}
+
+do_execsql_test where-binary-shift-right {
+    select count(*) from users where 2 >> 1;
+} {10000}
+
+do_execsql_test where-binary-bitwise-and {
+    select count(*) from users where 3 & 1;
+} {10000}
+
+do_execsql_test where-binary-bitwise-or {
+    select count(*) from users where 2 | 1;
+} {10000}

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -690,7 +690,6 @@ mod tests {
             .option_w(cast_expr, 1.0)
             .option_w(case_expr, 1.0)
             .option_w(cmp_op, 1.0)
-            // .option_w(in_op, 1.0)
             .options_str(["1", "0", "NULL", "2.0", "1.5", "-0.5", "-2.0", "(1 / 0)"])
             .build();
 

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -643,7 +643,15 @@ mod tests {
                     .concat(" ")
                     .push_str("(")
                     .push(column)
-                    .push(g.create().choice().options_str(["+", "-"]).build())
+                    .push(
+                        g.create()
+                            .choice()
+                            .options_str([
+                                "+", "-", "*", "/", "||", "=", "<>", ">", "<", ">=", "<=", "IS",
+                                "IS NOT",
+                            ])
+                            .build(),
+                    )
                     .push(column)
                     .push_str(")")
                     .build(),

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -871,16 +871,10 @@ mod tests {
         let limbo_conn = db.connect_limbo();
         let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
         for table in tables.iter() {
+            let query = format!("CREATE TABLE {} ({})", table.name, table.columns.join(", "));
             assert_eq!(
-                limbo_exec_rows(
-                    &db,
-                    &limbo_conn,
-                    &format!("CREATE TABLE {} ({})", table.name, table.columns.join(", "))
-                ),
-                sqlite_exec_rows(
-                    &sqlite_conn,
-                    &format!("CREATE TABLE {} ({})", table.name, table.columns.join(", "))
-                )
+                limbo_exec_rows(&db, &limbo_conn, &query),
+                sqlite_exec_rows(&sqlite_conn, &query)
             );
         }
 


### PR DESCRIPTION
This PR is sourced from the fuzzing exploration PR in https://github.com/tursodatabase/limbo/pull/1021

**Adds missing support:**

Support all the same literals in WHERE clause position as in SELECT position
Support CAST in WHERE clause position
Support FunctionCall in WHERE clause position
Support Column in WHERE clause position
Support Rowid in WHERE clause position
Support CASE in WHERE clause position
Support LIKE in SELECT position
Support Unary expressions in WHERE clause position
Support rest of the Binary expressions in WHERE clause position
Support TEXT in remainder operations

**Fix:**

Remove incorrect constant folding optimization for NULL

**Testing utils:**

Enhance sqlite fuzzer to mostly be able to work with the same set of possible expressions in both SELECT and WHERE clause position