### PR TITLE
Add support for `VALUES` statement

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod result_row;
 pub(crate) mod select;
 pub(crate) mod subquery;
 pub(crate) mod transaction;
+pub(crate) mod values;
 
 use crate::schema::Schema;
 use crate::storage::pager::Pager;

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -36,6 +36,7 @@ pub fn translate_select(
     });
 
     if let ast::OneSelect::Values(values) = &select.body.select.as_ref() {
+        program.alloc_registers(values[0].len() + 1);
         emit_values(&mut program, &values)?;
         return Ok(program);
     }

--- a/core/translate/values.rs
+++ b/core/translate/values.rs
@@ -1,0 +1,85 @@
+use crate::{
+    vdbe::{builder::ProgramBuilder, insn::Insn, BranchOffset},
+    LimboError, Result,
+};
+use limbo_sqlite3_parser::ast::{self, Literal};
+
+pub fn emit_values(program: &mut ProgramBuilder, values: &[Vec<ast::Expr>]) -> Result<()> {
+    let goto_target = program.allocate_label();
+    program.emit_insn(Insn::Init {
+        target_pc: goto_target,
+    });
+
+    let start_reg = 1;
+    let first_row_len = values[0].len();
+
+    for row in values {
+        if row.len() != first_row_len {
+            return Err(LimboError::ParseError(
+                "all VALUES rows must have the same number of values".into(),
+            ));
+        }
+
+        for (i, expr) in row.iter().enumerate() {
+            let reg = start_reg + i;
+
+            match expr {
+                ast::Expr::Literal(lit) => match lit {
+                    Literal::String(s) => {
+                        program.emit_insn(Insn::String8 {
+                            value: s.clone(),
+                            dest: reg,
+                        });
+                    }
+                    Literal::Numeric(num) => {
+                        if let Ok(int_val) = num.parse::<i64>() {
+                            program.emit_insn(Insn::Integer {
+                                value: int_val,
+                                dest: reg,
+                            });
+                        } else {
+                            let float_val = num.parse::<f64>()?;
+                            program.emit_insn(Insn::Real {
+                                value: float_val,
+                                dest: reg,
+                            });
+                        }
+                    }
+                    Literal::Null => {
+                        program.emit_insn(Insn::Null {
+                            dest: reg,
+                            dest_end: None,
+                        });
+                    }
+                    _ => {
+                        return Err(LimboError::ParseError(
+                            "unsupported literal type in VALUES".into(),
+                        ))
+                    }
+                },
+                _ => {
+                    return Err(LimboError::ParseError(
+                        "VALUES only supports literal values".into(),
+                    ))
+                }
+            }
+        }
+
+        program.emit_insn(Insn::ResultRow {
+            start_reg,
+            count: first_row_len,
+        });
+    }
+
+    program.emit_insn(Insn::Halt {
+        err_code: 0,
+        description: String::new(),
+    });
+
+    program.preassign_label_to_next_insn(goto_target);
+    program.emit_insn(Insn::Goto {
+        target_pc: BranchOffset::Offset(1),
+    });
+
+    Ok(())
+}

--- a/core/translate/values.rs
+++ b/core/translate/values.rs
@@ -1,8 +1,10 @@
 use crate::{
+    translate::expr::translate_expr,
+    translate::emitter::Resolver,
     vdbe::{builder::ProgramBuilder, insn::Insn, BranchOffset},
-    LimboError, Result,
+    LimboError, Result, SymbolTable,
 };
-use limbo_sqlite3_parser::ast::{self, Literal};
+use limbo_sqlite3_parser::ast;
 
 pub fn emit_values(program: &mut ProgramBuilder, values: &[Vec<ast::Expr>]) -> Result<()> {
     let goto_target = program.allocate_label();
@@ -10,165 +12,29 @@ pub fn emit_values(program: &mut ProgramBuilder, values: &[Vec<ast::Expr>]) -> R
         target_pc: goto_target,
     });
 
+    let start_offset = program.offset();
+
     let start_reg = 1;
     let first_row_len = values[0].len();
-    
-    let needs_binary_regs = values.iter().any(|row| {
-        row.iter().any(|expr| matches!(expr, ast::Expr::Binary(..)))
-    });
-    
-    let binary_regs = if needs_binary_regs { 2 } else { 0 };
-    let total_regs = start_reg + first_row_len + binary_regs;
+    let num_regs = start_reg + first_row_len;
 
