### PR TITLE
Clean up extension types API, introduce json text subtype

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc = { version = "0.1", default-features = false }
 libloading = "0.8.6"
 
 [dependencies]
-limbo_ext = { workspace = true }
+limbo_ext = { workspace = true, features = ["core_only"] }
 cfg_block = "0.1.1"
 fallible-iterator = "0.3.0"
 hex = "0.4.3"

--- a/core/types.rs
+++ b/core/types.rs
@@ -203,9 +203,7 @@ impl OwnedValue {
                 }
             }
         };
-        unsafe {
-            v.free();
-        }
+        unsafe { v.__free_internal_type() };
         res
     }
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -185,7 +185,11 @@ impl OwnedValue {
                 let Some(text) = v.to_text() else {
                     return Ok(OwnedValue::Null);
                 };
-                Ok(OwnedValue::build_text(text))
+                if v.is_json() {
+                    Ok(OwnedValue::Text(Text::json(text)))
+                } else {
+                    Ok(OwnedValue::build_text(text))
+                }
             }
             ExtValueType::Blob => {
                 let Some(blob) = v.to_blob() else {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1863,7 +1863,7 @@ impl Program {
                                 let argv_ptr = ext_values.as_ptr();
                                 unsafe { step_fn(state_ptr, argc as i32, argv_ptr) };
                                 for ext_value in ext_values {
-                                    unsafe { ext_value.free() };
+                                    unsafe { ext_value.__free_internal_type() };
                                 }
                             }
                         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -190,9 +190,6 @@ macro_rules! call_external_function {
             }
             let argv_ptr = ext_values.as_ptr();
             let result_c_value: ExtValue = unsafe { ($func_ptr)($arg_count as i32, argv_ptr) };
-            for arg in ext_values {
-                unsafe { arg.free() };
-            }
             match OwnedValue::from_ffi(result_c_value) {
                 Ok(result_ov) => {
                     $state.registers[$dest_register] = result_ov;

--- a/extensions/core/Cargo.toml
+++ b/extensions/core/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Limbo extensions core"
 
 [features]
-default = []
+core_only = []
 static = []
 
 [dependencies]

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -73,6 +73,7 @@ pub struct VTabModuleImpl {
     pub rowid: VtabRowIDFn,
 }
 
+#[cfg(feature = "core_only")]
 impl VTabModuleImpl {
     pub fn init_schema(&self, args: Vec<Value>) -> ExtResult<String> {
         let schema = unsafe { (self.create_schema)(args.as_ptr(), args.len() as i32) };
@@ -80,7 +81,7 @@ impl VTabModuleImpl {
             return Err(ResultCode::InvalidArgs);
         }
         for arg in args {
-            unsafe { arg.free() };
+            unsafe { arg.__free_internal_type() };
         }
         let schema = unsafe { std::ffi::CString::from_raw(schema) };
         Ok(schema.to_string_lossy().to_string())

--- a/extensions/core/src/types.rs
+++ b/extensions/core/src/types.rs
@@ -390,12 +390,7 @@ impl Value {
         }
     }
 
-    /// Extension authors should __not__ use this function.
-    /// Extensions should _not_ use this method directly. When used properly,
-    /// core will own all Value types and they should not need to be manually free'd
-    /// in any extension code. However, if you are arbitrarily creating `Value` types
-    /// that do not follow the intended control flow/API of the exposed traits, and are
-    /// not returned to `core`, your extension _will_ leak the underlying memory.
+    /// Extension authors should __not__ use this function, or enable the 'core_only' feature
     ///
     /// # Safety
     /// consumes the value while freeing the underlying memory with null check.

--- a/extensions/core/src/types.rs
+++ b/extensions/core/src/types.rs
@@ -154,20 +154,12 @@ impl TextValue {
         }
     }
 
-    fn new_json(text: *const u8, len: usize) -> Self {
-        Self {
-            _type: TextSubtype::Json,
-            text,
-            len: len as u32,
-        }
-    }
-
-    fn new_boxed(s: String) -> Box<Self> {
+    fn new_boxed(s: String, sub: TextSubtype) -> Box<Self> {
         let len = s.len();
         let buffer = s.into_boxed_str();
         let strbox = Box::into_raw(buffer);
         Box::new(Self {
-            _type: TextSubtype::Text,
+            _type: sub,
             text: strbox as *const u8,
             len: len as u32,
         })
@@ -396,7 +388,16 @@ impl Value {
 
     /// Creates a new text Value from a String
     pub fn from_text(s: String) -> Self {
-        let txt_value = TextValue::new_boxed(s);
+        let txt_value = TextValue::new_boxed(s, TextSubtype::Text);
+        let ptr = Box::into_raw(txt_value);
+        Self {
+            value_type: ValueType::Text,
+            value: ValueData { text: ptr },
+        }
+    }
+
+    pub fn from_json(s: String) -> Self {
+        let txt_value = TextValue::new_boxed(s, TextSubtype::Json);
         let ptr = Box::into_raw(txt_value);
         Self {
             value_type: ValueType::Text,

--- a/extensions/uuid/src/lib.rs
+++ b/extensions/uuid/src/lib.rs
@@ -89,7 +89,7 @@ fn uuid7_ts(args: &[Value]) -> Value {
             let Some(text) = args[0].to_text() else {
                 return Value::null();
             };
-            let Ok(uuid) = uuid::Uuid::parse_str(&text) else {
+            let Ok(uuid) = uuid::Uuid::parse_str(text) else {
                 return Value::null();
             };
             let unix = uuid_to_unix(uuid.as_bytes());
@@ -118,7 +118,7 @@ fn uuid_blob(&self, args: &[Value]) -> Value {
     let Some(text) = args[0].to_text() else {
         return Value::null();
     };
-    match uuid::Uuid::parse_str(&text) {
+    match uuid::Uuid::parse_str(text) {
         Ok(uuid) => Value::from_blob(uuid.as_bytes().to_vec()),
         Err(_) => Value::null(),
     }


### PR DESCRIPTION
This PR cleans up some comments in the extension API and prevents extensions themselves from calling 'free' on Value types that are exposed to the user facing traits, as well as changes the `from_ffi` method for OwnedValues to take ownership and automatically free the values to prevent memory leaks.

This PR also finds the name of the `args: &[Value]` argument for scalar functions in extensions, and uses that in the proc macro, instead of relying on documentation to communicate that the parameter must be named `args`.  