### PR TITLE
Initial pass at extending typesystem to extension modules

### DIFF
--- a/core/ext/extern_types.rs
+++ b/core/ext/extern_types.rs
@@ -1,0 +1,93 @@
+use limbo_ext::CustomTypeImpl;
+
+use crate::types::{OwnedValue, OwnedValueType};
+use std::{ffi::CString, fmt::Display, rc::Rc};
+
+/// Because we don't want to add additional opcodes, types that are
+/// defined in extensions will operate internally as functions.
+#[derive(Clone, Debug)]
+pub struct TsFunc {
+    pub ext_type: Rc<ExternType>,
+    pub op: TsFuncOp,
+}
+
+impl TsFunc {
+    pub fn new(ext_type: Rc<ExternType>, op: TsFuncOp) -> Self {
+        Self { ext_type, op }
+    }
+}
+
+impl Display for TsFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kind = match self.op {
+            TsFuncOp::Generate => "generate",
+        };
+        write!(f, "{}: {}", self.ext_type.name, kind)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TsFuncOp {
+    Generate,
+    // TODO
+}
+
+#[derive(Default)]
+pub struct TypeRegistry(Vec<(String, Rc<ExternType>)>);
+impl TypeRegistry {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn register(&mut self, name: &str, ctx: *const CustomTypeImpl, _type: OwnedValueType) {
+        self.0
+            .push((name.to_string(), ExternType::new(name, ctx, _type).into()));
+    }
+
+    pub fn get(&self, name: &str) -> Option<Rc<ExternType>> {
+        self.0
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, t)| t.clone())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ExternType {
+    pub name: String,
+    ctx: Box<CustomTypeImpl>,
+    _type: OwnedValueType,
+}
+
+impl ExternType {
+    pub fn new(name: &str, ctx: *const CustomTypeImpl, type_of: OwnedValueType) -> Self {
+        Self {
+            name: name.to_string(),
+            ctx: unsafe { Box::from_raw(ctx as *mut CustomTypeImpl) },
+            _type: type_of,
+        }
+    }
+
+    pub fn type_of(&self) -> OwnedValueType {
+        self._type
+    }
+
+    pub fn generate(
+        &self,
+        column_name: Option<&str>,
+        insert_val: Option<OwnedValue>,
+    ) -> crate::Result<OwnedValue> {
+        let ctx = &*self.ctx as *const limbo_ext::CustomTypeImpl;
+        let col = if let Ok(col_name_cstr) = CString::new(column_name.unwrap_or("")) {
+            col_name_cstr
+        } else {
+            CString::new("").unwrap()
+        };
+        let val = insert_val.unwrap_or(OwnedValue::Null).to_ffi();
+        let value = unsafe { ((*ctx).generate)(col.as_ptr(), &val as *const limbo_ext::Value) };
+        unsafe {
+            val.free();
+        }
+        OwnedValue::from_ffi(value)
+    }
+}

--- a/core/ext/foreign_types.rs
+++ b/core/ext/foreign_types.rs
@@ -89,7 +89,7 @@ impl ForeignType {
         let val = insert_val.unwrap_or(OwnedValue::Null).to_ffi();
         let value = unsafe { ((*ctx).generate)(col.as_ptr(), &val as *const limbo_ext::Value) };
         unsafe {
-            val.free();
+            val.__free_internal_type();
         }
         OwnedValue::from_ffi(value)
     }

--- a/core/ext/foreign_types.rs
+++ b/core/ext/foreign_types.rs
@@ -15,7 +15,7 @@ impl ForeignTypeFunc {
     pub fn new_generate(ext_type: Rc<ForeignType>) -> Self {
         Self {
             ext_type,
-            op: ForeignTypeOp::Generate,
+            op: ForeignTypeOp::OnInsertHook,
         }
     }
 }