-    for _ in 0..total_regs {
+    for _ in 0..num_regs {
         program.alloc_register();
     }
 
-    let temp_reg = start_reg + first_row_len;
+    let symbol_table = SymbolTable::new();
+    let resolver = Resolver::new(&symbol_table);
 
     for row in values {
         if row.len() != first_row_len {
             return Err(LimboError::ParseError(
-                "all VALUES rows must have the same number of values".into(),
+                "all VALUES rows must have the same number of values".into(),  
             ));
         }
 
         for (i, expr) in row.iter().enumerate() {
             let reg = start_reg + i;
-
-            match expr {
-                ast::Expr::Literal(lit) => match lit {
-                    Literal::String(s) => {
-                        let s = &s[1..s.len()-1];  
-                        let s = s.replace("''", "'");
-                        program.emit_insn(Insn::String8 {
-                            value: s,
-                            dest: reg,
-                        });
-                    }
-                    Literal::Numeric(num) => {
-                        if let Ok(int_val) = num.parse::<i64>() {
-                            program.emit_insn(Insn::Integer {
-                                value: int_val,
-                                dest: reg,
-                            });
-                        } else {
-                            let float_val = num.parse::<f64>()?;
-                            program.emit_insn(Insn::Real {
-                                value: float_val,
-                                dest: reg,
-                            });
-                        }
-                    }
-                    Literal::Null => {
-                        program.emit_insn(Insn::Null {
-                            dest: reg,
-                            dest_end: None,
-                        });
-                    }
-                    _ => {
-                        return Err(LimboError::ParseError(
-                            "unsupported literal type in VALUES".into(),
-                        ))
-                    }
-                },
-                ast::Expr::Unary(op, expr) => {
-                    match (&op, expr.as_ref()) {
-                        (_, ast::Expr::Literal(Literal::Null)) => {
-                            program.emit_insn(Insn::Null {
-                                dest: reg,
-                                dest_end: None,
-                            });
-                        },
-                        (ast::UnaryOperator::Negative | ast::UnaryOperator::Positive, ast::Expr::Literal(Literal::Numeric(numeric_value))) => {
-                            let multiplier = if let ast::UnaryOperator::Negative = op { -1 } else { 1 };
-                            
-                            if multiplier == -1 && numeric_value == "9223372036854775808" {
-                                program.emit_insn(Insn::Integer {
-                                    value: i64::MIN,
-                                    dest: reg,
-                                });
-                            } else {
-                                let maybe_int = numeric_value.parse::<i64>();
-                                if let Ok(value) = maybe_int {
-                                    program.emit_insn(Insn::Integer {
-                                        value: value * multiplier,
-                                        dest: reg,
-                                    });
-                                } else {
-                                    let value = numeric_value.parse::<f64>()?;
-                                    program.emit_insn(Insn::Real {
-                                        value: value * multiplier as f64,
-                                        dest: reg,
-                                    });
-                                }
-                            }
-                        },
-                        _ => {
-                            return Err(LimboError::ParseError(
-                                "VALUES only supports unary operations on NULL and numbers".into(),
-                            ))
-                        }
-                    }
-                },
-                ast::Expr::Binary(lhs, op, rhs) => {
-                    if !needs_binary_regs {
-                        return Err(LimboError::InternalError("binary operation found but no registers allocated".into()));
-                    }
-                    
-                    match (lhs.as_ref(), op, rhs.as_ref()) {
-                        (
-                            ast::Expr::Literal(Literal::Numeric(lhs)),
-                            ast::Operator::Divide,
-                            ast::Expr::Literal(Literal::Numeric(rhs))
-                        ) => {
-                            let lhs_reg = temp_reg;
-                            if let Ok(int_val) = lhs.parse::<i64>() {
-                                program.emit_insn(Insn::Integer {
-                                    value: int_val,
-                                    dest: lhs_reg, 
-                                });
-                            } else {
-                                let float_val = lhs.parse::<f64>()?;
-                                program.emit_insn(Insn::Real {
-                                    value: float_val,
-                                    dest: lhs_reg,
-                                });
-                            }
-
-                            let rhs_reg = temp_reg + 1;
-                            if let Ok(int_val) = rhs.parse::<i64>() {
-                                program.emit_insn(Insn::Integer {
-                                    value: int_val,
-                                    dest: rhs_reg,
-                                });
-                            } else {
-                                let float_val = rhs.parse::<f64>()?;
-                                program.emit_insn(Insn::Real {
-                                    value: float_val,
-                                    dest: rhs_reg,
-                                });
-                            }
-
-                            program.emit_insn(Insn::Divide {
-                                lhs: lhs_reg,
-                                rhs: rhs_reg, 
-                                dest: reg,
-                            });
-                        }
-                        _ => {
-                            return Err(LimboError::ParseError(
-                                "VALUES only supports division operations on numbers".into(),
-                            ))
-                        }
-                    }
-                },
-                _ => {
-                    return Err(LimboError::ParseError(
-                        "VALUES only supports literals, unary and basic arithmetic operations".into(),
-                    ))
-                }
-            }
+            translate_expr(program, None, expr, reg, &resolver)?;
         }
 
         program.emit_insn(Insn::ResultRow {
@@ -179,12 +45,16 @@ pub fn emit_values(program: &mut ProgramBuilder, values: &[Vec<ast::Expr>]) -> R
 
     program.emit_insn(Insn::Halt {
         err_code: 0,
-        description: String::new(),
+        description: String::new(), 
     });
 
-    program.preassign_label_to_next_insn(goto_target);
+    program.resolve_label(goto_target, program.offset());
+    program.emit_insn(Insn::Transaction { write: false });
+
+    program.emit_constant_insns();
+
     program.emit_insn(Insn::Goto {
-        target_pc: BranchOffset::Offset(1),
+        target_pc: start_offset,
     });
 
     Ok(())

--- a/core/translate/values.rs
+++ b/core/translate/values.rs
@@ -1,6 +1,6 @@
 use crate::{
-    translate::expr::translate_expr,
     translate::emitter::Resolver,
+    translate::expr::translate_expr,
     vdbe::{builder::ProgramBuilder, insn::Insn, BranchOffset},
     LimboError, Result, SymbolTable,
 };
@@ -28,7 +28,7 @@ pub fn emit_values(program: &mut ProgramBuilder, values: &[Vec<ast::Expr>]) -> R
     for row in values {
         if row.len() != first_row_len {
             return Err(LimboError::ParseError(
-                "all VALUES rows must have the same number of values".into(),  
+                "all VALUES rows must have the same number of values".into(),
             ));
         }
 
@@ -45,7 +45,7 @@ pub fn emit_values(program: &mut ProgramBuilder, values: &[Vec<ast::Expr>]) -> R
 
     program.emit_insn(Insn::Halt {
         err_code: 0,
-        description: String::new(), 
+        description: String::new(),
     });
 
     program.resolve_label(goto_target, program.offset());

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -913,4 +913,41 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    pub fn values_statement_edge_cases() {
+        let db = TempDatabase::new_empty();
+        let limbo_conn = db.connect_limbo();
+        let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+    
+        let test_cases = vec![
+            "VALUES (NULL)",
+            "VALUES (1), (2), (3)",
+            "VALUES (1, 2, 3)",
+            "VALUES ('hello', 1, NULL)",
+            "VALUES (1.5, -2.5, 0.0)",
+            "VALUES (9223372036854775807)",
+            "VALUES (-9223372036854775808)",
+            "VALUES (1, 'text with spaces', NULL)",
+            "VALUES (''), ('a'), ('ab')",
+            "VALUES (NULL, NULL), (1, 2)",
+            "VALUES (1), (2), (NULL), (4)",
+            "VALUES (1.0, 2.0), (3.0, 4.0)",
+            "VALUES (-1, -2), (-3, -4)",
+            "VALUES (1), (NULL), ('text')",
+        ];
+    
+        for query in test_cases {
+            println!("query: {:?}", query);
+            log::info!("Testing query: {}", query);
+            let limbo = limbo_exec_rows(&db, &limbo_conn, query);
+            let sqlite = sqlite_exec_rows(&sqlite_conn, query);
+            
+            assert_eq!(
+                limbo, sqlite,
+                "query: {}, limbo: {:?}, sqlite: {:?}",
+                query, limbo, sqlite
+            );
+        }
+    }
 }

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -920,6 +920,7 @@ mod tests {
         let limbo_conn = db.connect_limbo();
         let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
     
+        // Test edge cases and specific scenarios 
         let test_cases = vec![
             "VALUES (NULL)",
             "VALUES (1), (2), (3)",
@@ -927,7 +928,7 @@ mod tests {
             "VALUES ('hello', 1, NULL)",
             "VALUES (1.5, -2.5, 0.0)",
             "VALUES (9223372036854775807)",
-            "VALUES (-9223372036854775808)",
+            "VALUES (-9223372036854775808)",  
             "VALUES (1, 'text with spaces', NULL)",
             "VALUES (''), ('a'), ('ab')",
             "VALUES (NULL, NULL), (1, 2)",
@@ -935,10 +936,23 @@ mod tests {
             "VALUES (1.0, 2.0), (3.0, 4.0)",
             "VALUES (-1, -2), (-3, -4)",
             "VALUES (1), (NULL), ('text')",
+            "VALUES (0.0), (-0.0), (1.0/0.0)",
+            "VALUES ('text''with''quotes')",
+            "VALUES ('Monty Python and the Holy Grail', 1975, 8.2)",
+            "VALUES ('And Now for Something Completely Different', 1971, 7.5)",
+            // Unary ops tests
+            "VALUES (-1)", 
+            "VALUES (+1)",
+            "VALUES (+9223372036854775807)",
+            "VALUES (-1.7976931348623157e308)",
+            "VALUES (+1.7976931348623157e308)",
+            "VALUES (-0)",
+            "VALUES (+0)",
+            "VALUES (-NULL)",
+            "VALUES (-(1))",
         ];
     
         for query in test_cases {
-            println!("query: {:?}", query);
             log::info!("Testing query: {}", query);
             let limbo = limbo_exec_rows(&db, &limbo_conn, query);
             let sqlite = sqlite_exec_rows(&sqlite_conn, query);

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -915,6 +915,92 @@ mod tests {
     }
 
     #[test]
+    pub fn values_expression_fuzz_run() {
+        let _ = env_logger::try_init();
+        let g = GrammarGenerator::new();
+    
+        let (expr, expr_builder) = g.create_handle();
+        let (values_row, values_row_builder) = g.create_handle();
+        let (values_list, values_list_builder) = g.create_handle();
+        let (literal, literal_builder) = g.create_handle();
+        let (number, number_builder) = g.create_handle();
+        let (string, string_builder) = g.create_handle();
+    
+        number_builder
+            .choice()
+            .option_symbol(rand_int(-5..10))
+            .option_symbol(rand_int(-1000..1000))
+            .option_symbol(rand_int(-100000..100000))
+            .option_str("NULL")
+            .build();
+    
+        string_builder
+            .concat("")
+            .push_str("'")  // Open quote
+            .push_symbol(rand_str("abc123", 10))
+            .push_str("'")  // Close quote
+            .build();
+    
+        literal_builder
+            .choice()
+            .option(number)
+            .option(string) 
+            .option_str("NULL")
+            .option_str("1.5")
+            .option_str("-2.5")
+            .option_str("0.0")
+            .build();
+    
+        let fixed_columns = g.create()
+            .concat("")
+            .push(literal)
+            .push_str(", ")
+            .push(literal)
+            .push_str(", ")
+            .push(literal)
+            .build();
+    
+        values_row_builder
+            .concat("")
+            .push_str("(")
+            .push(fixed_columns)
+            .push_str(")")
+            .build();
+    
+        values_list_builder
+            .concat("")
+            .push(g.create().concat("").push(values_row).repeat(1..10, ", ").build())
+            .build();
+    
+        expr_builder
+            .concat("")
+            .push_str("VALUES ")
+            .push(values_list)
+            .build();
+    
+        let db = TempDatabase::new_empty();
+        let limbo_conn = db.connect_limbo();
+        let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+    
+        let (mut rng, seed) = rng_from_time();
+        log::info!("seed: {}", seed);
+    
+        for i in 0..1024 {
+            let query = g.generate(&mut rng, expr, 50);
+            log::info!("Query {} of 0..1024: {}", i, query);
+    
+            let limbo = limbo_exec_rows(&db, &limbo_conn, &query);
+            let sqlite = sqlite_exec_rows(&sqlite_conn, &query);
+    
+            assert_eq!(
+                limbo, sqlite,
+                "Query: {}\nLimbo result: {:?}\nSQLite result: {:?}",
+                query, limbo, sqlite
+            );
+        }
+    }
+
+    #[test]
     pub fn values_statement_edge_cases() {
         let db = TempDatabase::new_empty();
         let limbo_conn = db.connect_limbo();


### PR DESCRIPTION
Current: 

```
limbo> VALUES
('Monty Python and the Holy Grail', 1975, 8.2),
('And Now for Something Completely Different', 1971, 7.5);
thread 'main' panicked at core/translate/select.rs:336:14:
not yet implemented
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After this PR:

```
Limbo v0.0.15
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database
limbo> VALUES
('Monty Python and the Holy Grail', 1975, 8.2),
('And Now for Something Completely Different', 1971, 7.5);
Monty Python and the Holy Grail|1975|8.2
And Now for Something Completely Different|1971|7.5
```

```
limbo> SELECT * FROM (VALUES (1, 2, 'VALUES'));
1|2|VALUES
```

Fixes: https://github.com/tursodatabase/limbo/issues/866