### PR TITLE
Replace Refcells in IO buffers, more BTree cleanups 

### DIFF
--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -1,4 +1,4 @@
-use crate::{Completion, File, LimboError, OpenFlags, Result, IO};
+use crate::{Completion, File, IOBuff, LimboError, OpenFlags, Result, IO};
 use std::cell::RefCell;
 use std::io::{Read, Seek, Write};
 use std::sync::Arc;
@@ -78,10 +78,10 @@ impl File for GenericFile {
         Ok(())
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<crate::Buffer>>, c: Completion) -> Result<()> {
+    fn pwrite(&self, pos: usize, buffer: IOBuff, c: Completion) -> Result<()> {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
-        let buf = buffer.borrow();
+        let buf = buffer.buf();
         let buf = buf.as_slice();
         file.write_all(buf)?;
         c.complete(buf.len() as i32);

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -1,8 +1,8 @@
-use super::{Buffer, Completion, File, OpenFlags, IO};
+use super::{Completion, File, IOBuff, OpenFlags, IO};
 use crate::Result;
 
 use std::{
-    cell::{Cell, RefCell, UnsafeCell},
+    cell::{Cell, UnsafeCell},
     collections::BTreeMap,
     sync::Arc,
 };
@@ -84,7 +84,7 @@ impl File for MemoryFile {
 
         let read_len = buf_len.min(file_size - pos);
         {
-            let mut read_buf = r.buf_mut();
+            let read_buf = r.buf_mut();
             let mut offset = pos;
             let mut remaining = read_len;
             let mut buf_offset = 0;
@@ -109,8 +109,8 @@ impl File for MemoryFile {
         Ok(())
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion) -> Result<()> {
-        let buf = buffer.borrow();
+    fn pwrite(&self, pos: usize, buffer: IOBuff, c: Completion) -> Result<()> {
+        let buf = buffer.buf();
         let buf_len = buf.len();
         if buf_len == 0 {
             c.complete(0);

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -14,7 +14,7 @@ pub trait File: Send + Sync {
     fn size(&self) -> Result<u64>;
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum OpenFlags {
     None,
     Create,
@@ -139,6 +139,7 @@ impl SyncCompletion {
 #[derive(Debug, Clone)]
 pub struct IOBuff(Arc<UnsafeCell<Buffer>>);
 
+#[allow(clippy::arc_with_non_send_sync)]
 impl IOBuff {
     pub fn new(buf: Buffer) -> Self {
         Self(Arc::new(UnsafeCell::new(buf)))

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -1,20 +1,15 @@
 use crate::Result;
 use cfg_block::cfg_block;
+use std::cell::UnsafeCell;
 use std::fmt;
 use std::sync::Arc;
-use std::{
-    cell::{Ref, RefCell, RefMut},
-    fmt::Debug,
-    mem::ManuallyDrop,
-    pin::Pin,
-    rc::Rc,
-};
+use std::{fmt::Debug, mem::ManuallyDrop, pin::Pin, rc::Rc};
 
 pub trait File: Send + Sync {
     fn lock_file(&self, exclusive: bool) -> Result<()>;
     fn unlock_file(&self) -> Result<()>;
     fn pread(&self, pos: usize, c: Completion) -> Result<()>;
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion) -> Result<()>;
+    fn pwrite(&self, pos: usize, buffer: IOBuff, c: Completion) -> Result<()>;
     fn sync(&self, c: Completion) -> Result<()>;
     fn size(&self) -> Result<u64>;
 }
@@ -44,7 +39,7 @@ pub trait IO: Send + Sync {
     fn get_current_time(&self) -> String;
 }
 
-pub type Complete = dyn Fn(Arc<RefCell<Buffer>>);
+pub type Complete = dyn Fn(IOBuff);
 pub type WriteComplete = dyn Fn(i32);
 pub type SyncComplete = dyn Fn(i32);
 
@@ -55,7 +50,7 @@ pub enum Completion {
 }
 
 pub struct ReadCompletion {
-    pub buf: Arc<RefCell<Buffer>>,
+    pub buf: IOBuff,
     pub complete: Box<Complete>,
 }
 
@@ -66,6 +61,18 @@ impl Completion {
             Self::Write(w) => w.complete(result),
             Self::Sync(s) => s.complete(result), // fix
         }
+    }
+
+    // for io_uring, to ensure the buffer lives
+    pub fn async_write(c: Completion, buff: IOBuff) -> Self {
+        let cloned = buff.clone();
+        Self::Write(WriteCompletion {
+            complete: Box::new(move |res| {
+                let _ = cloned.clone();
+                c.complete(res);
+            }),
+            buf: Some(buff),
+        })
     }
 
     /// only call this method if you are sure that the completion is
@@ -80,6 +87,7 @@ impl Completion {
 
 pub struct WriteCompletion {
     pub complete: Box<WriteComplete>,
+    pub buf: Option<IOBuff>,
 }
 
 pub struct SyncCompletion {
@@ -87,16 +95,17 @@ pub struct SyncCompletion {
 }
 
 impl ReadCompletion {
-    pub fn new(buf: Arc<RefCell<Buffer>>, complete: Box<Complete>) -> Self {
+    pub fn new(buf: IOBuff, complete: Box<Complete>) -> Self {
         Self { buf, complete }
     }
 
-    pub fn buf(&self) -> Ref<'_, Buffer> {
-        self.buf.borrow()
+    pub fn buf(&self) -> &Buffer {
+        unsafe { &*self.buf.0.get() }
     }
 
-    pub fn buf_mut(&self) -> RefMut<'_, Buffer> {
-        self.buf.borrow_mut()
+    #[allow(clippy::mut_from_ref)]
+    pub fn buf_mut(&self) -> &mut Buffer {
+        unsafe { &mut *self.buf.0.get() }
     }
 
     pub fn complete(&self) {
@@ -106,7 +115,10 @@ impl ReadCompletion {
 
 impl WriteCompletion {
     pub fn new(complete: Box<WriteComplete>) -> Self {
-        Self { complete }
+        Self {
+            complete,
+            buf: None,
+        }
     }
 
     pub fn complete(&self, bytes_written: i32) {
@@ -121,6 +133,42 @@ impl SyncCompletion {
 
     pub fn complete(&self, res: i32) {
         (self.complete)(res);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IOBuff(Arc<UnsafeCell<Buffer>>);
+
+impl IOBuff {
+    pub fn new(buf: Buffer) -> Self {
+        Self(Arc::new(UnsafeCell::new(buf)))
+    }
+
+    pub fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+
+    // Clones the inner buffer and not just a refcount increase
+    pub fn clone_inner(&self) -> Self {
+        Self(Arc::new(UnsafeCell::new(unsafe {
+            (*self.0.get()).clone()
+        })))
+    }
+
+    pub fn buf(&self) -> &Buffer {
+        unsafe { &*self.0.get() }
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    pub fn buf_mut(&self) -> &mut Buffer {
+        unsafe { &mut *self.0.get() }
+    }
+
+    pub fn len(&self) -> usize {
+        self.buf().len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.buf().is_empty()
     }
 }
 

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -104,7 +104,7 @@ impl File for VfsFileImpl {
         let result = unsafe {
             (vfs.write)(
                 self.file,
-                buf.as_slice().as_ptr() as *mut u8,
+                buffer.buf_mut().as_ptr() as *mut u8,
                 count,
                 pos as i64,
             )

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -1,11 +1,10 @@
 use crate::ext::VfsMod;
 use crate::{LimboError, Result};
 use limbo_ext::{VfsFileImpl, VfsImpl};
-use std::cell::RefCell;
 use std::ffi::{c_void, CString};
 use std::sync::Arc;
 
-use super::{Buffer, Completion, File, OpenFlags, IO};
+use super::{Completion, File, IOBuff, OpenFlags, IO};
 
 impl IO for VfsMod {
     fn open_file(&self, path: &str, flags: OpenFlags, direct: bool) -> Result<Arc<dyn File>> {
@@ -82,7 +81,7 @@ impl File for VfsFileImpl {
             _ => unreachable!(),
         };
         let result = {
-            let mut buf = r.buf_mut();
+            let buf = r.buf_mut();
             let count = buf.len();
             let vfs = unsafe { &*self.vfs };
             unsafe { (vfs.read)(self.file, buf.as_mut_ptr(), count, pos as i64) }
@@ -95,8 +94,8 @@ impl File for VfsFileImpl {
         }
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion) -> Result<()> {
-        let buf = buffer.borrow();
+    fn pwrite(&self, pos: usize, buffer: IOBuff, c: Completion) -> Result<()> {
+        let buf = buffer.buf_mut();
         let count = buf.as_slice().len();
         if self.vfs.is_null() {
             return Err(LimboError::ExtensionError("VFS is null".to_string()));

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -1,4 +1,4 @@
-use crate::{Completion, File, LimboError, OpenFlags, Result, IO};
+use crate::{Completion, File, IOBuff, LimboError, OpenFlags, Result, IO};
 use std::cell::RefCell;
 use std::io::{Read, Seek, Write};
 use std::sync::Arc;
@@ -73,10 +73,10 @@ impl File for WindowsFile {
         Ok(())
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<crate::Buffer>>, c: Completion) -> Result<()> {
+    fn pwrite(&self, pos: usize, buffer: IOBuff, c: Completion) -> Result<()> {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
-        let buf = buffer.borrow();
+        let buf = buffer.buf();
         let buf = buf.as_slice();
         file.write_all(buf)?;
         c.complete(buffer.borrow().len() as i32);

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -65,7 +65,7 @@ impl File for WindowsFile {
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         {
             let r = c.as_read();
-            let mut buf = r.buf_mut();
+            let buf = r.buf_mut();
             let buf = buf.as_mut_slice();
             file.read_exact(buf)?;
         }
@@ -79,7 +79,7 @@ impl File for WindowsFile {
         let buf = buffer.buf();
         let buf = buf.as_slice();
         file.write_all(buf)?;
-        c.complete(buffer.borrow().len() as i32);
+        c.complete(buffer.len() as i32);
         Ok(())
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -35,7 +35,9 @@ use crate::storage::wal::CheckpointResult;
 pub use io::UnixIO;
 #[cfg(all(feature = "fs", target_os = "linux", feature = "io_uring"))]
 pub use io::UringIO;
-pub use io::{Buffer, Completion, File, MemoryIO, OpenFlags, PlatformIO, WriteCompletion, IO};
+pub use io::{
+    Buffer, Completion, File, IOBuff, MemoryIO, OpenFlags, PlatformIO, WriteCompletion, IO,
+};
 use limbo_ext::{ResultCode, VTabKind, VTabModuleImpl};
 use limbo_sqlite3_parser::{ast, ast::Cmd, lexer::sql::Parser};
 use parking_lot::RwLock;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -27,6 +27,10 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use crate::{fast_lock::SpinLock, translate::optimizer::optimize_plan};
 pub use error::LimboError;
 use fallible_iterator::FallibleIterator;
+use translate::select::prepare_select_plan;
+pub type Result<T, E = LimboError> = std::result::Result<T, E>;
+use crate::storage::wal::CheckpointResult;
+
 #[cfg(all(feature = "fs", target_family = "unix"))]
 pub use io::UnixIO;
 #[cfg(all(feature = "fs", target_os = "linux", feature = "io_uring"))]
@@ -53,19 +57,17 @@ pub use storage::{
     database::DatabaseStorage,
     pager::PageRef,
     pager::{Page, Pager},
-    wal::{CheckpointMode, CheckpointResult, CheckpointStatus, Wal, WalFile, WalFileShared},
+    wal::{CheckpointMode, CheckpointStatus, Wal, WalFile, WalFileShared},
 };
 use storage::{
     page_cache::DumbLruPageCache,
     pager::allocate_page,
     sqlite3_ondisk::{DatabaseHeader, DATABASE_HEADER_SIZE},
 };
-use translate::select::prepare_select_plan;
 pub use types::OwnedValue;
 use util::{columns_from_create_table_body, parse_schema_rows};
 use vdbe::{builder::QueryMode, VTabOpaqueCursor};
 
-pub type Result<T, E = LimboError> = std::result::Result<T, E>;
 pub static DATABASE_VERSION: OnceLock<String> = OnceLock::new();
 
 #[derive(Clone, PartialEq, Eq)]

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3587,7 +3587,7 @@ mod tests {
         let buf = IOBuff::new(Buffer::allocate(page_size as usize, drop_fn));
         {
             let buf_slice = buf.buf_mut().as_mut_slice();
-            sqlite3_ondisk::write_header_to_buf(buf_slice, &db_header.lock().unwrap());
+            sqlite3_ondisk::write_header_to_buf(buf_slice, &db_header.lock());
         }
 
         let write_complete = Box::new(|_| {});
@@ -3637,7 +3637,7 @@ mod tests {
             let drop_fn = Rc::new(|_buf| {});
             #[allow(clippy::arc_with_non_send_sync)]
             let buf = IOBuff::new(Buffer::allocate(
-                db_header.lock().unwrap().page_size as usize,
+                db_header.lock().page_size as usize,
                 drop_fn,
             ));
             let write_complete = Box::new(|_| {});

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4114,13 +4114,13 @@ mod tests {
         let usable_space = 4096;
 
         let record1 = Record::new([OwnedValue::Integer(1_i64)].to_vec());
-        let payload1 = add_record(1, 0, page, record1, &db);
+        let payload1 = add_record(1, 0, page, record1, &db.connect().unwrap());
         assert_eq!(page.cell_count(), 1);
 
         // insert second record (overflows)
         let large_text = "A".repeat(8192); // exceeds 1 page
         let record2 = Record::new([OwnedValue::build_text(&large_text)].to_vec());
-        let payload2 = add_record(2, 1, page, record2, &db);
+        let payload2 = add_record(2, 1, page, record2, &db.connect().unwrap());
         assert_eq!(page.cell_count(), 2);
 
         // 'fill_cell_payload' (called by add_record) writes to memory but doesn't modify the

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1062,8 +1062,7 @@ impl Program {
                             let rowid = {
                                 let mut index_cursor = state.get_cursor(index_cursor_id);
                                 let index_cursor = index_cursor.as_btree_mut();
-                                let rowid = index_cursor.rowid()?;
-                                rowid
+                                index_cursor.rowid()?
                             };
                             let mut table_cursor = state.get_cursor(table_cursor_id);
                             let table_cursor = table_cursor.as_btree_mut();

--- a/simulator/runner/file.rs
+++ b/simulator/runner/file.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, sync::Arc};
 
-use limbo_core::{File, Result};
+use limbo_core::{File, IOBuff, Result};
 pub(crate) struct SimulatorFile {
     pub(crate) inner: Arc<dyn File>,
     pub(crate) fault: RefCell<bool>,
@@ -88,12 +88,7 @@ impl File for SimulatorFile {
         self.inner.pread(pos, c)
     }
 
-    fn pwrite(
-        &self,
-        pos: usize,
-        buffer: Arc<RefCell<limbo_core::Buffer>>,
-        c: limbo_core::Completion,
-    ) -> Result<()> {
+    fn pwrite(&self, pos: usize, buffer: IOBuff, c: limbo_core::Completion) -> Result<()> {
         *self.nr_pwrite_calls.borrow_mut() += 1;
         if *self.fault.borrow() {
             *self.nr_pwrite_faults.borrow_mut() += 1;


### PR DESCRIPTION
I noticed that we are doing
```rust
    pub fn as_ptr(&self) -> &mut [u8] {
        unsafe {
            // unsafe trick to borrow twice
            let buf_pointer = &self.buffer.as_ptr();
            let buf = (*buf_pointer).as_mut().unwrap().as_mut_slice();
            buf
        }
    }
```
For `PageContent` (which is using an underlying `Rc<RefCell<Buffer>>`) so I figured lets just replace the RefCell with an UnsafeCell for an easy optimization that can extend all the way to the IO callbacks, seeing as the buffers data is `Pin`'d anyway. 

Also added a wrapper `IOBuff` to remove some of the verbosity around the type. I ran benchmarks locally and saw a non-trivial/fairly significant increase in performance.
```rust
pub struct IOBuff(Rc<UnsafeCell<Buffer>>);
```