@@ -23,7 +23,7 @@ impl ForeignTypeFunc {
 impl Display for ForeignTypeFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let kind = match self.op {
-            ForeignTypeOp::Generate => "generate",
+            ForeignTypeOp::OnInsertHook => "on_insert",
         };
         write!(f, "{}: {}", self.ext_type.name, kind)
     }
@@ -31,8 +31,8 @@ impl Display for ForeignTypeFunc {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ForeignTypeOp {
-    Generate,
-    // TODO
+    OnInsertHook,
+    // TODO: Sorting, comparison
 }
 
 #[derive(Default)]
@@ -87,7 +87,7 @@ impl ForeignType {
             CString::new("").unwrap()
         };
         let val = insert_val.unwrap_or(OwnedValue::Null).to_ffi();
-        let value = unsafe { ((*ctx).generate)(col.as_ptr(), &val as *const limbo_ext::Value) };
+        let value = unsafe { ((*ctx).on_insert)(col.as_ptr(), &val as *const limbo_ext::Value) };
         unsafe {
             val.__free_internal_type();
         }

--- a/core/ext/foreign_types.rs
+++ b/core/ext/foreign_types.rs
@@ -6,34 +6,37 @@ use std::{ffi::CString, fmt::Display, rc::Rc};
 /// Because we don't want to add additional opcodes, types that are
 /// defined in extensions will operate internally as functions.
 #[derive(Clone, Debug)]
-pub struct TsFunc {
-    pub ext_type: Rc<ExternType>,
-    pub op: TsFuncOp,
+pub struct ForeignTypeFunc {
+    pub ext_type: Rc<ForeignType>,
+    pub op: ForeignTypeOp,
 }
 
-impl TsFunc {
-    pub fn new(ext_type: Rc<ExternType>, op: TsFuncOp) -> Self {
-        Self { ext_type, op }
+impl ForeignTypeFunc {
+    pub fn new_generate(ext_type: Rc<ForeignType>) -> Self {
+        Self {
+            ext_type,
+            op: ForeignTypeOp::Generate,
+        }
     }
 }
 
-impl Display for TsFunc {
+impl Display for ForeignTypeFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let kind = match self.op {
-            TsFuncOp::Generate => "generate",
+            ForeignTypeOp::Generate => "generate",
         };
         write!(f, "{}: {}", self.ext_type.name, kind)
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum TsFuncOp {
+pub enum ForeignTypeOp {
     Generate,
     // TODO
 }
 
 #[derive(Default)]
-pub struct TypeRegistry(Vec<(String, Rc<ExternType>)>);
+pub struct TypeRegistry(Vec<(String, Rc<ForeignType>)>);
 impl TypeRegistry {
     pub fn new() -> Self {
         Self(Vec::new())
@@ -41,10 +44,10 @@ impl TypeRegistry {
 
     pub fn register(&mut self, name: &str, ctx: *const CustomTypeImpl, _type: OwnedValueType) {
         self.0
-            .push((name.to_string(), ExternType::new(name, ctx, _type).into()));
+            .push((name.to_string(), ForeignType::new(name, ctx, _type).into()));
     }
 
-    pub fn get(&self, name: &str) -> Option<Rc<ExternType>> {
+    pub fn get(&self, name: &str) -> Option<Rc<ForeignType>> {
         self.0
             .iter()
             .find(|(n, _)| n.eq_ignore_ascii_case(name))
@@ -53,13 +56,13 @@ impl TypeRegistry {
 }
 
 #[derive(Clone, Debug)]
-pub struct ExternType {
+pub struct ForeignType {
     pub name: String,
     ctx: Box<CustomTypeImpl>,
     _type: OwnedValueType,
 }
 
-impl ExternType {
+impl ForeignType {
     pub fn new(name: &str, ctx: *const CustomTypeImpl, type_of: OwnedValueType) -> Self {
         Self {
             name: name.to_string(),

--- a/core/ext/foreign_types.rs
+++ b/core/ext/foreign_types.rs
@@ -12,7 +12,7 @@ pub struct ForeignTypeFunc {
 }
 
 impl ForeignTypeFunc {
-    pub fn new_generate(ext_type: Rc<ForeignType>) -> Self {
+    pub fn new_insert_hook(ext_type: Rc<ForeignType>) -> Self {
         Self {
             ext_type,
             op: ForeignTypeOp::OnInsertHook,
@@ -75,7 +75,7 @@ impl ForeignType {
         self._type
     }
 
-    pub fn generate(
+    pub fn on_insert(
         &self,
         column_name: Option<&str>,
         insert_val: Option<OwnedValue>,

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -134,6 +134,7 @@ pub fn add_builtin_vfs_extensions(
             register_aggregate_function,
             register_vfs,
             register_module,
+            register_custom_type,
             builtin_vfs: vfslist.as_mut_ptr(),
             builtin_vfs_count: 0,
         },

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -272,14 +272,10 @@ impl Connection {
             register_scalar_function,
             register_aggregate_function,
             register_module,
-<<<<<<< HEAD
             register_vfs,
             builtin_vfs: std::ptr::null_mut(),
             builtin_vfs_count: 0,
-||||||| parent of 6b73c198 (Add custom type registration to extension api)
-=======
             register_custom_type,
->>>>>>> 6b73c198 (Add custom type registration to extension api)
         }
     }
 

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -93,15 +93,15 @@ unsafe extern "C" fn register_module(
     conn.register_module_impl(&name_str, module, kind)
 }
 
-unsafe extern "C" fn register_extension_type(
+unsafe extern "C" fn register_custom_type(
     ctx: *mut c_void,
     module: *const CustomTypeImpl,
 ) -> ResultCode {
     if ctx.is_null() {
         return ResultCode::Error;
     }
-    let db = unsafe { &mut *(ctx as *mut Connection) };
-    db.register_extension_type_impl(module)
+    let conn = unsafe { &mut *(ctx as *mut Connection) };
+    conn.register_custom_type_impl(module)
 }
 
 #[allow(clippy::arc_with_non_send_sync)]
@@ -246,7 +246,7 @@ impl Connection {
         ResultCode::OK
     }
 
-    fn register_extension_type_impl(&mut self, type_impl: *const CustomTypeImpl) -> ResultCode {
+    fn register_custom_type_impl(&mut self, type_impl: *const CustomTypeImpl) -> ResultCode {
         let name = unsafe { CStr::from_ptr((*type_impl).name) }
             .to_str()
             .unwrap_or_default();
@@ -272,9 +272,14 @@ impl Connection {
             register_scalar_function,
             register_aggregate_function,
             register_module,
+<<<<<<< HEAD
             register_vfs,
             builtin_vfs: std::ptr::null_mut(),
             builtin_vfs_count: 0,
+||||||| parent of 6b73c198 (Add custom type registration to extension api)
+=======
+            register_custom_type,
+>>>>>>> 6b73c198 (Add custom type registration to extension api)
         }
     }
 

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -4,6 +4,7 @@ mod dynamic;
 use crate::UringIO;
 use crate::IO;
 use crate::{function::ExternalFunc, Connection, Database, LimboError};
+pub mod foreign_types;
 use limbo_ext::{
     ExtensionApi, InitAggFunction, ResultCode, ScalarFunction, VTabKind, VTabModuleImpl, VfsImpl,
 };

--- a/core/function.rs
+++ b/core/function.rs
@@ -1,3 +1,4 @@
+use crate::ext::foreign_types::ForeignTypeFunc;
 use crate::LimboError;
 use limbo_ext::{FinalizeFunction, InitAggFunction, ScalarFunction, StepFunction};
 use std::fmt;
@@ -433,6 +434,7 @@ pub enum Func {
     #[cfg(feature = "json")]
     Json(JsonFunc),
     External(Rc<ExternalFunc>),
+    ForeignType(ForeignTypeFunc),
 }
 
 impl Display for Func {
@@ -445,6 +447,7 @@ impl Display for Func {
             #[cfg(feature = "json")]
             Self::Json(json_func) => write!(f, "{}", json_func),
             Self::External(generic_func) => write!(f, "{}", generic_func),
+            Self::ForeignType(ts) => write!(f, "{}", ts),
         }
     }
 }

--- a/core/function.rs
+++ b/core/function.rs
@@ -1,9 +1,8 @@
+use crate::LimboError;
 use limbo_ext::{FinalizeFunction, InitAggFunction, ScalarFunction, StepFunction};
 use std::fmt;
 use std::fmt::{Debug, Display};
 use std::rc::Rc;
-
-use crate::LimboError;
 
 pub struct ExternalFunc {
     pub name: String,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -652,7 +652,7 @@ impl VirtualTable {
         if let ast::Cmd::Stmt(ast::Stmt::CreateTable { body, .. }) = parser.next()?.ok_or(
             LimboError::ParseError("Failed to parse schema from virtual table module".to_string()),
         )? {
-            let columns = columns_from_create_table_body(&body)?;
+            let columns = columns_from_create_table_body(&body, syms)?;
             let vtab = Rc::new(VirtualTable {
                 name: tbl_name.unwrap_or(module_name).to_owned(),
                 implementation: module.implementation.clone(),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -24,6 +24,7 @@ mod vector;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+use ext::foreign_types::TypeRegistry;
 use ext::list_vfs_modules;
 use fallible_iterator::FallibleIterator;
 use fast_lock::SpinLock;
@@ -740,6 +741,7 @@ pub(crate) struct SymbolTable {
     pub functions: HashMap<String, Rc<function::ExternalFunc>>,
     pub vtabs: HashMap<String, Rc<VirtualTable>>,
     pub vtab_modules: HashMap<String, Rc<crate::ext::VTabImpl>>,
+    pub type_registry: TypeRegistry,
 }
 
 impl std::fmt::Debug for SymbolTable {
@@ -783,6 +785,7 @@ impl SymbolTable {
             functions: HashMap::new(),
             vtabs: HashMap::new(),
             vtab_modules: HashMap::new(),
+            type_registry: TypeRegistry::new(),
         }
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,5 +1,4 @@
-use crate::VirtualTable;
-use crate::{util::normalize_ident, Result};
+use crate::{util::normalize_ident, Result, VirtualTable};
 use core::fmt;
 use fallible_iterator::FallibleIterator;
 use limbo_sqlite3_parser::ast::{Expr, Literal, TableOptions};

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -858,6 +858,9 @@ pub fn translate_expr(
                 Func::Agg(_) => {
                     crate::bail_parse_error!("aggregation function in non-aggregation context")
                 }
+                Func::ForeignType(_) => {
+                    unreachable!("ForeignType functions are used internally")
+                }
                 Func::External(_) => {
                     let regs = program.alloc_registers(args_count);
                     if let Some(args) = args {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -498,7 +498,7 @@ fn handle_inserted_external_value(
     // call the generate function
     program.emit_insn(Insn::Function {
         func: FuncCtx {
-            func: Func::ForeignType(ForeignTypeFunc::new_generate(ext_type.clone())),
+            func: Func::ForeignType(ForeignTypeFunc::new_insert_hook(ext_type.clone())),
             arg_count: 2,
         },
         dest: target_reg,

--- a/core/types.rs
+++ b/core/types.rs
@@ -21,6 +21,30 @@ pub enum OwnedValueType {
     Error,
 }
 
+impl From<ExtValueType> for OwnedValueType {
+    fn from(val: ExtValueType) -> Self {
+        match val {
+            ExtValueType::Integer => Self::Integer,
+            ExtValueType::Float => Self::Float,
+            ExtValueType::Blob => Self::Blob,
+            ExtValueType::Text => Self::Text,
+            _ => Self::Null,
+        }
+    }
+}
+
+impl Into<crate::schema::Type> for OwnedValueType {
+    fn into(self) -> crate::schema::Type {
+        match self {
+            OwnedValueType::Integer => crate::schema::Type::Integer,
+            OwnedValueType::Float => crate::schema::Type::Real,
+            OwnedValueType::Blob => crate::schema::Type::Blob,
+            OwnedValueType::Text => crate::schema::Type::Text,
+            _ => crate::schema::Type::Null,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum TextSubtype {
     Text,

--- a/core/util.rs
+++ b/core/util.rs
@@ -328,9 +328,11 @@ pub fn exprs_are_equivalent(expr1: &Expr, expr2: &Expr) -> bool {
     }
 }
 
-pub fn columns_from_create_table_body(body: &ast::CreateTableBody) -> crate::Result<Vec<Column>> {
+pub fn columns_from_create_table_body(
+    body: ast::CreateTableBody,
+) -> Result<Vec<Column>, LimboError> {
     let CreateTableBody::ColumnsAndConstraints { columns, .. } = body else {
-        return Err(crate::LimboError::ParseError(
+        return Err(LimboError::ParseError(
             "CREATE TABLE body must contain columns and constraints".to_string(),
         ));
     };

--- a/core/util.rs
+++ b/core/util.rs
@@ -329,7 +329,7 @@ pub fn exprs_are_equivalent(expr1: &Expr, expr2: &Expr) -> bool {
 }
 
 pub fn columns_from_create_table_body(
-    body: ast::CreateTableBody,
+    body: &ast::CreateTableBody,
 ) -> Result<Vec<Column>, LimboError> {
     let CreateTableBody::ColumnsAndConstraints { columns, .. } = body else {
         return Err(LimboError::ParseError(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -24,7 +24,7 @@ pub mod likeop;
 pub mod sorter;
 
 use crate::error::{LimboError, SQLITE_CONSTRAINT_PRIMARYKEY};
-use crate::ext::ExtValue;
+use crate::ext::{foreign_types::ForeignTypeOp, ExtValue};
 use crate::fast_lock::SpinLock;
 use crate::function::{AggFunc, ExtFunc, FuncCtx, MathFunc, MathFuncArity, ScalarFunc, VectorFunc};
 use crate::functions::datetime::{

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2726,6 +2726,19 @@ impl Program {
                             }
                             _ => unreachable!("aggregate called in scalar context"),
                         },
+                        crate::function::Func::ForeignType(ts) => match ts.op {
+                            ForeignTypeOp::Generate => {
+                                let col_name = state.registers[*start_reg].to_text();
+                                let insert_val = &state.registers[*start_reg + 1];
+                                let insert_val = if let OwnedValue::Null = insert_val {
+                                    None
+                                } else {
+                                    Some(insert_val)
+                                };
+                                let result = ts.ext_type.generate(col_name, insert_val.cloned())?;
+                                state.registers[*dest] = result;
+                            }
+                        },
                         crate::function::Func::Math(math_func) => match math_func.arity() {
                             MathFuncArity::Nullary => match math_func {
                                 MathFunc::Pi => {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2727,7 +2727,7 @@ impl Program {
                             _ => unreachable!("aggregate called in scalar context"),
                         },
                         crate::function::Func::ForeignType(ts) => match ts.op {
-                            ForeignTypeOp::Generate => {
+                            ForeignTypeOp::OnInsertHook => {
                                 let col_name = state.registers[*start_reg].to_text();
                                 let insert_val = &state.registers[*start_reg + 1];
                                 let insert_val = if let OwnedValue::Null = insert_val {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2735,7 +2735,8 @@ impl Program {
                                 } else {
                                     Some(insert_val)
                                 };
-                                let result = ts.ext_type.generate(col_name, insert_val.cloned())?;
+                                let result =
+                                    ts.ext_type.on_insert(col_name, insert_val.cloned())?;
                                 state.registers[*dest] = result;
                             }
                         },

--- a/extensions/core/README.md
+++ b/extensions/core/README.md
@@ -11,6 +11,8 @@ like traditional `sqlite3` extensions, but are able to be written in much more e
  - [ x ] **Aggregate Functions**: Define aggregate functions with `AggregateDerive` macro and `AggFunc` trait.
  - [ x ]  **Virtual tables**: Create a module for a virtual table with the `VTabModuleDerive` macro and `VTabCursor` trait.
  - [ x ] **VFS Modules**: Extend Limbo's OS interface by implementing `VfsExtension` and `VfsFile` traits.
+ - [] **Custom Types**: Create a custom type alias to define columns and handle insert behavior.
+
 ---
 
 ## Installation

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -21,6 +21,7 @@ pub struct ExtensionApi {
     pub register_aggregate_function: RegisterAggFn,
     pub register_module: RegisterModuleFn,
     pub register_vfs: RegisterVfsFn,
+    pub register_custom_type: RegisterCustomTypeFn,
     pub builtin_vfs: *mut *const VfsImpl,
     pub builtin_vfs_count: i32,
 }

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -201,7 +201,7 @@ pub struct CustomTypeImpl {
 pub trait CustomType: Default + Sized {
     const NAME: &'static str;
     const TYPE: ValueType;
-    fn generate(col_name: Option<&str>, insert_val: Option<&Value>) -> Value;
+    fn generate(col_name: Option<&str>, insert_val: &Value) -> Value;
 }
 
 pub type CustomTypeGenerateFn =

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -2,7 +2,9 @@ mod types;
 mod vfs_modules;
 #[cfg(not(target_family = "wasm"))]
 pub use limbo_macros::VfsDerive;
-pub use limbo_macros::{register_extension, scalar, AggregateDerive, VTabModuleDerive};
+pub use limbo_macros::{
+    register_extension, scalar, AggregateDerive, CustomTypeDerive, VTabModuleDerive,
+};
 use std::{
     ffi::{c_char, c_void},
     fmt::Display,

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -195,14 +195,14 @@ pub trait VTabCursor: Sized {
 pub struct CustomTypeImpl {
     pub name: *const c_char,
     pub type_of: ValueType,
-    pub generate: CustomTypeGenerateFn,
+    pub on_insert: CustomTypeOnInsertFn,
 }
 
 pub trait CustomType: Default + Sized {
     const NAME: &'static str;
     const TYPE: ValueType;
-    fn generate(col_name: Option<&str>, insert_val: &Value) -> Value;
+    fn on_insert(col_name: Option<&str>, insert_val: Option<&Value>) -> Value;
 }
 
-pub type CustomTypeGenerateFn =
+pub type CustomTypeOnInsertFn =
     unsafe extern "C" fn(col_name: *const c_char, insert_val: *const Value) -> Value;

--- a/extensions/core/src/types.rs
+++ b/extensions/core/src/types.rs
@@ -249,6 +249,10 @@ impl Value {
         }
     }
 
+    pub fn is_null(&self) -> bool {
+        self.value_type == ValueType::Null
+    }
+
     /// Returns the value type of the Value
     pub fn value_type(&self) -> ValueType {
         self.value_type

--- a/extensions/uuid/src/lib.rs
+++ b/extensions/uuid/src/lib.rs
@@ -144,14 +144,18 @@ impl CustomType for UUID {
     const NAME: &'static str = "UUID";
     const TYPE: ValueType = ValueType::Text;
 
-    fn generate(_col_name: Option<&str>, insert_val: Option<&Value>) -> Value {
+    fn generate(_col_name: Option<&str>, insert_val: &Value) -> Value {
         // if value inserted is a unix timestamp, store a uuidv7. otherwise store a uuidv4
-        if let Some(val) = insert_val {
-            let maybe_ts = val.to_integer().unwrap_or(0);
-            let ctx = uuid::ContextV7::new();
-            let ts = uuid::Timestamp::from_unix(ctx, maybe_ts as u64, 0);
-            return Value::from_text(uuid::Uuid::new_v7(ts).to_string());
+        if let Some(val) = insert_val.to_integer() {
+            if val > 0 {
+                let ctx = uuid::ContextV7::new();
+                let ts = uuid::Timestamp::from_unix(ctx, val as u64, 0);
+                Value::from_text(uuid::Uuid::new_v7(ts).to_string())
+            } else {
+                Value::from_text(uuid::Uuid::new_v4().to_string())
+            }
+        } else {
+            Value::from_text(uuid::Uuid::new_v4().to_string())
         }
-        Value::from_text(uuid::Uuid::new_v4().to_string())
     }
 }

--- a/extensions/uuid/src/lib.rs
+++ b/extensions/uuid/src/lib.rs
@@ -1,7 +1,7 @@
 use limbo_ext::{register_extension, scalar, ResultCode, Value, ValueType};
 
 register_extension! {
-    scalars: {uuid4_str, uuid4_blob, uuid7_str, uuid7, uuid7_ts, uuid_str, uuid_blob },
+    scalars: {uuid4_str, uuid4_blob, uuid7_str, uuid7, uuid7_ts, uuid_str, uuid_blob }
 }
 
 #[scalar(name = "uuid4_str", alias = "gen_random_uuid")]

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -8,6 +8,7 @@ pub(crate) struct RegisterExtensionInput {
     pub scalars: Vec<Ident>,
     pub vtabs: Vec<Ident>,
     pub vfs: Vec<Ident>,
+    pub types: Vec<Ident>,
 }
 
 impl syn::parse::Parse for RegisterExtensionInput {
@@ -16,11 +17,12 @@ impl syn::parse::Parse for RegisterExtensionInput {
         let mut scalars = Vec::new();
         let mut vtabs = Vec::new();
         let mut vfs = Vec::new();
+        let mut types = Vec::new();
         while !input.is_empty() {
             if input.peek(syn::Ident) && input.peek2(Token![:]) {
                 let section_name: Ident = input.parse()?;
                 input.parse::<Token![:]>()?;
-                let names = ["aggregates", "scalars", "vtabs", "vfs"];
+                let names = ["aggregates", "scalars", "vtabs", "vfs", "types"];
                 if names.contains(&section_name.to_string().as_str()) {
                     let content;
                     syn::braced!(content in input);
@@ -33,7 +35,10 @@ impl syn::parse::Parse for RegisterExtensionInput {
                         "scalars" => scalars = parsed_items,
                         "vtabs" => vtabs = parsed_items,
                         "vfs" => vfs = parsed_items,
-                        _ => unreachable!(),
+                        "types" => types = parsed_items,
+                        _ => {
+                            return Err(syn::Error::new(section_name.span(), "Invalid section"));
+                        }
                     };
 
                     if input.peek(Token![,]) {
@@ -43,7 +48,8 @@ impl syn::parse::Parse for RegisterExtensionInput {
                     return Err(syn::Error::new(section_name.span(), "Unknown section"));
                 }
             } else {
-                return Err(input.error("Expected aggregates:, scalars:, or vtabs: section"));
+                return Err(input
+                    .error("Expected 'aggregates:', 'scalars:', 'types:', or 'vtabs:' section"));
             }
         }
 
@@ -52,6 +58,7 @@ impl syn::parse::Parse for RegisterExtensionInput {
             scalars,
             vtabs,
             vfs,
+            types,
         })
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -874,7 +874,7 @@ pub fn derive_type(input: TokenStream) -> TokenStream {
                 type_of: Self::TYPE,
                 generate: Self::#generate_fn_name,
             }));
-            (api.register_extension_type)(api.ctx, module as *const ::limbo_ext::CustomTypeImpl)
+            (api.register_custom_type)(api.ctx, module as *const ::limbo_ext::CustomTypeImpl)
         }
       }
     };

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -857,7 +857,11 @@ pub fn derive_type(input: TokenStream) -> TokenStream {
             } else {
                 ::std::ffi::CStr::from_ptr(col_name as *mut i8).to_str().map_or(None, |s| Some(s))
             };
-            let val = if insert_val.is_null() { None } else { Some(&*insert_val) };
+            let val = if insert_val.is_null() {
+                &::limbo_ext::Value::null()
+            } else {
+                 &*(insert_val)
+            };
             <#struct_name as ::limbo_ext::CustomType>::generate(col_name, val)
         }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -879,6 +879,7 @@ pub fn register_extension(input: TokenStream) -> TokenStream {
         scalars,
         vtabs,
         vfs,
+        types,
     } = input_ast;
 
     let scalar_calls = scalars.iter().map(|scalar_ident| {

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -75,16 +75,20 @@ def test_uuid():
     limbo.run_test_fn(
         "SELECT uuid7_timestamp_ms(id) / 1000 from users where name = 'next';",
         validate_ts,
-    )
-    limbo.execute_dot("CREATE TABLE users2 (id uuid, name TEXT);")
-    limbo.execute_dot("INSERT INTO users2 (name) values ('test');")
-    limbo.execute_dot("INSERT INTO users2 (name) values ('next');")
-    limbo.run_test_fn(
-        "SELECT id from users2 where name = 'next';", validate_string_uuid
+        "unixepoch() inserted to ID column",
     )
     limbo.run_test_fn(
-        "SELECT uuid7_timestamp_ms(id) / 1000 from users2 where name = 'next';",
-        validate_ts,
+        "INSERT INTO users (id, name) values (1740853356, 'testing');", null
+    )
+    limbo.run_test_fn(
+        "SELECT id from users where name = 'testing';",
+        validate_string_uuid,
+        "correct uuid was inserted to ID field",
+    )
+    limbo.run_test_fn(
+        "SELECT uuid7_timestamp_ms(id) / 1000 from users where name = 'testing';",
+        lambda x: x == "1740853356",
+        "correct uuid was inserted to ID field when unix timestamp was inserted to ID column",
     )
     limbo.quit()
 


### PR DESCRIPTION
This PR implements the beginnings of extending our typesytem (type alias's, not new serial/encodings relevant to storage).

Trying to diverge from my normal PR's of 1k+ lines here, so I'm making this as minimal as possible.

I figured we didn't want to add any new/different opcodes for these types, so internally they are just a function call op.

That function is called with the column name and the inserted value, and that can validate, generate default values, or transform the value to be inserted. 


```console
imbo> create table t (id uuid, name text);
limbo> explain insert into t (name) values ('limbo');
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     11    0                    0   Start at 11
1     OpenWriteAsync     0     2     0                    0
2     OpenWriteAwait     0     0     0                    0
3     Null               0     6     0                    0   r[6]=NULL
4     Function           0     5     2     UUID: on_insert  0   r[2]=func(r[5..6])
5     String8            0     3     0     limbo          0   r[3]='limbo'
6     NewRowId           0     1     0                    0
7     MakeRecord         2     2     4                    0   r[4]=mkrec(r[2..3])
8     InsertAsync        0     4     1                    0
9     InsertAwait        0     0     0                    0
10    Halt               0     0     0                    0
11    Transaction        0     1     0                    0   write=true
12    String8            0     5     0     id             0   r[5]='id'
13    Goto               0     1     0                    0
```


Example:

```console
limbo> create table test (id uuid, name text);
limbo> insert into test (name) values ('limbo');
limbo> select * from test;
0195a97d-9f96-7911-8b77-f4fa9fdb5aca|limbo
```