### PR TITLE
Handle parsing URI according to SQLite specification

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -14,6 +14,7 @@ mod schema;
 mod storage;
 mod translate;
 mod types;
+#[allow(dead_code)]
 mod util;
 mod vdbe;
 mod vector;

--- a/core/util.rs
+++ b/core/util.rs
@@ -3,7 +3,7 @@ use std::{rc::Rc, sync::Arc};
 
 use crate::{
     schema::{self, Column, Schema, Type},
-    Result, Statement, StepResult, IO,
+    LimboError, OpenFlags, Result, Statement, StepResult, IO,
 };
 
 // https://sqlite.org/lang_keywords.html
@@ -380,6 +380,167 @@ pub fn columns_from_create_table_body(body: ast::CreateTableBody) -> Result<Vec<
         .collect::<Vec<_>>())
 }
 
+#[derive(Debug, Default, PartialEq)]
+pub struct OpenOptions<'a> {
+    pub authority: Option<&'a str>,
+    pub path: String,
+    pub fragment: Option<String>,
+    pub vfs: Option<String>,
+    pub mode: Mode,
+    pub modeof: Option<String>,
+    pub cache: Option<CacheMode>,
+    pub immutable: Option<bool>,
+}
+
+#[derive(Clone, Default, Debug, Copy, PartialEq)]
+pub enum Mode {
+    ReadOnly,
+    ReadWrite,
+    Memory,
+    #[default]
+    ReadWriteCreate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CacheMode {
+    Private,
+    Shared,
+}
+
+impl From<&str> for CacheMode {
+    fn from(s: &str) -> Self {
+        match s {
+            "private" => CacheMode::Private,
+            "shared" => CacheMode::Shared,
+            _ => CacheMode::Private,
+        }
+    }
+}
+
+impl Mode {
+    pub fn from_str(s: &str) -> Result<Self> {
+        match s.trim().to_lowercase().as_str() {
+            "ro" => Ok(Mode::ReadOnly),
+            "rw" => Ok(Mode::ReadWrite),
+            "memory" => Ok(Mode::Memory),
+            "rwc" => Ok(Mode::ReadWriteCreate),
+            _ => Err(LimboError::InvalidArgument(format!(
+                "Invalid mode: '{}'. Expected one of 'ro', 'rw', 'memory', 'rwc'",
+                s
+            ))),
+        }
+    }
+    pub fn get_flags(&self) -> OpenFlags {
+        match self {
+            Mode::ReadWriteCreate => OpenFlags::Create,
+            _ => OpenFlags::None,
+        }
+    }
+}
+
+fn is_windows_path(path: &str) -> bool {
+    path.len() >= 3 && path.chars().nth(1) == Some(':') && path.chars().nth(2) == Some('/')
+}
+
+/// Parses a SQLite URI, handling Windows and Unix paths separately.
+pub fn parse_sqlite_uri(uri: &str) -> Result<OpenOptions> {
+    if !uri.starts_with("file:") {
+        return Ok(OpenOptions {
+            path: uri.to_string(),
+            ..Default::default()
+        });
+    }
+
+    let mut opts = OpenOptions::default();
+    let without_scheme = &uri[5..];
+
+    let (without_fragment, fragment) = without_scheme
+        .split_once('#')
+        .unwrap_or((without_scheme, ""));
+    if !fragment.is_empty() {
+        opts.fragment = Some(decode_percent(fragment));
+    }
+
+    let (without_query, query) = without_fragment
+        .split_once('?')
+        .unwrap_or((without_fragment, ""));
+    parse_query_params(query, &mut opts)?;
+
+    // Handle authority + path separately
+    if let Some(after_slashes) = without_query.strip_prefix("//") {
+        let (authority, path) = after_slashes.split_once('/').unwrap_or((after_slashes, ""));
+
+        // SQLite allows only `localhost` or empty authority.
+        if !(authority.is_empty() || authority == "localhost") {
+            return Err(LimboError::InvalidArgument(format!(
+                "Invalid authority '{}'. Only '' or 'localhost' allowed.",
+                authority
+            )));
+        }
+        opts.authority = if authority.is_empty() {
+            None
+        } else {
+            Some(authority)
+        };
+
+        if is_windows_path(path) {
+            opts.path = format!("/{}", decode_percent(path)); // Ensure `/C:/` format
+        } else if !path.is_empty() {
+            opts.path = format!("/{}", decode_percent(path));
+        } else {
+            opts.path = String::new();
+        }
+    } else {
+        // no authority, must be a normal absolute or relative path.
+        opts.path = decode_percent(without_query);
+    }
+
+    Ok(opts)
+}
+
+// parses query parameters and updates OpenOptions
+fn parse_query_params(query: &str, opts: &mut OpenOptions) -> Result<()> {
+    for param in query.split('&') {
+        if let Some((key, value)) = param.split_once('=') {
+            let decoded_value = decode_percent(value);
+            match key {
+                "mode" => opts.mode = Mode::from_str(value)?,
+                "modeof" => opts.modeof = Some(decoded_value),
+                "cache" => opts.cache = Some(decoded_value.as_str().into()),
+                "immutable" => opts.immutable = Some(decoded_value == "1"),
+                "vfs" => opts.vfs = Some(decoded_value),
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Decodes percent-encoded characters (e.g., `%20` → `' '`).
+fn decode_percent(input: &str) -> String {
+    let mut result = String::new();
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '%' {
+            if let (Some(h1), Some(h2)) = (chars.next(), chars.next()) {
+                if let Ok(byte) = u8::from_str_radix(&format!("{}{}", h1, h2), 16) {
+                    result.push(byte as char);
+                } else {
+                    result.push('%');
+                    result.push(h1);
+                    result.push(h2);
+                }
+            } else {
+                result.push('%');
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -634,5 +795,240 @@ pub mod tests {
         assert!(check_ident_equivalency("\"foo\"", "`FOO`"));
         assert!(!check_ident_equivalency("\"foo\"", "[bar]"));
         assert!(!check_ident_equivalency("foo", "\"bar\""));
+    }
+
+    #[test]
+    fn test_simple_uri() {
+        let uri = "file:/home/user/db.sqlite";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.authority, None);
+    }
+
+    #[test]
+    fn test_uri_with_authority() {
+        let uri = "file://localhost/home/user/db.sqlite";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.authority, Some("localhost"));
+    }
+
+    #[test]
+    fn test_uri_with_invalid_authority() {
+        let uri = "file://example.com/home/user/db.sqlite";
+        let result = parse_sqlite_uri(uri);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_uri_with_query_params() {
+        let uri = "file:/home/user/db.sqlite?vfs=unix&mode=ro&immutable=1";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.vfs, Some("unix".to_string()));
+        assert_eq!(opts.mode, Mode::ReadOnly);
+        assert_eq!(opts.immutable, Some(true));
+    }
+
+    #[test]
+    fn test_uri_with_fragment() {
+        let uri = "file:/home/user/db.sqlite#section1";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.fragment, Some("section1".to_string()));
+    }
+
+    #[test]
+    fn test_uri_with_percent_encoding() {
+        let uri = "file:/home/user/db%20with%20spaces.sqlite?vfs=unix";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db with spaces.sqlite");
+        assert_eq!(opts.vfs, Some("unix".to_string()));
+    }
+
+    #[test]
+    fn test_uri_without_scheme() {
+        let uri = "/home/user/db.sqlite";
+        let result = parse_sqlite_uri(uri);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().path, "/home/user/db.sqlite");
+    }
+
+    #[test]
+    fn test_uri_with_empty_query() {
+        let uri = "file:/home/user/db.sqlite?";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.vfs, None);
+    }
+
+    #[test]
+    fn test_uri_with_partial_query() {
+        let uri = "file:/home/user/db.sqlite?mode=rw";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.mode, Mode::ReadWrite);
+        assert_eq!(opts.vfs, None);
+    }
+
+    #[test]
+    fn test_uri_windows_style_path() {
+        let uri = "file:///C:/Users/test/db.sqlite";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/C:/Users/test/db.sqlite");
+    }
+
+    #[test]
+    fn test_uri_with_only_query_params() {
+        let uri = "file:?mode=memory&cache=shared";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "");
+        assert_eq!(opts.mode, Mode::Memory);
+        assert_eq!(opts.cache, Some(CacheMode::Shared));
+    }
+
+    #[test]
+    fn test_uri_with_only_fragment() {
+        let uri = "file:#fragment";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "");
+        assert_eq!(opts.fragment, Some("fragment".to_string()));
+    }
+
+    #[test]
+    fn test_uri_with_invalid_scheme() {
+        let uri = "http:/home/user/db.sqlite";
+        let result = parse_sqlite_uri(uri);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().path, "http:/home/user/db.sqlite");
+    }
+
+    #[test]
+    fn test_uri_with_multiple_query_params() {
+        let uri = "file:/home/user/db.sqlite?vfs=unix&mode=rw&cache=private&immutable=0";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.vfs, Some("unix".to_string()));
+        assert_eq!(opts.mode, Mode::ReadWrite);
+        assert_eq!(opts.cache, Some(CacheMode::Private));
+        assert_eq!(opts.immutable, Some(false));
+    }
+
+    #[test]
+    fn test_uri_with_unknown_query_param() {
+        let uri = "file:/home/user/db.sqlite?unknown=param";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.vfs, None);
+    }
+
+    #[test]
+    fn test_uri_with_multiple_equal_signs() {
+        let uri = "file:/home/user/db.sqlite?vfs=unix=custom";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.vfs, Some("unix=custom".to_string()));
+    }
+
+    #[test]
+    fn test_uri_with_trailing_slash() {
+        let uri = "file:/home/user/db.sqlite/";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite/");
+    }
+
+    #[test]
+    fn test_uri_with_encoded_characters_in_query() {
+        let uri = "file:/home/user/db.sqlite?vfs=unix%20mode";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.vfs, Some("unix mode".to_string()));
+    }
+
+    #[test]
+    fn test_uri_windows_network_path() {
+        let uri = "file://server/share/db.sqlite";
+        let result = parse_sqlite_uri(uri);
+        assert!(result.is_err()); // non-localhost authority should fail
+    }
+
+    #[test]
+    fn test_uri_windows_drive_letter_with_slash() {
+        let uri = "file:///C:/database.sqlite";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/C:/database.sqlite");
+    }
+
+    #[test]
+    fn test_localhost_with_double_slash_and_no_path() {
+        let uri = "file://localhost";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "");
+        assert_eq!(opts.authority, Some("localhost"));
+    }
+
+    #[test]
+    fn test_uri_windows_drive_letter_without_slash() {
+        let uri = "file:///C:/database.sqlite";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/C:/database.sqlite");
+    }
+
+    #[test]
+    fn test_improper_mode() {
+        // any other mode but ro, rwc, rw, memory should fail per sqlite
+
+        let uri = "file:data.db?mode=readonly";
+        let res = parse_sqlite_uri(uri);
+        assert!(res.is_err());
+        // including empty
+        let uri = "file:/home/user/db.sqlite?vfs=&mode=";
+        let res = parse_sqlite_uri(uri);
+        assert!(res.is_err());
+    }
+
+    // Some examples from https://www.sqlite.org/c3ref/open.html#urifilenameexamples
+    #[test]
+    fn test_simple_file_current_dir() {
+        let uri = "file:data.db";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "data.db");
+        assert_eq!(opts.authority, None);
+        assert_eq!(opts.vfs, None);
+        assert_eq!(opts.mode, Mode::ReadWriteCreate);
+    }
+
+    #[test]
+    fn test_simple_file_three_slash() {
+        let uri = "file:///home/data/data.db";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/data/data.db");
+        assert_eq!(opts.authority, None);
+        assert_eq!(opts.vfs, None);
+        assert_eq!(opts.mode, Mode::ReadWriteCreate);
+    }
+
+    #[test]
+    fn test_simple_file_two_slash_localhost() {
+        let uri = "file://localhost/home/fred/data.db";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/home/fred/data.db");
+        assert_eq!(opts.authority, Some("localhost"));
+        assert_eq!(opts.vfs, None);
+    }
+
+    #[test]
+    fn test_windows_double_invalid() {
+        let uri = "file://C:/home/fred/data.db?mode=ro";
+        let opts = parse_sqlite_uri(uri);
+        assert!(opts.is_err());
+    }
+
+    #[test]
+    fn test_simple_file_two_slash() {
+        let uri = "file:///C:/Documents%20and%20Settings/fred/Desktop/data.db";
+        let opts = parse_sqlite_uri(uri).unwrap();
+        assert_eq!(opts.path, "/C:/Documents and Settings/fred/Desktop/data.db");
+        assert_eq!(opts.vfs, None);
     }
 }


### PR DESCRIPTION
closes #977 
In order to properly get #960 merged and keep some sort of the same API we have now, we need to support URIs/query parameters for opening new databases.

This PR doesn't attempt to implement anything useful with this, it only handles parsing, but it will allow #960 to properly open a new file with a specific VFS without having to entirely re-design the `open_file` method/API. The existing option in that PR right now is less than ideal.

e.g. All of the existing methods already accept an `IO` impl
```rust
    pub fn open_file(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
// or
      pub fn open(
        io: Arc<dyn IO>,
        page_io: Rc<dyn DatabaseStorage>,
        wal: Rc<RefCell<dyn Wal>>,
        shared_wal: Arc<RwLock<WalFileShared>>,
        buffer_pool: Rc<BufferPool>,
    ) -> Result<Arc<Database>> {

```

Right now, most of the parsed query parameters are not options we support yet, but I figured it's better to handle parsing them now and using them later on when we support them.

Also, if this looks way overly complicated for what it does... that's because the cross platform edge-cases are a super pain in the ass.