### PR TITLE
Fix cast_text_to_number compatibility

### DIFF
--- a/core/util.rs
+++ b/core/util.rs
@@ -540,16 +540,6 @@ pub fn text_to_real(text: &str) -> (OwnedValue, CastTextToRealResultCode) {
         }
     }
 
-    dbg!(
-        &has_decimal_separator,
-        &sign,
-        &exp_sign,
-        &has_exponent,
-        &has_digit,
-        &has_decimal_digit,
-        &excess_space
-    );
-
     if let Ok(num) = accum.parse::<f64>() {
         if !has_decimal_separator && !exp_sign && !has_exponent && !excess_space {
             return (OwnedValue::Float(num), CastTextToRealResultCode::PureInt);

--- a/core/util.rs
+++ b/core/util.rs
@@ -1,8 +1,10 @@
+use core::num::IntErrorKind;
 use limbo_sqlite3_parser::ast::{self, CreateTableBody, Expr, FunctionTail, Literal};
 use std::{rc::Rc, sync::Arc};
 
 use crate::{
     schema::{self, Column, Schema, Type},
+    types::OwnedValue,
     Result, Statement, StepResult, IO,
 };
 
@@ -380,6 +382,147 @@ pub fn columns_from_create_table_body(body: ast::CreateTableBody) -> Result<Vec<
         .collect::<Vec<_>>())
 }
 
