### PR TITLE
Display blobs as blob literals in `.dump`

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -9,6 +9,7 @@ use limbo_core::{Database, LimboError, OwnedValue, Statement, StepResult};
 use clap::{Parser, ValueEnum};
 use rustyline::DefaultEditor;
 use std::{
+    fmt,
     io::{self, Write},
     path::PathBuf,
     rc::Rc,
@@ -310,7 +311,11 @@ impl<'a> Limbo<'a> {
                         } else if value_type.contains("BLOB") {
                             let blob = value.to_blob().unwrap_or(&[]);
                             let hex_string: String =
-                                blob.iter().map(|b| format!("{:02x}", b)).collect();
+                                blob.iter().fold(String::new(), |mut output, b| {
+                                    let _ =
+                                        fmt::Write::write_fmt(&mut output, format_args!("{b:02x}"));
+                                    output
+                                });
                             format!("X'{}'", hex_string)
                         } else {
                             value.to_string()

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -307,6 +307,11 @@ impl<'a> Limbo<'a> {
                             || value_type.contains("TEXT")
                         {
                             format!("'{}'", value.to_string().replace("'", "''"))
+                        } else if value_type.contains("BLOB") {
+                            let blob = value.to_blob().unwrap_or(&[]);
+                            let hex_string: String =
+                                blob.iter().map(|b| format!("{:02x}", b)).collect();
+                            format!("X'{}'", hex_string)
                         } else {
                             value.to_string()
                         }


### PR DESCRIPTION
Fixes [#1084](https://github.com/tursodatabase/limbo/issues/1084), displays blobs as blob literals for the `.dump` command:
```
limbo> CREATE TABLE IF NOT EXISTS files (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    data BLOB
);
INSERT INTO files (data) VALUES (X'89504E470D0A1A0A0000000D49484452000000');
limbo> .dump
PRAGMA foreign_keys=OFF;
BEGIN TRANSACTION;
CREATE TABLE files (id INTEGER PRIMARY KEY AUTOINCREMENT, data BLOB);
INSERT INTO files VALUES(1,X'89504e470d0a1a0a0000000d49484452000000');
COMMIT;
```