### PR TITLE
Adds AddImm OpCode Instruction

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -183,6 +183,18 @@ impl OwnedValue {
             OwnedValue::Blob(b) => out.extend_from_slice(b),
         };
     }
+
+    pub fn to_i64(&self) -> i64 {
+        match self {
+            Self::Integer(i) => *i,
+            Self::Float(f) => *f as i64,
+            Self::Text(t) => t.as_str().parse::<i64>().unwrap_or(0),
+            Self::Null => 0,
+            Self::Blob(_) => 0,
+            Self::Agg(ctx) => ctx.final_value().to_i64(),
+            Self::Record(_) => 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -198,6 +198,14 @@ impl ProgramBuilder {
         self.emit_insn(Insn::Goto { target_pc });
     }
 
+    #[allow(dead_code)]
+    pub fn emit_add_imm(&mut self, reg: usize, constant: i64) {
+        self.emit_insn(Insn::AddImm {
+            reg,
+            value: constant,
+        });
+    }
+
     pub fn add_comment(&mut self, insn_index: BranchOffset, comment: &'static str) {
         if let Some(comments) = &mut self.comments {
             comments.insert(insn_index.to_offset_int(), comment);

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1389,6 +1389,15 @@ pub fn insn_to_str(
                 0,
                 format!("auto_commit={}, rollback={}", auto_commit, rollback),
             ),
+            Insn::AddImm { reg, value } => (
+                "AddImm",
+                *value as i32,
+                *reg as i32,
+                0,
+                OwnedValue::build_text(""),
+                0,
+                format!("r[{}]=r[{}]+{}", reg, reg, value),
+            ),
         };
     format!(
         "{:<4}  {:<17}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -808,6 +808,11 @@ pub enum Insn {
         dest: usize,
         cookie: Cookie,
     },
+    /// Add the value in p2 to the value in p1 and then store back in p1
+    AddImm {
+        reg: usize,
+        value: i64,
+    },
 }
 
 impl Insn {


### PR DESCRIPTION
This PR:

* adds the AddImm opcode instruction

The instruction is required for https://github.com/tursodatabase/limbo/issues/895 which is tracking `ALTER TABLE` support.

See screenshot for relevant SQLite bytecode

<img width="671" alt="Screenshot 2025-02-19 at 10 12 16 PM" src="https://github.com/user-attachments/assets/31a0d667-f25a-4c2a-be01-d1c4ac524ad1" />
