### PR TITLE
Fix "unreachable code" in LIKE function for INT columns

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2137,6 +2137,19 @@ impl Program {
                                         )
                                             as i64)
                                     }
+                                    (OwnedValue::Text(pattern), OwnedValue::Integer(text)) => {
+                                        let cache = if *constant_mask > 0 {
+                                            Some(&mut state.regex_cache.like)
+                                        } else {
+                                            None
+                                        };
+                                        OwnedValue::Integer(exec_like(
+                                            cache,
+                                            &pattern.as_str(),
+                                            &text.to_string(),
+                                        )
+                                            as i64)
+                                    }
                                     _ => {
                                         unreachable!("Like on non-text registers");
                                     }


### PR DESCRIPTION
Fix [#1040](https://github.com/tursodatabase/limbo/issues/1040)

The `LIKE` function currently works on `TEXT` columns only and returns `internal error: entered unreachable code: Like on non-text registers` when the field being matched with the pattern is not `TEXT`.

I added support for matching `INTEGER` fields by converting them to strings using `to_string()`.
The examples mentioned in [#1040](https://github.com/tursodatabase/limbo/issues/1040) now produce the same results as SQLite:
```
Limbo v0.0.15
Enter ".help" for usage hints.
limbo> CREATE TABLE t1 (c1 INTEGER);
INSERT INTO t1 VALUES (1);
SELECT * FROM t1 WHERE c1 LIKE '';
limbo>
```
```
limbo> CREATE TABLE alluring_simons (rousing_veidaux INTEGER);
INSERT INTO alluring_simons VALUES ('-4750696213641675957'), ('-5458087213939326485'), (-3919859408639645563), ('5557375199733233444'), ('8012037637129400302');      
SELECT * FROM alluring_simons WHERE ((rousing_veidaux > '-3moocfczqdkdrhzfpjj' OR (rousing_veidaux = '-4750696213641675957' OR rousing_veidaux LIKE '%506%6213%6%75957' OR rousing_veidaux = '-4750696213641675957')) OR (rousing_veidaux != '-4750696213641675957' OR rousing_veidaux = '-8139761129027681166'));
-4750696213641675957
-5458087213939326485
-3919859408639645563
5557375199733233444
8012037637129400302
limbo>
```