### PR TITLE
remove lifetimes from JsonPath

### DIFF
--- a/core/json/json_path.rs
+++ b/core/json/json_path.rs
@@ -1,5 +1,5 @@
 use crate::bail_parse_error;
-use std::borrow::Cow;
+use std::ops::Range;
 
 #[derive(Clone, Debug, PartialEq)]
 enum PPState {
@@ -20,19 +20,43 @@ enum ArrayIndexState {
 
 /// Describes a JSON path, which is a sequence of keys and/or array locators.
 #[derive(Clone, Debug)]
-pub struct JsonPath<'a> {
-    pub elements: Vec<PathElement<'a>>,
+pub struct JsonPath {
+    elements: Vec<PathElement>,
+    path: String,
+}
+
+impl JsonPath {
+    pub fn new(path: String, elements: Vec<PathElement>) -> Self {
+        Self { elements, path }
+    }
+
+    pub fn elements(&self) -> &Vec<PathElement> {
+        self.elements.as_ref()
+    }
+
+    pub fn path(&self) -> &str {
+        self.path.as_str()
+    }
+}
+
+impl Default for JsonPath {
+    fn default() -> Self {
+        Self {
+            elements: vec![PathElement::Root()],
+            path: "$".to_string(),
+        }
+    }
 }
 
 type RawString = bool;
 
 /// PathElement describes a single element of a JSON path.
 #[derive(Clone, Debug, PartialEq)]
-pub enum PathElement<'a> {
+pub enum PathElement {
     /// Root element: '$'
     Root(),
     /// JSON key
-    Key(Cow<'a, str>, RawString),
+    Key(Range<usize>, RawString),
     /// Array locator, eg. [2], [#-5]
     ArrayLocator(Option<i32>),
 }
@@ -60,7 +84,7 @@ fn estimate_path_capacity(input: &str) -> usize {
 }
 
 /// Parses path into a Vec of Strings, where each string is a key or an array locator.
-pub fn json_path(path: &str) -> crate::Result<JsonPath<'_>> {
+pub fn json_path(path: &str) -> crate::Result<JsonPath> {
     if path.is_empty() {
         bail_parse_error!("Bad json path: {}", path)
     }
@@ -70,6 +94,9 @@ pub fn json_path(path: &str) -> crate::Result<JsonPath<'_>> {
     let mut index_buffer: i128 = 0;
     let mut path_components = Vec::with_capacity(estimate_path_capacity(path));
     let mut path_iter = path.char_indices();
+
+    let mut j_path = JsonPath::default();
+    j_path.path = path.to_string();
 
     while let Some(ch) = path_iter.next() {
         match parser_state {
@@ -123,9 +150,8 @@ pub fn json_path(path: &str) -> crate::Result<JsonPath<'_>> {
     }
 
     finalize_path(parser_state, key_start, path, &mut path_components)?;
-    Ok(JsonPath {
-        elements: path_components,
-    })
+    j_path.elements = path_components;
+    Ok(j_path)
 }
 
 fn handle_start(
@@ -174,7 +200,7 @@ fn handle_in_key<'a>(
     index_state: &mut ArrayIndexState,
     key_start: &mut usize,
     index_buffer: &mut i128,
-    path_components: &mut Vec<PathElement<'a>>,
+    path_components: &mut Vec<PathElement>,
     path_iter: &mut std::str::CharIndices,
     path: &'a str,
 ) -> crate::Result<()> {
@@ -182,7 +208,7 @@ fn handle_in_key<'a>(
         (idx, '.' | '[') => {
             let key_end = idx;
             if key_end > *key_start {
-                let key = &path[*key_start..key_end];
+                let range = *key_start..key_end;
                 if ch.1 == '[' {
                     *index_state = ArrayIndexState::Start;
                     *parser_state = PPState::InArrayIndex;
@@ -190,13 +216,13 @@ fn handle_in_key<'a>(
                 } else {
                     *key_start = idx + ch.1.len_utf8();
                 }
-                path_components.push(PathElement::Key(Cow::Borrowed(key), false));
+                path_components.push(PathElement::Key(range, false));
             } else {
                 bail_parse_error!("Bad json path: {}", path)
             }
         }
         (_, '"') => {
-            handle_quoted_key(parser_state, key_start, path_components, path_iter, path)?;
+            handle_quoted_key(parser_state, key_start, path_components, path_iter)?;
         }
         (_, _) => (),
     }
@@ -206,9 +232,8 @@ fn handle_in_key<'a>(
 fn handle_quoted_key<'a>(
     parser_state: &mut PPState,
     key_start: &mut usize,
-    path_components: &mut Vec<PathElement<'a>>,
+    path_components: &mut Vec<PathElement>,
     path_iter: &mut std::str::CharIndices,
-    path: &'a str,
 ) -> crate::Result<()> {
     while let Some((idx, ch)) = path_iter.next() {
         match ch {
@@ -217,8 +242,7 @@ fn handle_quoted_key<'a>(
             }
             '"' => {
                 if *key_start < idx {
-                    let key = &path[*key_start + 1..idx];
-                    path_components.push(PathElement::Key(Cow::Borrowed(key), true));
+                    path_components.push(PathElement::Key(*key_start + 1..idx, true));
                     *parser_state = PPState::ExpectDotOrBracket;
                     return Ok(());
                 }
@@ -234,7 +258,7 @@ fn handle_array_index(
     parser_state: &mut PPState,
     index_state: &mut ArrayIndexState,
     index_buffer: &mut i128,
-    path_components: &mut Vec<PathElement<'_>>,
+    path_components: &mut Vec<PathElement>,
     path_iter: &mut std::str::CharIndices,
     path: &str,
 ) -> crate::Result<()> {
@@ -321,7 +345,7 @@ fn finalize_path<'a>(
     parser_state: PPState,
     key_start: usize,
     path: &'a str,
-    path_components: &mut Vec<PathElement<'a>>,
+    path_components: &mut Vec<PathElement>,
 ) -> crate::Result<()> {
     match parser_state {
         PPState::InArrayIndex => bail_parse_error!("Bad json path: {}", path),
@@ -331,7 +355,7 @@ fn finalize_path<'a>(
                 if key.starts_with('"') & !key.ends_with('"') {
                     bail_parse_error!("Bad json path: {}", path)
                 }
-                path_components.push(PathElement::Key(Cow::Borrowed(key), false));
+                path_components.push(PathElement::Key(key_start..path.len(), false));
             } else {
                 bail_parse_error!("Bad json path: {}", path)
             }
@@ -357,10 +381,7 @@ mod tests {
         let path = json_path("$.x").unwrap();
         assert_eq!(path.elements.len(), 2);
         assert_eq!(path.elements[0], PathElement::Root());
-        assert_eq!(
-            path.elements[1],
-            PathElement::Key(Cow::Borrowed("x"), false)
-        );
+        assert_eq!(path.elements[1], PathElement::Key(2..3, false));
     }
 
     #[test]
@@ -402,19 +423,10 @@ mod tests {
         let path = json_path("$.store.book[0].title").unwrap();
         assert_eq!(path.elements.len(), 5);
         assert_eq!(path.elements[0], PathElement::Root());
-        assert_eq!(
-            path.elements[1],
-            PathElement::Key(Cow::Borrowed("store"), false)
-        );
-        assert_eq!(
-            path.elements[2],
-            PathElement::Key(Cow::Borrowed("book"), false)
-        );
+        assert_eq!(path.elements[1], PathElement::Key(2..7, false));
+        assert_eq!(path.elements[2], PathElement::Key(8..12, false));
         assert_eq!(path.elements[3], PathElement::ArrayLocator(Some(0)));
-        assert_eq!(
-            path.elements[4],
-            PathElement::Key(Cow::Borrowed("title"), false)
-        );
+        assert_eq!(path.elements[4], PathElement::Key(16..21, false));
     }
 
     #[test]
@@ -434,10 +446,7 @@ mod tests {
         assert_eq!(path.elements[1], PathElement::ArrayLocator(Some(0)));
         assert_eq!(path.elements[2], PathElement::ArrayLocator(Some(1)));
         assert_eq!(path.elements[3], PathElement::ArrayLocator(Some(2)));
-        assert_eq!(
-            path.elements[4],
-            PathElement::Key(Cow::Borrowed("key"), false)
-        );
+        assert_eq!(path.elements[4], PathElement::Key(11..14, false));
         assert_eq!(path.elements[5], PathElement::ArrayLocator(Some(3)));
     }
 
@@ -470,22 +479,13 @@ mod tests {
     #[test]
     fn test_quoted_keys() {
         let path = json_path(r#"$."key""#).unwrap();
-        assert_eq!(
-            path.elements[1],
-            PathElement::Key(Cow::Borrowed("key"), true)
-        );
+        assert_eq!(path.elements[1], PathElement::Key(3..6, true));
 
         let path = json_path(r#"$."key.with.dots""#).unwrap();
-        assert_eq!(
-            path.elements[1],
-            PathElement::Key(Cow::Borrowed("key.with.dots"), true)
-        );
+        assert_eq!(path.elements[1], PathElement::Key(3..16, true));
 
         let path = json_path(r#"$."key[0]""#).unwrap();
-        assert_eq!(
-            path.elements[1],
-            PathElement::Key(Cow::Borrowed("key[0]"), true)
-        );
+        assert_eq!(path.elements[1], PathElement::Key(3..9, true));
     }
 
     #[test]

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -15,7 +15,6 @@ use indexmap::IndexMap;
 use jsonb::Error as JsonbError;
 use ser::to_string_pretty;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(untagged)]
@@ -387,13 +386,14 @@ fn json_extract_single<'a>(
 
     let mut current_element = &Val::Null;
 
-    for element in json_path.elements.iter() {
+    for element in json_path.elements().iter() {
         match element {
             PathElement::Root() => {
                 current_element = json;
             }
-            PathElement::Key(key, _) => match current_element {
+            PathElement::Key(key_range, _) => match current_element {
                 Val::Object(map) => {
+                    let key = &json_path.path()[key_range.start..key_range.end];
                     if let Some((_, value)) = map.iter().find(|(k, _)| k == key) {
                         current_element = value;
                     } else {
@@ -437,27 +437,33 @@ fn json_path_from_owned_value(path: &OwnedValue, strict: bool) -> crate::Result<
                 if t.as_str().starts_with("$") {
                     json_path(t.as_str())?
                 } else {
-                    JsonPath {
-                        elements: vec![
-                            PathElement::Root(),
-                            PathElement::Key(Cow::Borrowed(t.as_str()), false),
-                        ],
-                    }
+                    let path = format!("$.{}", t.as_str());
+                    let len = path.len();
+                    JsonPath::new(
+                        path,
+                        vec![PathElement::Root(), PathElement::Key(2..len, false)],
+                    )
                 }
             }
             OwnedValue::Null => return Ok(None),
-            OwnedValue::Integer(i) => JsonPath {
-                elements: vec![
-                    PathElement::Root(),
-                    PathElement::ArrayLocator(Some(*i as i32)),
-                ],
-            },
-            OwnedValue::Float(f) => JsonPath {
-                elements: vec![
-                    PathElement::Root(),
-                    PathElement::Key(Cow::Owned(f.to_string()), false),
-                ],
-            },
+            OwnedValue::Integer(i) => {
+                let path = format!("$.[{}]", *i as i32);
+                JsonPath::new(
+                    path,
+                    vec![
+                        PathElement::Root(),
+                        PathElement::ArrayLocator(Some(*i as i32)),
+                    ],
+                )
+            }
+            OwnedValue::Float(f) => {
+                let path = format!("$.{}", f.to_string());
+                let len = path.len();
+                JsonPath::new(
+                    path,
+                    vec![PathElement::Root(), PathElement::Key(2..len, false)],
+                )
+            }
             _ => crate::bail_constraint_error!("JSON path error near: {:?}", path.to_string()),
         }
     };
@@ -479,8 +485,8 @@ where
 
 fn find_target<'a>(json: &'a mut Val, path: &JsonPath) -> Option<Target<'a>> {
     let mut current = json;
-    for (i, key) in path.elements.iter().enumerate() {
-        let is_last = i == path.elements.len() - 1;
+    for (i, key) in path.elements().iter().enumerate() {
+        let is_last = i == path.elements().len() - 1;
         match key {
             PathElement::Root() => continue,
             PathElement::ArrayLocator(index) => match current {
@@ -503,22 +509,25 @@ fn find_target<'a>(json: &'a mut Val, path: &JsonPath) -> Option<Target<'a>> {
                     return None;
                 }
             },
-            PathElement::Key(key, _) => match current {
-                Val::Object(obj) => {
-                    if let Some(pos) = &obj
-                        .iter()
-                        .position(|(k, v)| k == key && !matches!(v, Val::Removed))
-                    {
-                        let val = &mut obj[*pos].1;
-                        current = val;
-                    } else {
+            PathElement::Key(key_range, _) => {
+                let key = &path.path()[key_range.start..key_range.end];
+                match current {
+                    Val::Object(obj) => {
+                        if let Some(pos) = &obj
+                            .iter()
+                            .position(|(k, v)| k == key && !matches!(v, Val::Removed))
+                        {
+                            let val = &mut obj[*pos].1;
+                            current = val;
+                        } else {
+                            return None;
+                        }
+                    }
+                    _ => {
                         return None;
                     }
                 }
-                _ => {
-                    return None;
-                }
-            },
+            }
         }
     }
     Some(Target::Value(current))
@@ -533,8 +542,8 @@ where
 
 fn find_or_create_target<'a>(json: &'a mut Val, path: &JsonPath) -> Option<Target<'a>> {
     let mut current = json;
-    for (i, key) in path.elements.iter().enumerate() {
-        let is_last = i == path.elements.len() - 1;
+    for (i, key) in path.elements().iter().enumerate() {
+        let is_last = i == path.elements().len() - 1;
         match key {
             PathElement::Root() => continue,
             PathElement::ArrayLocator(index) => match current {
@@ -557,8 +566,10 @@ fn find_or_create_target<'a>(json: &'a mut Val, path: &JsonPath) -> Option<Targe
                         } else {
                             if index == arr.len() {
                                 arr.push(
-                                    if matches!(path.elements[i + 1], PathElement::ArrayLocator(_))
-                                    {
+                                    if matches!(
+                                        path.elements()[i + 1],
+                                        PathElement::ArrayLocator(_)
+                                    ) {
                                         Val::Array(vec![])
                                     } else {
                                         Val::Object(vec![])
@@ -580,32 +591,34 @@ fn find_or_create_target<'a>(json: &'a mut Val, path: &JsonPath) -> Option<Targe
                     *current = Val::Array(vec![]);
                 }
             },
-            PathElement::Key(key, _) => match current {
-                Val::Object(obj) => {
-                    if let Some(pos) = &obj
-                        .iter()
-                        .position(|(k, v)| k == key && !matches!(v, Val::Removed))
-                    {
-                        let val = &mut obj[*pos].1;
-                        current = val;
-                    } else {
-                        let element = if !is_last
-                            && matches!(path.elements[i + 1], PathElement::ArrayLocator(_))
+            PathElement::Key(key_range, _) => {
+                let key = &path.path()[key_range.start..key_range.end];
+                match current {
+                    Val::Object(obj) => {
+                        if let Some(pos) = &obj
+                            .iter()
+                            .position(|(k, v)| k == key && !matches!(v, Val::Removed))
                         {
-                            Val::Array(vec![])
+                            let val = &mut obj[*pos].1;
+                            current = val;
                         } else {
-                            Val::Object(vec![])
-                        };
-
-                        obj.push((key.to_string(), element));
-                        let index = obj.len() - 1;
-                        current = &mut obj[index].1;
+                            let element = if !is_last
+                                && matches!(path.elements()[i + 1], PathElement::ArrayLocator(_))
+                            {
+                                Val::Array(vec![])
+                            } else {
+                                Val::Object(vec![])
+                            };
+                            obj.push((key.to_string(), element));
+                            let index = obj.len() - 1;
+                            current = &mut obj[index].1;
+                        }
+                    }
+                    _ => {
+                        return None;
                     }
                 }
-                _ => {
-                    return None;
-                }
-            },
+            }
         }
     }
     Some(Target::Value(current))
@@ -1226,9 +1239,7 @@ mod tests {
             Val::String("first".to_string()),
             Val::String("second".to_string()),
         ]);
-        let path = JsonPath {
-            elements: vec![PathElement::ArrayLocator(Some(0))],
-        };
+        let path = JsonPath::new("[0]".to_string(), vec![PathElement::ArrayLocator(Some(0))]);
 
         match find_target(&mut val, &path) {
             Some(Target::Array(_, idx)) => assert_eq!(idx, 0),
@@ -1242,9 +1253,7 @@ mod tests {
             Val::String("first".to_string()),
             Val::String("second".to_string()),
         ]);
-        let path = JsonPath {
-            elements: vec![PathElement::ArrayLocator(Some(-1))],
-        };
+        let path = JsonPath::new("[-1]".to_string(), vec![PathElement::ArrayLocator(Some(1))]);
 
         match find_target(&mut val, &path) {
             Some(Target::Array(_, idx)) => assert_eq!(idx, 1),
@@ -1255,9 +1264,7 @@ mod tests {
     #[test]
     fn test_find_target_object() {
         let mut val = Val::Object(vec![("key".to_string(), Val::String("value".to_string()))]);
-        let path = JsonPath {
-            elements: vec![PathElement::Key(Cow::Borrowed("key"), false)],
-        };
+        let path = JsonPath::new("key".to_string(), vec![PathElement::Key(0..3, false)]);
 
         match find_target(&mut val, &path) {
             Some(Target::Value(_)) => {}
@@ -1271,9 +1278,7 @@ mod tests {
             ("key".to_string(), Val::Removed),
             ("key".to_string(), Val::String("value".to_string())),
         ]);
-        let path = JsonPath {
-            elements: vec![PathElement::Key(Cow::Borrowed("key"), false)],
-        };
+        let path = JsonPath::new("key".to_string(), vec![PathElement::Key(0..3, false)]);
 
         match find_target(&mut val, &path) {
             Some(Target::Value(val)) => assert!(matches!(val, Val::String(_))),
@@ -1284,9 +1289,7 @@ mod tests {
     #[test]
     fn test_mutate_json() {
         let mut val = Val::Array(vec![Val::String("test".to_string())]);
-        let path = JsonPath {
-            elements: vec![PathElement::ArrayLocator(Some(0))],
-        };
+        let path = JsonPath::new("[0]".to_string(), vec![PathElement::ArrayLocator(Some(0))]);
 
         let result = mutate_json_by_path(&mut val, path, |target| match target {
             Target::Array(arr, idx) => {
@@ -1303,9 +1306,7 @@ mod tests {
     #[test]
     fn test_mutate_json_none() {
         let mut val = Val::Array(vec![]);
-        let path = JsonPath {
-            elements: vec![PathElement::ArrayLocator(Some(0))],
-        };
+        let path = JsonPath::new("[0]".to_string(), vec![PathElement::ArrayLocator(Some(0))]);
 
         let result: Option<()> = mutate_json_by_path(&mut val, path, |_| {
             panic!("Should not be called");
@@ -1325,7 +1326,7 @@ mod tests {
         assert!(result.is_some());
 
         let result = result.unwrap();
-        match result.elements[..] {
+        match result.elements()[..] {
             [PathElement::Root()] => {}
             _ => panic!("Expected root"),
         }
@@ -1342,7 +1343,7 @@ mod tests {
         assert!(result.is_some());
 
         let result = result.unwrap();
-        match result.elements[..] {
+        match result.elements()[..] {
             [PathElement::Root()] => {}
             _ => panic!("Expected root"),
         }
@@ -1366,8 +1367,9 @@ mod tests {
         assert!(result.is_some());
 
         let result = result.unwrap();
-        match &result.elements[..] {
-            [PathElement::Root(), PathElement::Key(field, false)] if *field == "field" => {}
+        match &result.elements()[..] {
+            [PathElement::Root(), PathElement::Key(key_range, false)]
+                if &result.path()[key_range.start..key_range.end] == "field" => {}
             _ => panic!("Expected root and field"),
         }
     }
@@ -1389,7 +1391,7 @@ mod tests {
         assert!(result.is_some());
 
         let result = result.unwrap();
-        match &result.elements[..] {
+        match &result.elements()[..] {
             [PathElement::Root(), PathElement::ArrayLocator(index)] if *index == Some(3) => {}
             _ => panic!("Expected root and array locator"),
         }
@@ -1435,8 +1437,9 @@ mod tests {
         assert!(result.is_some());
 
         let result = result.unwrap();
-        match &result.elements[..] {
-            [PathElement::Root(), PathElement::Key(field, false)] if *field == "1.23" => {}
+        match &result.elements()[..] {
+            [PathElement::Root(), PathElement::Key(key_range, false)]
+                if &result.path()[key_range.start..key_range.end] == "1.23" => {}
             _ => panic!("Expected root and field"),
         }
     }

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -457,7 +457,7 @@ fn json_path_from_owned_value(path: &OwnedValue, strict: bool) -> crate::Result<
                 )
             }
             OwnedValue::Float(f) => {
-                let path = format!("$.{}", f.to_string());
+                let path = format!("$.{}", f);
                 let len = path.len();
                 JsonPath::new(
                     path,


### PR DESCRIPTION
Currently, I am implementing` json_each` and `json_tree` vtab functions, and I want to use the already existing `json_path` code to be consistent with the rest of the path related functionality. However, our current implementation of `JsonPath` relies on the use of lifetimes, as it stores slices of `&str` to avoid copying string values from the original path. This works great, but in the context of Virtual Tables the current trait interface does not allow the use of lifetimes. 

For that reason, I reworked a bit how json_path works. Instead of storing `Cow<'a, str>` as the Key in the `PathElements`, it now stores the `Range<usize>` of where the path should be indexed to get the Key we want. In essence, we delay the indexing of the path when we need it in other functions by doing something like this:

```rust
PathElement::Key(key_range, _) => 
    let key = &json_path.path()[key_range.start..key_range.end];
                   
```

With this change, I also made some adjustments so that the path string lives together with the `JsonPath` struct and to the visibility of internal member of the struct. 