+#[derive(Debug, PartialEq)]
+/// Reference:
+/// https://github.com/sqlite/sqlite/blob/master/src/util.c#L798
+pub enum CastTextToIntResultCode {
+    NotInt = -1,
+    Success = 0,
+    ExcessSpace = 1,
+    TooLargeOrMalformed = 2,
+    #[allow(dead_code)]
+    SpecialCase = 3,
+}
+
+pub fn text_to_integer(text: &str) -> (OwnedValue, CastTextToIntResultCode) {
+    let text = text.trim();
+    if text.is_empty() {
+        return (OwnedValue::Integer(0), CastTextToIntResultCode::NotInt);
+    }
+    let mut accum = String::new();
+    let mut sign = false;
+    let mut has_digit = false;
+    let mut excess_space = false;
+
+    let chars = text.chars();
+
+    for c in chars {
+        match c {
+            '0'..='9' => {
+                has_digit = true;
+                accum.push(c);
+            }
+            '+' | '-' if !has_digit && !sign => {
+                sign = true;
+                accum.push(c);
+            }
+            _ => {
+                excess_space = true;
+                break;
+            }
+        }
+    }
+
+    match accum.parse::<i64>() {
+        Ok(num) => {
+            if excess_space {
+                return (
+                    OwnedValue::Integer(num),
+                    CastTextToIntResultCode::ExcessSpace,
+                );
+            }
+
+            return (OwnedValue::Integer(num), CastTextToIntResultCode::Success);
+        }
+        Err(e) => match e.kind() {
+            IntErrorKind::NegOverflow | IntErrorKind::PosOverflow => (
+                OwnedValue::Integer(0),
+                CastTextToIntResultCode::TooLargeOrMalformed,
+            ),
+            _ => (OwnedValue::Integer(0), CastTextToIntResultCode::NotInt),
+        },
+    }
+}
+
+#[derive(Debug, PartialEq)]
+/// Reference
+/// https://github.com/sqlite/sqlite/blob/master/src/util.c#L529
+pub enum CastTextToRealResultCode {
+    PureInt = 1,
+    HasDecimal = 2,
+    NotValid = 0,
+    NotValidButPrefix = -1,
+}
+
+pub fn text_to_real(text: &str) -> (OwnedValue, CastTextToRealResultCode) {
+    let text = text.trim();
+    if text.is_empty() {
+        return (OwnedValue::Float(0.0), CastTextToRealResultCode::NotValid);
+    }
+    let mut accum = String::new();
+    let mut has_decimal_separator = false;
+    let mut sign = false;
+    let mut exp_sign = false;
+    let mut has_exponent = false;
+    let mut has_digit = false;
+    let mut has_decimal_digit = false;
+    let mut excess_space = false;
+
+    let chars = text.chars();
+
+    for c in chars {
+        match c {
+            '0'..='9' if !has_decimal_separator => {
+                has_digit = true;
+                accum.push(c);
+            }
+            '0'..='9' => {
+                has_decimal_digit = true;
+                accum.push(c);
+            }
+            '+' | '-' if !has_digit && !sign => {
+                sign = true;
+                accum.push(c);
+            }
+            '+' | '-' if has_exponent && !exp_sign => {
+                exp_sign = true;
+                accum.push(c);
+            }
+            '.' if !has_decimal_separator => {
+                has_decimal_separator = true;
+                accum.push(c);
+            }
+            'E' | 'e' if !has_decimal_separator || has_decimal_digit => {
+                has_exponent = true;
+                accum.push(c);
+            }
+            _ => {
+                excess_space = true;
+                break;
+            }
+        }
+    }
+
+    if let Ok(num) = accum.parse::<f64>() {
+        if !has_decimal_separator && !exp_sign && !has_exponent {
+            return (OwnedValue::Float(num), CastTextToRealResultCode::PureInt);
+        }
+
+        if excess_space {
+            // TODO see if this branch satisfies: not a valid number, but has a valid prefix which
+            // includes a decimal point and/or an eNNN clause
+            return (
+                OwnedValue::Float(num),
+                CastTextToRealResultCode::NotValidButPrefix,
+            );
+        }
+
+        return (OwnedValue::Float(num), CastTextToRealResultCode::HasDecimal);
+    }
+
+    return (OwnedValue::Float(0.0), CastTextToRealResultCode::NotValid);
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -634,5 +777,197 @@ pub mod tests {
         assert!(check_ident_equivalency("\"foo\"", "`FOO`"));
         assert!(!check_ident_equivalency("\"foo\"", "[bar]"));
         assert!(!check_ident_equivalency("foo", "\"bar\""));
+    }
+
+    #[test]
+    fn test_text_to_integer() {
+        let pairs = vec![
+            (
+                text_to_integer("1"),
+                (OwnedValue::Integer(1), CastTextToIntResultCode::Success),
+            ),
+            (
+                text_to_integer("-1"),
+                (OwnedValue::Integer(-1), CastTextToIntResultCode::Success),
+            ),
+            (
+                text_to_integer("10000000"),
+                (
+                    OwnedValue::Integer(10000000),
+                    CastTextToIntResultCode::Success,
+                ),
+            ),
+            (
+                text_to_integer("-10000000"),
+                (
+                    OwnedValue::Integer(-10000000),
+                    CastTextToIntResultCode::Success,
+                ),
+            ),
+            (
+                text_to_integer("xxx"),
+                (OwnedValue::Integer(0), CastTextToIntResultCode::NotInt),
+            ),
+            (
+                text_to_integer("123xxx"),
+                (
+                    OwnedValue::Integer(123),
+                    CastTextToIntResultCode::ExcessSpace,
+                ),
+            ),
+            (
+                text_to_integer("9223372036854775807"),
+                (
+                    OwnedValue::Integer(i64::MAX),
+                    CastTextToIntResultCode::Success,
+                ),
+            ),
+            (
+                text_to_integer("9223372036854775808"),
+                (
+                    OwnedValue::Integer(0),
+                    CastTextToIntResultCode::TooLargeOrMalformed,
+                ),
+            ),
+            (
+                text_to_integer("-9223372036854775808"),
+                (
+                    OwnedValue::Integer(i64::MIN),
+                    CastTextToIntResultCode::Success,
+                ),
+            ),
+            (
+                text_to_integer("-9223372036854775809"),
+                (
+                    OwnedValue::Integer(0),
+                    CastTextToIntResultCode::TooLargeOrMalformed,
+                ),
+            ),
+        ];
+
+        for (left, right) in pairs {
+            assert_eq!(left, right);
+        }
+    }
+
+    #[test]
+    fn test_text_to_real() {
+        let pairs = vec![
+            (
+                text_to_real("1"),
+                (OwnedValue::Float(1.0), CastTextToRealResultCode::PureInt),
+            ),
+            (
+                text_to_real("-1"),
+                (OwnedValue::Float(-1.0), CastTextToRealResultCode::PureInt),
+            ),
+            (
+                text_to_real("1.0"),
+                (OwnedValue::Float(1.0), CastTextToRealResultCode::HasDecimal),
+            ),
+            (
+                text_to_real("-1.0"),
+                (
+                    OwnedValue::Float(-1.0),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("1e10"),
+                (
+                    OwnedValue::Float(1e10),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("-1e10"),
+                (
+                    OwnedValue::Float(-1e10),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("1e-10"),
+                (
+                    OwnedValue::Float(1e-10),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("-1e-10"),
+                (
+                    OwnedValue::Float(-1e-10),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("1.123e10"),
+                (
+                    OwnedValue::Float(1.123e10),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("-1.123e10"),
+                (
+                    OwnedValue::Float(-1.123e10),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("1.123e-10"),
+                (
+                    OwnedValue::Float(1.123e-10),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("-1.123e-10"),
+                (
+                    OwnedValue::Float(-1.123e-10),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("1-282584294928"),
+                (OwnedValue::Float(1.0), CastTextToRealResultCode::PureInt),
+            ),
+            (
+                text_to_real("xxx"),
+                (OwnedValue::Float(0.0), CastTextToRealResultCode::NotValid),
+            ),
+            (
+                text_to_real("1.7976931348623157e308"),
+                (
+                    OwnedValue::Float(f64::MAX),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("1.7976931348623157e309"),
+                (
+                    OwnedValue::Float(f64::INFINITY),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("-1.7976931348623157e308"),
+                (
+                    OwnedValue::Float(f64::MIN),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+            (
+                text_to_real("-1.7976931348623157e309"),
+                (
+                    OwnedValue::Float(f64::NEG_INFINITY),
+                    CastTextToRealResultCode::HasDecimal,
+                ),
+            ),
+        ];
+
+        for (left, right) in pairs {
+            assert_eq!(left, right);
+        }
     }
 }

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -688,10 +688,6 @@ pub enum Cookie {
     UserVersion = 6,
 }
 
-// fn cast_text_to_numeric(value: &str) -> OwnedValue {
-//     cast_text_to_numeric(value)
-// }
-
 pub fn exec_add(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
     if let OwnedValue::Agg(agg) = lhs {
         lhs = agg.final_value();

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1,6 +1,6 @@
 use std::num::NonZero;
 
-use super::{AggFunc, BranchOffset, CursorID, FuncCtx, PageIdx};
+use super::{cast_text_to_numeric, AggFunc, BranchOffset, CursorID, FuncCtx, PageIdx};
 use crate::storage::wal::CheckpointMode;
 use crate::types::{OwnedValue, Record};
 use limbo_macros::Description;
@@ -688,15 +688,9 @@ pub enum Cookie {
     UserVersion = 6,
 }
 
-fn cast_text_to_numerical(value: &str) -> OwnedValue {
-    if let Ok(x) = value.parse::<i64>() {
-        OwnedValue::Integer(x)
-    } else if let Ok(x) = value.parse::<f64>() {
-        OwnedValue::Float(x)
-    } else {
-        OwnedValue::Integer(0)
-    }
-}
+// fn cast_text_to_numeric(value: &str) -> OwnedValue {
+//     cast_text_to_numeric(value)
+// }
 
 pub fn exec_add(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
     if let OwnedValue::Agg(agg) = lhs {
@@ -719,11 +713,11 @@ pub fn exec_add(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
         | (OwnedValue::Integer(i), OwnedValue::Float(f)) => OwnedValue::Float(*f + *i as f64),
         (OwnedValue::Null, _) | (_, OwnedValue::Null) => OwnedValue::Null,
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_add(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) | (other, OwnedValue::Text(text)) => {
-            exec_add(&cast_text_to_numerical(text.as_str()), other)
+            exec_add(&cast_text_to_numeric(text.as_str()), other)
         }
         _ => todo!(),
     }
@@ -750,14 +744,14 @@ pub fn exec_subtract(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
         (OwnedValue::Integer(lhs), OwnedValue::Float(rhs)) => OwnedValue::Float(*lhs as f64 - rhs),
         (OwnedValue::Null, _) | (_, OwnedValue::Null) => OwnedValue::Null,
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_subtract(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) => {
-            exec_subtract(&cast_text_to_numerical(text.as_str()), other)
+            exec_subtract(&cast_text_to_numeric(text.as_str()), other)
         }
         (other, OwnedValue::Text(text)) => {
-            exec_subtract(other, &cast_text_to_numerical(text.as_str()))
+            exec_subtract(other, &cast_text_to_numeric(text.as_str()))
         }
         _ => todo!(),
     }
@@ -783,11 +777,11 @@ pub fn exec_multiply(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
         | (OwnedValue::Float(f), OwnedValue::Integer(i)) => OwnedValue::Float(*i as f64 * { *f }),
         (OwnedValue::Null, _) | (_, OwnedValue::Null) => OwnedValue::Null,
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_multiply(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) | (other, OwnedValue::Text(text)) => {
-            exec_multiply(&cast_text_to_numerical(text.as_str()), other)
+            exec_multiply(&cast_text_to_numeric(text.as_str()), other)
         }
 
         _ => todo!(),
@@ -816,15 +810,11 @@ pub fn exec_divide(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
         (OwnedValue::Integer(lhs), OwnedValue::Float(rhs)) => OwnedValue::Float(*lhs as f64 / rhs),
         (OwnedValue::Null, _) | (_, OwnedValue::Null) => OwnedValue::Null,
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_divide(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
-        (OwnedValue::Text(text), other) => {
-            exec_divide(&cast_text_to_numerical(text.as_str()), other)
-        }
-        (other, OwnedValue::Text(text)) => {
-            exec_divide(other, &cast_text_to_numerical(text.as_str()))
-        }
+        (OwnedValue::Text(text), other) => exec_divide(&cast_text_to_numeric(text.as_str()), other),
+        (other, OwnedValue::Text(text)) => exec_divide(other, &cast_text_to_numeric(text.as_str())),
         _ => todo!(),
     }
 }
@@ -849,11 +839,11 @@ pub fn exec_bit_and(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
         (OwnedValue::Float(lh), OwnedValue::Integer(rh)) => OwnedValue::Integer(*lh as i64 & rh),
         (OwnedValue::Integer(lh), OwnedValue::Float(rh)) => OwnedValue::Integer(lh & *rh as i64),
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_bit_and(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) | (other, OwnedValue::Text(text)) => {
-            exec_bit_and(&cast_text_to_numerical(text.as_str()), other)
+            exec_bit_and(&cast_text_to_numeric(text.as_str()), other)
         }
         _ => todo!(),
     }
@@ -875,11 +865,11 @@ pub fn exec_bit_or(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
             OwnedValue::Integer(*lh as i64 | *rh as i64)
         }
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_bit_or(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) | (other, OwnedValue::Text(text)) => {
-            exec_bit_or(&cast_text_to_numerical(text.as_str()), other)
+            exec_bit_or(&cast_text_to_numeric(text.as_str()), other)
         }
         _ => todo!(),
     }
@@ -939,7 +929,7 @@ pub fn exec_bit_not(mut reg: &OwnedValue) -> OwnedValue {
         OwnedValue::Null => OwnedValue::Null,
         OwnedValue::Integer(i) => OwnedValue::Integer(!i),
         OwnedValue::Float(f) => OwnedValue::Integer(!(*f as i64)),
-        OwnedValue::Text(text) => exec_bit_not(&cast_text_to_numerical(text.as_str())),
+        OwnedValue::Text(text) => exec_bit_not(&cast_text_to_numeric(text.as_str())),
         _ => todo!(),
     }
 }
@@ -966,14 +956,14 @@ pub fn exec_shift_left(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue
             OwnedValue::Integer(compute_shl(*lh as i64, *rh as i64))
         }
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_shift_left(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) => {
-            exec_shift_left(&cast_text_to_numerical(text.as_str()), other)
+            exec_shift_left(&cast_text_to_numeric(text.as_str()), other)
         }
         (other, OwnedValue::Text(text)) => {
-            exec_shift_left(other, &cast_text_to_numerical(text.as_str()))
+            exec_shift_left(other, &cast_text_to_numeric(text.as_str()))
         }
         _ => todo!(),
     }
@@ -1005,14 +995,14 @@ pub fn exec_shift_right(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValu
             OwnedValue::Integer(compute_shr(*lh as i64, *rh as i64))
         }
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_shift_right(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) => {
-            exec_shift_right(&cast_text_to_numerical(text.as_str()), other)
+            exec_shift_right(&cast_text_to_numeric(text.as_str()), other)
         }
         (other, OwnedValue::Text(text)) => {
-            exec_shift_right(other, &cast_text_to_numerical(text.as_str()))
+            exec_shift_right(other, &cast_text_to_numeric(text.as_str()))
         }
         _ => todo!(),
     }
@@ -1043,7 +1033,7 @@ pub fn exec_boolean_not(mut reg: &OwnedValue) -> OwnedValue {
         OwnedValue::Null => OwnedValue::Null,
         OwnedValue::Integer(i) => OwnedValue::Integer((*i == 0) as i64),
         OwnedValue::Float(f) => OwnedValue::Integer((*f == 0.0) as i64),
-        OwnedValue::Text(text) => exec_boolean_not(&cast_text_to_numerical(text.as_str())),
+        OwnedValue::Text(text) => exec_boolean_not(&cast_text_to_numeric(text.as_str())),
         _ => todo!(),
     }
 }
@@ -1125,11 +1115,11 @@ pub fn exec_and(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
         | (OwnedValue::Float(0.0), _) => OwnedValue::Integer(0),
         (OwnedValue::Null, _) | (_, OwnedValue::Null) => OwnedValue::Null,
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_and(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) | (other, OwnedValue::Text(text)) => {
-            exec_and(&cast_text_to_numerical(text.as_str()), other)
+            exec_and(&cast_text_to_numeric(text.as_str()), other)
         }
         _ => OwnedValue::Integer(1),
     }
@@ -1154,11 +1144,11 @@ pub fn exec_or(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {
         | (OwnedValue::Float(0.0), OwnedValue::Float(0.0))
         | (OwnedValue::Integer(0), OwnedValue::Integer(0)) => OwnedValue::Integer(0),
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_or(
-            &cast_text_to_numerical(lhs.as_str()),
-            &cast_text_to_numerical(rhs.as_str()),
+            &cast_text_to_numeric(lhs.as_str()),
+            &cast_text_to_numeric(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) | (other, OwnedValue::Text(text)) => {
-            exec_or(&cast_text_to_numerical(text.as_str()), other)
+            exec_or(&cast_text_to_numeric(text.as_str()), other)
         }
         _ => OwnedValue::Integer(1),
     }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3760,7 +3760,6 @@ fn cast_text_to_numeric(text: &str) -> OwnedValue {
             CastTextToIntResultCode::TooLargeOrMalformed | CastTextToIntResultCode::SpecialCase,
         ) => real_cast,
         (CastTextToRealResultCode::PureInt, CastTextToIntResultCode::Success) => int_cast,
-        // CastTextToRealResultCode::NotValid => (),
         _ => real_cast,
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3676,7 +3676,7 @@ fn checked_cast_text_to_numeric(text: &str) -> std::result::Result<OwnedValue, (
 fn cast_text_to_numeric(text: &str) -> OwnedValue {
     let (real_cast, rc_real) = cast_text_to_real(text);
     let (int_cast, rc_int) = cast_text_to_integer(text);
-
+    dbg!(&real_cast, &rc_real, &int_cast, &rc_int);
     match (rc_real, rc_int) {
         (
             CastTextToRealResultCode::NotValid,
@@ -3684,12 +3684,13 @@ fn cast_text_to_numeric(text: &str) -> OwnedValue {
             | CastTextToIntResultCode::Success
             | CastTextToIntResultCode::NotInt,
         ) => int_cast,
-        (CastTextToRealResultCode::NotValidButPrefix, _) => real_cast,
         (
             CastTextToRealResultCode::NotValid,
             CastTextToIntResultCode::TooLargeOrMalformed | CastTextToIntResultCode::SpecialCase,
         ) => real_cast,
+        (CastTextToRealResultCode::NotValidButPrefix, _) => real_cast,
         (CastTextToRealResultCode::PureInt, CastTextToIntResultCode::Success) => int_cast,
+        (CastTextToRealResultCode::HasDecimal, _) => real_cast,
         _ => real_cast,
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3676,7 +3676,6 @@ fn checked_cast_text_to_numeric(text: &str) -> std::result::Result<OwnedValue, (
 fn cast_text_to_numeric(text: &str) -> OwnedValue {
     let (real_cast, rc_real) = cast_text_to_real(text);
     let (int_cast, rc_int) = cast_text_to_integer(text);
-    dbg!(&real_cast, &rc_real, &int_cast, &rc_int);
     match (rc_real, rc_int) {
         (
             CastTextToRealResultCode::NotValid,


### PR DESCRIPTION
Modified  `cast_text_to_number` to be more compatible with SQLite. When I was running some fuzz tests, I would eventually get errors due to incorrect casting of text to `INTEGER` or `REAL`. Previously in code there were 2 implementations of `cast_text_to_number`: one in `core/vdbe/insn.rs` and one in `core/vdbe/mod.rs`. I consolidated the casting to only one function. Previously, the `mod.rs` function was just calling `checked_cast_text_to_numeric`, which was used in `MustBeInt` opcode.  Hopefully this fixes some of the CI testing issues we are having. This was the query that prompted me to do this: `SELECT  ( ( ( 878352367 ) <> ( 29 ) ) ) = ( ( ( -4309097 ) / ( -37 || -149680985265412 ) ) - 755066415 );`