### PR TITLE
Add sqlean ipaddr extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1625,7 @@ dependencies = [
  "libloading",
  "limbo_crypto",
  "limbo_ext",
+ "limbo_ipaddr",
  "limbo_macros",
  "limbo_percentile",
  "limbo_regexp",
@@ -1668,6 +1675,15 @@ name = "limbo_ext"
 version = "0.0.15"
 dependencies = [
  "limbo_macros",
+]
+
+[[package]]
+name = "limbo_ipaddr"
+version = "0.0.15"
+dependencies = [
+ "ipnetwork",
+ "limbo_ext",
+ "mimalloc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ limbo_series = { path = "extensions/series", version = "0.0.15" }
 limbo_time = { path = "extensions/time", version = "0.0.15" }
 limbo_uuid = { path = "extensions/uuid", version = "0.0.15" }
 limbo_sqlite3_parser = { path = "vendored/sqlite3-parser", version = "0.0.15" }
-
+limbo_ipaddr = { path = "extensions/ipaddr", version = "0.0.15" }
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -38,3 +38,9 @@ This product depends on serde_json5, distributed
 
 * License: licenses/core/serde_json5-license.md (Apache License v2.0)
 * Homepage: https://github.com/google/serde_json5
+
+This project depends on ipnetwork, distributed by the ipnetwork project:
+
+* License: licenses/extensions/ipnetwork-apache-license.md (Apache License v2.0)
+* License: licenses/extensions/ipnetwork-mit-license.md (MIT License)
+* Homepage: https://github.com/achanda/ipnetwork

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,6 +24,7 @@ regexp = ["limbo_regexp/static"]
 time = ["limbo_time/static"]
 crypto = ["limbo_crypto/static"]
 series = ["limbo_series/static"]
+ipaddr = ["limbo_ipaddr/static"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.6.1", optional = true }
@@ -62,6 +63,7 @@ limbo_percentile = { workspace = true, optional = true, features = ["static"] }
 limbo_time = { workspace = true, optional = true, features = ["static"] }
 limbo_crypto = { workspace = true, optional = true, features = ["static"] }
 limbo_series = { workspace = true, optional = true, features = ["static"] }
+limbo_ipaddr = { workspace = true, optional = true, features = ["static"] }
 miette = "7.4.0"
 strum = "0.26"
 parking_lot = "0.12.3"

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -150,6 +150,10 @@ impl Database {
         if unsafe { !limbo_series::register_extension_static(&ext_api).is_ok() } {
             return Err("Failed to register series extension".to_string());
         }
+        #[cfg(feature = "ipaddr")]
+        if unsafe { !limbo_ipaddr::register_extension_static(&ext_api).is_ok() } {
+            return Err("Failed to register ipaddr extension".to_string());
+        }
         Ok(())
     }
 }

--- a/extensions/ipaddr/Cargo.toml
+++ b/extensions/ipaddr/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "limbo_ipaddr"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Limbo IPAddr extension"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+static= [ "limbo_ext/static" ]
+
+[dependencies]
+limbo_ext = { workspace = true, features = ["static"] }
+ipnetwork = "0.21.1"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mimalloc = { version = "0.1", default-features = false }

--- a/extensions/ipaddr/src/lib.rs
+++ b/extensions/ipaddr/src/lib.rs
@@ -1,0 +1,81 @@
+use std::net::IpAddr;
+
+use ipnetwork::IpNetwork;
+use limbo_ext::{register_extension, scalar, ResultCode, Value};
+
+register_extension! {
+    scalars: { ip_contains, ip_family, ip_host, ip_masklen, ip_network },
+}
+
+#[scalar(name = "ipcontains")]
+fn ip_contains(args: &[Value]) -> Value {
+    let Some(cidr_arg) = args[0].to_text() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    let Ok(network) = cidr_arg.parse::<IpNetwork>() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    let Some(ip_arg) = args[1].to_text() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    let Ok(ip) = ip_arg.parse::<IpAddr>() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    Value::from_integer(network.contains(ip) as i64)
+}
+
+#[scalar(name = "ipfamily")]
+fn ip_family(args: &[Value]) -> Value {
+    let Some(ip_addr) = args[0].to_text() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    match ip_addr.parse::<IpAddr>() {
+        Ok(IpAddr::V4(_)) => Value::from_integer(4),
+        Ok(IpAddr::V6(_)) => Value::from_integer(6),
+        Err(_) => Value::error(ResultCode::InvalidArgs),
+    }
+}
+
+#[scalar(name = "iphost")]
+fn ip_host(args: &[Value]) -> Value {
+    let Some(cidr_arg) = args[0].to_text() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    let Ok(network) = cidr_arg.parse::<IpNetwork>() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    return Value::from_text(network.ip().to_string());
+}
+
+#[scalar(name = "ipmasklen")]
+fn ip_masklen(args: &[Value]) -> Value {
+    let Some(cidr_arg) = args[0].to_text() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    let Ok(network) = cidr_arg.parse::<IpNetwork>() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    Value::from_integer(network.prefix() as i64)
+}
+
+#[scalar(name = "ipnetwork")]
+fn ip_network(args: &[Value]) -> Value {
+    let Some(cidr_arg) = args[0].to_text() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    let Ok(network) = cidr_arg.parse::<IpNetwork>() else {
+        return Value::error(ResultCode::InvalidArgs);
+    };
+
+    Value::from_text(format!("{}/{}", network.network(), network.prefix()))
+}

--- a/licenses/extensions/ipnetwork-apache-license.md
+++ b/licenses/extensions/ipnetwork-apache-license.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/extensions/ipnetwork-mit-license.md
+++ b/licenses/extensions/ipnetwork-mit-license.md
@@ -1,0 +1,25 @@
+Copyright 2020 Developers of the ipnetwork project
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -8,5 +8,6 @@ cargo publish -p limbo_regexp
 cargo publish -p limbo_series
 cargo publish -p limbo_time
 cargo publish -p limbo_uuid
+cargo publish -p limbo_ipaddr
 cargo publish -p limbo_core
 cargo publish -p limbo


### PR DESCRIPTION
Relatively simple one, although I notice we don't have a lot of testing here. The extensions have all their tests in the python cli extension tests. Do we want to keep it that way or motivate inline rust tests for these modules?