### PR TITLE
Minor improvements and cleanups in btree

### DIFF
--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -19,3 +19,10 @@ pub(crate) mod pager;
 pub(crate) mod sqlite3_ondisk;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod wal;
+
+#[macro_export]
+macro_rules! return_corrupt {
+    ($msg:expr) => {
+        return Err(LimboError::Corrupt($msg.into()));
+    };
+}

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1116,7 +1116,7 @@ impl Program {
                                 cursors,
                                 "Column"
                             );
-                            let record = cursor.record()?;
+                            let record = cursor.record();
                             if let Some(record) = record.as_ref() {
                                 state.registers[*dest] = if cursor.get_null_flag() {
                                     OwnedValue::Null
@@ -1517,7 +1517,7 @@ impl Program {
                     let cursor = get_cursor_as_index_mut(&mut cursors, *cursor_id);
                     let record_from_regs: Record =
                         make_owned_record(&state.registers, start_reg, num_regs);
-                    if let Some(ref idx_record) = *cursor.record()? {
+                    if let Some(ref idx_record) = *cursor.record() {
                         // Compare against the same number of values
                         if idx_record.get_values()[..record_from_regs.len()]
                             >= record_from_regs.get_values()[..]
@@ -1541,7 +1541,7 @@ impl Program {
                     let cursor = get_cursor_as_index_mut(&mut cursors, *cursor_id);
                     let record_from_regs: Record =
                         make_owned_record(&state.registers, start_reg, num_regs);
-                    if let Some(ref idx_record) = *cursor.record()? {
+                    if let Some(ref idx_record) = *cursor.record() {
                         // Compare against the same number of values
                         if idx_record.get_values()[..record_from_regs.len()]
                             <= record_from_regs.get_values()[..]
@@ -1565,7 +1565,7 @@ impl Program {
                     let cursor = get_cursor_as_index_mut(&mut cursors, *cursor_id);
                     let record_from_regs: Record =
                         make_owned_record(&state.registers, start_reg, num_regs);
-                    if let Some(ref idx_record) = *cursor.record()? {
+                    if let Some(ref idx_record) = *cursor.record() {
                         // Compare against the same number of values
                         if idx_record.get_values()[..record_from_regs.len()]
                             > record_from_regs.get_values()[..]
@@ -1589,7 +1589,7 @@ impl Program {
                     let cursor = get_cursor_as_index_mut(&mut cursors, *cursor_id);
                     let record_from_regs: Record =
                         make_owned_record(&state.registers, start_reg, num_regs);
-                    if let Some(ref idx_record) = *cursor.record()? {
+                    if let Some(ref idx_record) = *cursor.record() {
                         // Compare against the same number of values
                         if idx_record.get_values()[..record_from_regs.len()]
                             < record_from_regs.get_values()[..]


### PR DESCRIPTION
This PR does the following:

1. Replaces a couple `RefCell`'s on the cursor and page stack with `Cell` since the types implement `Copy`

2. Adds a `return_corrupt!` macro to handle the frequent error

3. Removed `Result` return type from cursor `record` method

4. Removed a couple clones and very minor refactoring (a few clippy suggestions)