### PR TITLE
Bunch `Database` changes to prepare for multi threading.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_completion"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "limbo_ext",
  "mimalloc",

--- a/bindings/go/rs_src/lib.rs
+++ b/bindings/go/rs_src/lib.rs
@@ -22,15 +22,13 @@ pub unsafe extern "C" fn db_open(path: *const c_char) -> *mut c_void {
     let path = unsafe { std::ffi::CStr::from_ptr(path) };
     let path = path.to_str().unwrap();
     let io: Arc<dyn IO> = match path {
-        p if p.contains(":memory:") => {
-            Arc::new(limbo_core::MemoryIO::new().expect("Failed to create IO"))
-        }
+        p if p.contains(":memory:") => Arc::new(limbo_core::MemoryIO::new()),
         _ => Arc::new(limbo_core::PlatformIO::new().expect("Failed to create IO")),
     };
     let db = Database::open_file(io.clone(), path);
     match db {
         Ok(db) => {
-            let conn = db.connect();
+            let conn = db.connect().unwrap();
             LimboConn::new(conn, io).to_ptr()
         }
         Err(e) => {

--- a/bindings/java/rs_src/limbo_db.rs
+++ b/bindings/java/rs_src/limbo_db.rs
@@ -92,7 +92,7 @@ pub extern "system" fn Java_tech_turso_core_LimboDB_connect0<'local>(
         }
     };
 
-    let conn = LimboConnection::new(db.db.connect(), db.io.clone());
+    let conn = LimboConnection::new(db.db.connect().unwrap(), db.io.clone());
     conn.to_ptr()
 }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -284,15 +284,15 @@ pub fn connect(path: &str) -> Result<Connection> {
 
     match path {
         ":memory:" => {
-            let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::MemoryIO::new()?);
+            let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::MemoryIO::new());
             let db = open_or(io.clone(), path)?;
-            let conn: Rc<limbo_core::Connection> = db.connect();
+            let conn: Rc<limbo_core::Connection> = db.connect().unwrap();
             Ok(Connection { conn, io })
         }
         path => {
             let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::PlatformIO::new()?);
             let db = open_or(io.clone(), path)?;
-            let conn: Rc<limbo_core::Connection> = db.connect();
+            let conn: Rc<limbo_core::Connection> = db.connect().unwrap();
             Ok(Connection { conn, io })
         }
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -41,7 +41,7 @@ impl Builder {
     pub async fn build(self) -> Result<Database> {
         match self.path.as_str() {
             ":memory:" => {
-                let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::MemoryIO::new()?);
+                let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::MemoryIO::new());
                 let db = limbo_core::Database::open_file(io, self.path.as_str())?;
                 Ok(Database { inner: db })
             }
@@ -63,7 +63,7 @@ unsafe impl Sync for Database {}
 
 impl Database {
     pub fn connect(&self) -> Result<Connection> {
-        let conn = self.inner.connect();
+        let conn = self.inner.connect().unwrap();
         #[allow(clippy::arc_with_non_send_sync)]
         let connection = Connection {
             inner: Arc::new(Mutex::new(conn)),

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -1,7 +1,5 @@
 use js_sys::{Array, Object};
-use limbo_core::{
-    maybe_init_database_file, OpenFlags, Pager, Result, WalFileShared,
-};
+use limbo_core::{maybe_init_database_file, OpenFlags, Pager, Result, WalFileShared};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -328,7 +326,6 @@ impl DatabaseStorage {
         Self { file }
     }
 }
-
 
 impl limbo_core::DatabaseStorage for DatabaseStorage {
     fn read_page(&self, page_idx: usize, c: limbo_core::Completion) -> Result<()> {

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -211,7 +211,7 @@ impl<'a> Limbo<'a> {
             }
         };
         let db = Database::open_file(io.clone(), &db_file)?;
-        let conn = db.connect();
+        let conn = db.connect().unwrap();
         let h = LimboHelper::new(conn.clone(), io.clone());
         rl.set_helper(Some(h));
         let interrupt_count = Arc::new(AtomicUsize::new(0));
@@ -413,7 +413,7 @@ impl<'a> Limbo<'a> {
         };
         self.io = Arc::clone(&io);
         let db = Database::open_file(self.io.clone(), path)?;
-        self.conn = db.connect();
+        self.conn = db.connect().unwrap();
         self.opts.db_file = path.to_string();
         Ok(())
     }

--- a/cli/input.rs
+++ b/cli/input.rs
@@ -120,7 +120,7 @@ pub fn get_writer(output: &str) -> Box<dyn Write> {
 
 pub fn get_io(db_location: DbLocation, io_choice: Io) -> anyhow::Result<Arc<dyn limbo_core::IO>> {
     Ok(match db_location {
-        DbLocation::Memory => Arc::new(limbo_core::MemoryIO::new()?),
+        DbLocation::Memory => Arc::new(limbo_core::MemoryIO::new()),
         DbLocation::Path => {
             match io_choice {
                 Io::Syscall => {

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -19,7 +19,7 @@ fn bench(criterion: &mut Criterion) {
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
-    let limbo_conn = db.connect();
+    let limbo_conn = db.connect().unwrap();
 
     let queries = [
         "SELECT 1",

--- a/core/error.rs
+++ b/core/error.rs
@@ -53,6 +53,8 @@ pub enum LimboError {
     Unbound(NonZero<usize>),
     #[error("Runtime error: integer overflow")]
     IntegerOverflow,
+    #[error("Schema is locked for write")]
+    SchemaLocked,
 }
 
 #[macro_export]

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -76,7 +76,7 @@ unsafe extern "C" fn register_module(
 
 impl Database {
     fn register_scalar_function_impl(&self, name: &str, func: ScalarFunction) -> ResultCode {
-        self.syms.borrow_mut().functions.insert(
+        self.syms.lock().unwrap().functions.insert(
             name.to_string(),
             Rc::new(ExternalFunc::new_scalar(name.to_string(), func)),
         );
@@ -89,7 +89,7 @@ impl Database {
         args: i32,
         func: ExternAggFunc,
     ) -> ResultCode {
-        self.syms.borrow_mut().functions.insert(
+        self.syms.lock().unwrap().functions.insert(
             name.to_string(),
             Rc::new(ExternalFunc::new_aggregate(name.to_string(), args, func)),
         );
@@ -108,7 +108,8 @@ impl Database {
             implementation: module,
         };
         self.syms
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .vtab_modules
             .insert(name.to_string(), vmodule.into());
         ResultCode::OK

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -48,6 +48,9 @@ pub struct GenericFile {
     file: RefCell<std::fs::File>,
 }
 
+unsafe impl Send for GenericFile {}
+unsafe impl Sync for GenericFile {}
+
 impl File for GenericFile {
     // Since we let the OS handle the locking, file locking is not supported on the generic IO implementation
     // No-op implementation allows compilation but provides no actual file locking.

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -4,15 +4,12 @@ use crate::Result;
 use std::{
     cell::{Cell, RefCell, UnsafeCell},
     collections::BTreeMap,
-    rc::Rc,
     sync::Arc,
 };
 use tracing::debug;
 
-pub struct MemoryIO {
-    pages: UnsafeCell<BTreeMap<usize, MemPage>>,
-    size: Cell<usize>,
-}
+pub struct MemoryIO {}
+unsafe impl Send for MemoryIO {}
 
 // TODO: page size flag
 const PAGE_SIZE: usize = 4096;
@@ -20,33 +17,23 @@ type MemPage = Box<[u8; PAGE_SIZE]>;
 
 impl MemoryIO {
     #[allow(clippy::arc_with_non_send_sync)]
-    pub fn new() -> Result<Arc<Self>> {
+    pub fn new() -> Self {
         debug!("Using IO backend 'memory'");
-        Ok(Arc::new(Self {
-            pages: BTreeMap::new().into(),
-            size: 0.into(),
-        }))
-    }
-
-    #[allow(clippy::mut_from_ref)]
-    fn get_or_allocate_page(&self, page_no: usize) -> &mut MemPage {
-        unsafe {
-            let pages = &mut *self.pages.get();
-            pages
-                .entry(page_no)
-                .or_insert_with(|| Box::new([0; PAGE_SIZE]))
-        }
-    }
-
-    fn get_page(&self, page_no: usize) -> Option<&MemPage> {
-        unsafe { (*self.pages.get()).get(&page_no) }
+        Self {}
     }
 }
 
-impl IO for Arc<MemoryIO> {
-    fn open_file(&self, _path: &str, _flags: OpenFlags, _direct: bool) -> Result<Rc<dyn File>> {
-        Ok(Rc::new(MemoryFile {
-            io: Arc::clone(self),
+impl Default for MemoryIO {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IO for MemoryIO {
+    fn open_file(&self, _path: &str, _flags: OpenFlags, _direct: bool) -> Result<Arc<dyn File>> {
+        Ok(Arc::new(MemoryFile {
+            pages: BTreeMap::new().into(),
+            size: 0.into(),
         }))
     }
 
@@ -67,8 +54,12 @@ impl IO for Arc<MemoryIO> {
 }
 
 pub struct MemoryFile {
-    io: Arc<MemoryIO>,
+    pages: UnsafeCell<BTreeMap<usize, MemPage>>,
+    size: Cell<usize>,
 }
+unsafe impl Send for MemoryFile {}
+unsafe impl Sync for MemoryFile {}
+
 
 impl File for MemoryFile {
     fn lock_file(&self, _exclusive: bool) -> Result<()> {
@@ -86,7 +77,7 @@ impl File for MemoryFile {
             return Ok(());
         }
 
-        let file_size = self.io.size.get();
+        let file_size = self.size.get();
         if pos >= file_size {
             c.complete(0);
             return Ok(());
@@ -103,7 +94,7 @@ impl File for MemoryFile {
                 let page_no = offset / PAGE_SIZE;
                 let page_offset = offset % PAGE_SIZE;
                 let bytes_to_read = remaining.min(PAGE_SIZE - page_offset);
-                if let Some(page) = self.io.get_page(page_no) {
+                if let Some(page) = self.get_page(page_no) {
                     read_buf.as_mut_slice()[buf_offset..buf_offset + bytes_to_read]
                         .copy_from_slice(&page[page_offset..page_offset + bytes_to_read]);
                 } else {
@@ -119,7 +110,7 @@ impl File for MemoryFile {
         Ok(())
     }
 
-    fn pwrite(&self, pos: usize, buffer: Rc<RefCell<Buffer>>, c: Completion) -> Result<()> {
+    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion) -> Result<()> {
         let buf = buffer.borrow();
         let buf_len = buf.len();
         if buf_len == 0 {
@@ -138,7 +129,7 @@ impl File for MemoryFile {
             let bytes_to_write = remaining.min(PAGE_SIZE - page_offset);
 
             {
-                let page = self.io.get_or_allocate_page(page_no);
+                let page = self.get_or_allocate_page(page_no);
                 page[page_offset..page_offset + bytes_to_write]
                     .copy_from_slice(&data[buf_offset..buf_offset + bytes_to_write]);
             }
@@ -148,9 +139,8 @@ impl File for MemoryFile {
             remaining -= bytes_to_write;
         }
 
-        self.io
-            .size
-            .set(core::cmp::max(pos + buf_len, self.io.size.get()));
+        self.size
+            .set(core::cmp::max(pos + buf_len, self.size.get()));
 
         c.complete(buf_len as i32);
         Ok(())
@@ -163,12 +153,28 @@ impl File for MemoryFile {
     }
 
     fn size(&self) -> Result<u64> {
-        Ok(self.io.size.get() as u64)
+        Ok(self.size.get() as u64)
     }
 }
 
 impl Drop for MemoryFile {
     fn drop(&mut self) {
         // no-op
+    }
+}
+
+impl MemoryFile {
+    #[allow(clippy::mut_from_ref)]
+    fn get_or_allocate_page(&self, page_no: usize) -> &mut MemPage {
+        unsafe {
+            let pages = &mut *self.pages.get();
+            pages
+                .entry(page_no)
+                .or_insert_with(|| Box::new([0; PAGE_SIZE]))
+        }
+    }
+
+    fn get_page(&self, page_no: usize) -> Option<&MemPage> {
+        unsafe { (*self.pages.get()).get(&page_no) }
     }
 }

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -60,7 +60,6 @@ pub struct MemoryFile {
 unsafe impl Send for MemoryFile {}
 unsafe impl Sync for MemoryFile {}
 
-
 impl File for MemoryFile {
     fn lock_file(&self, _exclusive: bool) -> Result<()> {
         Ok(())

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -193,6 +193,7 @@ impl IO for UnixIO {
             .create(matches!(flags, OpenFlags::Create))
             .open(path)?;
 
+        #[allow(clippy::arc_with_non_send_sync)]
         let unix_file = Arc::new(UnixFile {
             file: Arc::new(RefCell::new(file)),
             poller: BorrowedPollHandler(self.poller.as_mut().into()),
@@ -263,6 +264,7 @@ enum CompletionCallback {
 }
 
 pub struct UnixFile<'io> {
+    #[allow(clippy::arc_with_non_send_sync)]
     file: Arc<RefCell<std::fs::File>>,
     poller: BorrowedPollHandler<'io>,
     callbacks: BorrowedCallbacks<'io>,

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -48,6 +48,9 @@ pub struct WindowsFile {
     file: RefCell<std::fs::File>,
 }
 
+unsafe impl Send for WindowsFile {}
+unsafe impl Sync for WindowsFile {}
+
 impl File for WindowsFile {
     fn lock_file(&self, exclusive: bool) -> Result<()> {
         unimplemented!()

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -70,7 +70,7 @@ impl File for WindowsFile {
         Ok(())
     }
 
-    fn pwrite(&self, pos: usize, buffer: Rc<RefCell<crate::Buffer>>, c: Completion) -> Result<()> {
+    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<crate::Buffer>>, c: Completion) -> Result<()> {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         let buf = buffer.borrow();

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -172,7 +172,7 @@ impl Database {
             buffer_pool,
         )?);
         let conn = Rc::new(Connection {
-            db: self.clone(),
+            _db: self.clone(),
             pager: pager.clone(),
             schema: self.schema.clone(),
             header: self.header.clone(),
@@ -239,7 +239,7 @@ pub fn maybe_init_database_file(file: &Arc<dyn File>, io: &Arc<dyn IO>) -> Resul
 }
 
 pub struct Connection {
-    db: Arc<Database>,
+    _db: Arc<Database>,
     pager: Rc<Pager>,
     schema: Arc<RwLock<Schema>>,
     header: Arc<Mutex<DatabaseHeader>>,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -84,7 +84,6 @@ enum TransactionState {
 }
 
 pub struct Database {
-    // TODO: make schema work without lock
     schema: Arc<RwLock<Schema>>,
     // TODO: make header work without lock
     header: Arc<Mutex<DatabaseHeader>>,
@@ -146,7 +145,9 @@ impl Database {
             // parse schema
             let conn = db.connect()?;
             let rows = conn.query("SELECT * FROM sqlite_schema")?;
-            let mut schema = schema.try_write().expect("lock on schema should succeed first try");
+            let mut schema = schema
+                .try_write()
+                .expect("lock on schema should succeed first try");
             let syms = conn.syms.borrow();
             parse_schema_rows(rows, &mut schema, io, syms.deref())?;
         }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -84,8 +84,11 @@ enum TransactionState {
 }
 
 pub struct Database {
+    // TODO: make schema work without lock
     schema: Arc<Mutex<Schema>>,
+    // TODO: make header work without lock
     header: Arc<Mutex<DatabaseHeader>>,
+    // TODO: make syms work without lock
     syms: Arc<Mutex<SymbolTable>>,
     page_io: Arc<dyn DatabaseStorage>,
     io: Arc<dyn IO>,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,6 +1,7 @@
 use crate::VirtualTable;
 use crate::{util::normalize_ident, Result};
 use core::fmt;
+use std::sync::Arc;
 use fallible_iterator::FallibleIterator;
 use limbo_sqlite3_parser::ast::{Expr, Literal, TableOptions};
 use limbo_sqlite3_parser::{
@@ -12,18 +13,18 @@ use std::rc::Rc;
 use tracing::trace;
 
 pub struct Schema {
-    pub tables: HashMap<String, Rc<Table>>,
+    pub tables: HashMap<String, Arc<Table>>,
     // table_name to list of indexes for the table
-    pub indexes: HashMap<String, Vec<Rc<Index>>>,
+    pub indexes: HashMap<String, Vec<Arc<Index>>>,
 }
 
 impl Schema {
     pub fn new() -> Self {
-        let mut tables: HashMap<String, Rc<Table>> = HashMap::new();
-        let indexes: HashMap<String, Vec<Rc<Index>>> = HashMap::new();
+        let mut tables: HashMap<String, Arc<Table>> = HashMap::new();
+        let indexes: HashMap<String, Vec<Arc<Index>>> = HashMap::new();
         tables.insert(
             "sqlite_schema".to_string(),
-            Rc::new(Table::BTree(sqlite_schema_table().into())),
+            Arc::new(Table::BTree(sqlite_schema_table().into())),
         );
         Self { tables, indexes }
     }
@@ -38,7 +39,7 @@ impl Schema {
         self.tables.insert(name, Table::Virtual(table).into());
     }
 
-    pub fn get_table(&self, name: &str) -> Option<Rc<Table>> {
+    pub fn get_table(&self, name: &str) -> Option<Arc<Table>> {
         let name = normalize_ident(name);
         self.tables.get(&name).cloned()
     }
@@ -52,7 +53,7 @@ impl Schema {
         }
     }
 
-    pub fn add_index(&mut self, index: Rc<Index>) {
+    pub fn add_index(&mut self, index: Arc<Index>) {
         let table_name = normalize_ident(&index.table_name);
         self.indexes
             .entry(table_name)

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -22,6 +22,7 @@ impl Schema {
     pub fn new() -> Self {
         let mut tables: HashMap<String, Arc<Table>> = HashMap::new();
         let indexes: HashMap<String, Vec<Arc<Index>>> = HashMap::new();
+        #[allow(clippy::arc_with_non_send_sync)]
         tables.insert(
             "sqlite_schema".to_string(),
             Arc::new(Table::BTree(sqlite_schema_table().into())),

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,7 +1,6 @@
 use crate::VirtualTable;
 use crate::{util::normalize_ident, Result};
 use core::fmt;
-use std::sync::Arc;
 use fallible_iterator::FallibleIterator;
 use limbo_sqlite3_parser::ast::{Expr, Literal, TableOptions};
 use limbo_sqlite3_parser::{
@@ -10,6 +9,7 @@ use limbo_sqlite3_parser::{
 };
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::Arc;
 use tracing::trace;
 
 pub struct Schema {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1871,7 +1871,7 @@ impl BTreeCursor {
         let Some(first_page) = first_overflow_page else {
             return Ok(CursorResult::Ok(()));
         };
-        let page_count = self.pager.db_header.borrow().database_size as usize;
+        let page_count = self.pager.db_header.lock().unwrap().database_size as usize;
         let mut pages_left = n_overflow;
         let mut current_page = first_page;
         // Clear overflow pages
@@ -2752,12 +2752,14 @@ mod tests {
     use crate::storage::sqlite3_ondisk;
     use crate::storage::sqlite3_ondisk::DatabaseHeader;
     use crate::types::Text;
+    use crate::Connection;
     use crate::{BufferPool, DatabaseStorage, WalFile, WalFileShared, WriteCompletion};
     use std::cell::RefCell;
     use std::ops::Deref;
     use std::panic;
     use std::rc::Rc;
     use std::sync::Arc;
+    use std::sync::Mutex;
 
     use rand::{thread_rng, Rng};
     use tempfile::TempDir;
@@ -2785,7 +2787,7 @@ mod tests {
         let drop_fn = Rc::new(|_| {});
         let inner = PageContent {
             offset: 0,
-            buffer: Rc::new(RefCell::new(Buffer::new(
+            buffer: Arc::new(RefCell::new(Buffer::new(
                 BufferData::new(vec![0; 4096]),
                 drop_fn,
             ))),
@@ -2831,7 +2833,7 @@ mod tests {
         pos: usize,
         page: &mut PageContent,
         record: Record,
-        db: &Arc<Database>,
+        conn: &Rc<Connection>,
     ) -> Vec<u8> {
         let mut payload: Vec<u8> = Vec::new();
         fill_cell_payload(
@@ -2840,7 +2842,7 @@ mod tests {
             &mut payload,
             &record,
             4096,
-            db.pager.clone(),
+            conn.pager.clone(),
         );
         insert_into_cell(page, &payload, pos, 4096).unwrap();
         payload
@@ -2849,11 +2851,12 @@ mod tests {
     #[test]
     fn test_insert_cell() {
         let db = get_database();
+        let conn = db.connect().unwrap();
         let page = get_page(2);
         let page = page.get_contents();
         let header_size = 8;
         let record = Record::new([OwnedValue::Integer(1)].to_vec());
-        let payload = add_record(1, 0, page, record, &db);
+        let payload = add_record(1, 0, page, record, &conn);
         assert_eq!(page.cell_count(), 1);
         let free = compute_free_space(page, 4096);
         assert_eq!(free, 4096 - payload.len() as u16 - 2 - header_size);
@@ -2870,6 +2873,7 @@ mod tests {
     #[test]
     fn test_drop_1() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
@@ -2880,7 +2884,7 @@ mod tests {
         let usable_space = 4096;
         for i in 0..3 {
             let record = Record::new([OwnedValue::Integer(i as i64)].to_vec());
-            let payload = add_record(i, i, page, record, &db);
+            let payload = add_record(i, i, page, record, &conn);
             assert_eq!(page.cell_count(), i + 1);
             let free = compute_free_space(page, usable_space);
             total_size += payload.len() as u16 + 2;
@@ -3027,9 +3031,9 @@ mod tests {
         let page_size = db_header.page_size as usize;
 
         #[allow(clippy::arc_with_non_send_sync)]
-        let io: Arc<dyn IO> = Arc::new(MemoryIO::new().unwrap());
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
         let io_file = io.open_file("test.db", OpenFlags::Create, false).unwrap();
-        let page_io = Rc::new(FileStorage::new(io_file));
+        let page_io = Arc::new(FileStorage::new(io_file));
 
         let buffer_pool = Rc::new(BufferPool::new(db_header.page_size as usize));
         let wal_shared = WalFileShared::open_shared(&io, "test.wal", db_header.page_size).unwrap();
@@ -3038,7 +3042,7 @@ mod tests {
 
         let page_cache = Arc::new(parking_lot::RwLock::new(DumbLruPageCache::new(10)));
         let pager = {
-            let db_header = Rc::new(RefCell::new(db_header.clone()));
+            let db_header = Arc::new(Mutex::new(db_header.clone()));
             Pager::finish_open(db_header, page_io, wal, io, page_cache, buffer_pool).unwrap()
         };
         let pager = Rc::new(pager);
@@ -3208,7 +3212,7 @@ mod tests {
         let total_cells = 10;
         for i in 0..total_cells {
             let record = Record::new([OwnedValue::Integer(i as i64)].to_vec());
-            let payload = add_record(i, i, page, record, &db);
+            let payload = add_record(i, i, page, record, &conn);
             assert_eq!(page.cell_count(), i + 1);
             let free = compute_free_space(page, usable_space);
             total_size += payload.len() as u16 + 2;
@@ -3270,12 +3274,12 @@ mod tests {
     }
 
     #[allow(clippy::arc_with_non_send_sync)]
-    fn setup_test_env(database_size: u32) -> (Rc<Pager>, Rc<RefCell<DatabaseHeader>>) {
+    fn setup_test_env(database_size: u32) -> (Rc<Pager>, Arc<Mutex<DatabaseHeader>>) {
         let page_size = 512;
         let mut db_header = DatabaseHeader::default();
         db_header.page_size = page_size;
         db_header.database_size = database_size;
-        let db_header = Rc::new(RefCell::new(db_header));
+        let db_header = Arc::new(Mutex::new(db_header));
 
         let buffer_pool = Rc::new(BufferPool::new(10));
 
@@ -3285,17 +3289,17 @@ mod tests {
             buffer_pool.put(Pin::new(vec));
         }
 
-        let io: Arc<dyn IO> = Arc::new(MemoryIO::new().unwrap());
-        let page_io = Rc::new(FileStorage::new(
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let page_io = Arc::new(FileStorage::new(
             io.open_file("test.db", OpenFlags::Create, false).unwrap(),
         ));
 
         let drop_fn = Rc::new(|_buf| {});
-        let buf = Rc::new(RefCell::new(Buffer::allocate(page_size as usize, drop_fn)));
+        let buf = Arc::new(RefCell::new(Buffer::allocate(page_size as usize, drop_fn)));
         {
             let mut buf_mut = buf.borrow_mut();
             let buf_slice = buf_mut.as_mut_slice();
-            sqlite3_ondisk::write_header_to_buf(buf_slice, &db_header.borrow());
+            sqlite3_ondisk::write_header_to_buf(buf_slice, &db_header.lock().unwrap());
         }
 
         let write_complete = Box::new(|_| {});
@@ -3343,8 +3347,8 @@ mod tests {
         let mut current_page = 2u32;
         while current_page <= 4 {
             let drop_fn = Rc::new(|_buf| {});
-            let buf = Rc::new(RefCell::new(Buffer::allocate(
-                db_header.borrow().page_size as usize,
+            let buf = Arc::new(RefCell::new(Buffer::allocate(
+                db_header.lock().unwrap().page_size as usize,
                 drop_fn,
             )));
             let write_complete = Box::new(|_| {});
@@ -3384,20 +3388,20 @@ mod tests {
             first_overflow_page: Some(2), // Point to first overflow page
         });
 
-        let initial_freelist_pages = db_header.borrow().freelist_pages;
+        let initial_freelist_pages = db_header.lock().unwrap().freelist_pages;
         // Clear overflow pages
         let clear_result = cursor.clear_overflow_pages(&leaf_cell)?;
         match clear_result {
             CursorResult::Ok(_) => {
                 // Verify proper number of pages were added to freelist
                 assert_eq!(
-                    db_header.borrow().freelist_pages,
+                    db_header.lock().unwrap().freelist_pages,
                     initial_freelist_pages + 3,
                     "Expected 3 pages to be added to freelist"
                 );
 
                 // If this is first trunk page
-                let trunk_page_id = db_header.borrow().freelist_trunk_page;
+                let trunk_page_id = db_header.lock().unwrap().freelist_trunk_page;
                 if trunk_page_id > 0 {
                     // Verify trunk page structure
                     let trunk_page = cursor.pager.read_page(trunk_page_id as usize)?;
@@ -3439,7 +3443,7 @@ mod tests {
             first_overflow_page: None,
         });
 
-        let initial_freelist_pages = db_header.borrow().freelist_pages;
+        let initial_freelist_pages = db_header.lock().unwrap().freelist_pages;
 
         // Try to clear non-existent overflow pages
         let clear_result = cursor.clear_overflow_pages(&leaf_cell)?;
@@ -3447,14 +3451,14 @@ mod tests {
             CursorResult::Ok(_) => {
                 // Verify freelist was not modified
                 assert_eq!(
-                    db_header.borrow().freelist_pages,
+                    db_header.lock().unwrap().freelist_pages,
                     initial_freelist_pages,
                     "Freelist should not change when no overflow pages exist"
                 );
 
                 // Verify trunk page wasn't created
                 assert_eq!(
-                    db_header.borrow().freelist_trunk_page,
+                    db_header.lock().unwrap().freelist_trunk_page,
                     0,
                     "No trunk page should be created when no overflow pages exist"
                 );
@@ -3469,6 +3473,7 @@ mod tests {
     #[test]
     pub fn test_defragment() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
@@ -3479,7 +3484,7 @@ mod tests {
         let usable_space = 4096;
         for i in 0..3 {
             let record = Record::new([OwnedValue::Integer(i as i64)].to_vec());
-            let payload = add_record(i, i, page, record, &db);
+            let payload = add_record(i, i, page, record, &conn);
             assert_eq!(page.cell_count(), i + 1);
             let free = compute_free_space(page, usable_space);
             total_size += payload.len() as u16 + 2;
@@ -3507,6 +3512,7 @@ mod tests {
     #[test]
     pub fn test_drop_odd_with_defragment() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
@@ -3518,7 +3524,7 @@ mod tests {
         let total_cells = 10;
         for i in 0..total_cells {
             let record = Record::new([OwnedValue::Integer(i as i64)].to_vec());
-            let payload = add_record(i, i, page, record, &db);
+            let payload = add_record(i, i, page, record, &conn);
             assert_eq!(page.cell_count(), i + 1);
             let free = compute_free_space(page, usable_space);
             total_size += payload.len() as u16 + 2;
@@ -3551,6 +3557,7 @@ mod tests {
     #[test]
     pub fn test_fuzz_drop_defragment_insert() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
@@ -3577,7 +3584,7 @@ mod tests {
                         &mut payload,
                         &record,
                         4096,
-                        db.pager.clone(),
+                        conn.pager.clone(),
                     );
                     if (free as usize) < payload.len() - 2 {
                         // do not try to insert overflow pages because they require balancing
@@ -3616,13 +3623,14 @@ mod tests {
     #[test]
     pub fn test_free_space() {
         let db = get_database();
+        let conn = db.connect().unwrap();
         let page = get_page(2);
         let page = page.get_contents();
         let header_size = 8;
         let usable_space = 4096;
 
         let record = Record::new([OwnedValue::Integer(0)].to_vec());
-        let payload = add_record(0, 0, page, record, &db);
+        let payload = add_record(0, 0, page, record, &conn);
         let free = compute_free_space(page, usable_space);
         assert_eq!(free, 4096 - payload.len() as u16 - 2 - header_size);
     }
@@ -3630,13 +3638,14 @@ mod tests {
     #[test]
     pub fn test_defragment_1() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
         let usable_space = 4096;
 
         let record = Record::new([OwnedValue::Integer(0 as i64)].to_vec());
-        let payload = add_record(0, 0, page, record, &db);
+        let payload = add_record(0, 0, page, record, &conn);
 
         assert_eq!(page.cell_count(), 1);
         defragment_page(page, usable_space);
@@ -3654,6 +3663,7 @@ mod tests {
     #[test]
     pub fn test_insert_drop_insert() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
@@ -3666,14 +3676,14 @@ mod tests {
             ]
             .to_vec(),
         );
-        let _ = add_record(0, 0, page, record, &db);
+        let _ = add_record(0, 0, page, record, &conn);
 
         assert_eq!(page.cell_count(), 1);
         drop_cell(page, 0, usable_space).unwrap();
         assert_eq!(page.cell_count(), 0);
 
         let record = Record::new([OwnedValue::Integer(0 as i64)].to_vec());
-        let payload = add_record(0, 0, page, record, &db);
+        let payload = add_record(0, 0, page, record, &conn);
         assert_eq!(page.cell_count(), 1);
 
         let (start, len) = page.cell_get_raw_region(
@@ -3689,6 +3699,7 @@ mod tests {
     #[test]
     pub fn test_insert_drop_insert_multiple() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
@@ -3701,7 +3712,7 @@ mod tests {
             ]
             .to_vec(),
         );
-        let _ = add_record(0, 0, page, record, &db);
+        let _ = add_record(0, 0, page, record, &conn);
 
         for _ in 0..100 {
             assert_eq!(page.cell_count(), 1);
@@ -3709,7 +3720,7 @@ mod tests {
             assert_eq!(page.cell_count(), 0);
 
             let record = Record::new([OwnedValue::Integer(0)].to_vec());
-            let payload = add_record(0, 0, page, record, &db);
+            let payload = add_record(0, 0, page, record, &conn);
             assert_eq!(page.cell_count(), 1);
 
             let (start, len) = page.cell_get_raw_region(
@@ -3726,17 +3737,18 @@ mod tests {
     #[test]
     pub fn test_drop_a_few_insert() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
         let usable_space = 4096;
 
         let record = Record::new([OwnedValue::Integer(0)].to_vec());
-        let payload = add_record(0, 0, page, record, &db);
+        let payload = add_record(0, 0, page, record, &conn);
         let record = Record::new([OwnedValue::Integer(1)].to_vec());
-        let _ = add_record(1, 1, page, record, &db);
+        let _ = add_record(1, 1, page, record, &conn);
         let record = Record::new([OwnedValue::Integer(2)].to_vec());
-        let _ = add_record(2, 2, page, record, &db);
+        let _ = add_record(2, 2, page, record, &conn);
 
         drop_cell(page, 1, usable_space).unwrap();
         drop_cell(page, 1, usable_space).unwrap();
@@ -3747,38 +3759,40 @@ mod tests {
     #[test]
     pub fn test_fuzz_victim_1() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
         let usable_space = 4096;
 
         let record = Record::new([OwnedValue::Integer(0)].to_vec());
-        let _ = add_record(0, 0, page, record, &db);
+        let _ = add_record(0, 0, page, record, &conn);
 
         let record = Record::new([OwnedValue::Integer(0)].to_vec());
-        let _ = add_record(0, 0, page, record, &db);
+        let _ = add_record(0, 0, page, record, &conn);
         drop_cell(page, 0, usable_space).unwrap();
 
         defragment_page(page, usable_space);
 
         let record = Record::new([OwnedValue::Integer(0)].to_vec());
-        let _ = add_record(0, 1, page, record, &db);
+        let _ = add_record(0, 1, page, record, &conn);
 
         drop_cell(page, 0, usable_space).unwrap();
 
         let record = Record::new([OwnedValue::Integer(0)].to_vec());
-        let _ = add_record(0, 1, page, record, &db);
+        let _ = add_record(0, 1, page, record, &conn);
     }
 
     #[test]
     pub fn test_fuzz_victim_2() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let usable_space = 4096;
         let insert = |pos, page| {
             let record = Record::new([OwnedValue::Integer(0)].to_vec());
-            let _ = add_record(0, pos, page, record, &db);
+            let _ = add_record(0, pos, page, record, &conn);
         };
         let drop = |pos, page| {
             drop_cell(page, pos, usable_space).unwrap();
@@ -3811,12 +3825,13 @@ mod tests {
     #[test]
     pub fn test_fuzz_victim_3() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let usable_space = 4096;
         let insert = |pos, page| {
             let record = Record::new([OwnedValue::Integer(0)].to_vec());
-            let _ = add_record(0, pos, page, record, &db);
+            let _ = add_record(0, pos, page, record, &conn);
         };
         let drop = |pos, page| {
             drop_cell(page, pos, usable_space).unwrap();
@@ -3889,6 +3904,7 @@ mod tests {
     #[test]
     pub fn test_big_payload_compute_free() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let usable_space = 4096;
@@ -3900,7 +3916,7 @@ mod tests {
             &mut payload,
             &record,
             4096,
-            db.pager.clone(),
+            conn.pager.clone(),
         );
         insert_into_cell(page.get_contents(), &payload, 0, 4096).unwrap();
         let free = compute_free_space(page.get_contents(), usable_space);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3201,6 +3201,7 @@ mod tests {
     #[test]
     pub fn test_drop_odd() {
         let db = get_database();
+        let conn = db.connect().unwrap();
 
         let page = get_page(2);
         let page = page.get_contents();
@@ -3847,7 +3848,7 @@ mod tests {
             &mut payload,
             &record,
             4096,
-            db.pager.clone(),
+            conn.pager.clone(),
         );
         insert(0, page.get_contents());
         defragment(page.get_contents());

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3348,6 +3348,7 @@ mod tests {
         let mut current_page = 2u32;
         while current_page <= 4 {
             let drop_fn = Rc::new(|_buf| {});
+            #[allow(clippy::arc_with_non_send_sync)]
             let buf = Arc::new(RefCell::new(Buffer::allocate(
                 db_header.lock().unwrap().page_size as usize,
                 drop_fn,

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -19,7 +19,6 @@ pub trait DatabaseStorage: Send + Sync {
     fn sync(&self, c: Completion) -> Result<()>;
 }
 
-
 #[cfg(feature = "fs")]
 pub struct FileStorage {
     file: Arc<dyn crate::io::File>,

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -24,7 +24,9 @@ pub struct FileStorage {
     file: Arc<dyn crate::io::File>,
 }
 
+#[cfg(feature = "fs")]
 unsafe impl Send for FileStorage {}
+#[cfg(feature = "fs")]
 unsafe impl Sync for FileStorage {}
 
 #[cfg(feature = "fs")]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -246,6 +246,7 @@ pub fn begin_read_database_header(
     page_io: Arc<dyn DatabaseStorage>,
 ) -> Result<Arc<Mutex<DatabaseHeader>>> {
     let drop_fn = Rc::new(|_buf| {});
+    #[allow(clippy::arc_with_non_send_sync)]
     let buf = Arc::new(RefCell::new(Buffer::allocate(512, drop_fn)));
     let result = Arc::new(Mutex::new(DatabaseHeader::default()));
     let header = result.clone();
@@ -299,6 +300,7 @@ pub fn begin_write_database_header(header: &DatabaseHeader, pager: &Pager) -> Re
     let page_source = pager.page_io.clone();
 
     let drop_fn = Rc::new(|_buf| {});
+    #[allow(clippy::arc_with_non_send_sync)]
     let buffer_to_copy = Arc::new(RefCell::new(Buffer::allocate(512, drop_fn)));
     let buffer_to_copy_in_cb = buffer_to_copy.clone();
 
@@ -312,6 +314,7 @@ pub fn begin_write_database_header(header: &DatabaseHeader, pager: &Pager) -> Re
     });
 
     let drop_fn = Rc::new(|_buf| {});
+    #[allow(clippy::arc_with_non_send_sync)]
     let buf = Arc::new(RefCell::new(Buffer::allocate(512, drop_fn)));
     let c = Completion::Read(ReadCompletion::new(buf, read_complete));
     page_source.read_page(1, c)?;
@@ -399,6 +402,7 @@ pub struct PageContent {
 
 impl Clone for PageContent {
     fn clone(&self) -> Self {
+        #[allow(clippy::arc_with_non_send_sync)]
         Self {
             offset: self.offset,
             buffer: Arc::new(RefCell::new((*self.buffer.borrow()).clone())),
@@ -684,6 +688,7 @@ pub fn begin_read_page(
         let buffer_pool = buffer_pool.clone();
         buffer_pool.put(buf);
     });
+    #[allow(clippy::arc_with_non_send_sync)]
     let buf = Arc::new(RefCell::new(Buffer::new(buf, drop_fn)));
     let complete = Box::new(move |buf: Arc<RefCell<Buffer>>| {
         let page = page.clone();
@@ -1254,6 +1259,7 @@ pub fn write_varint_to_vec(value: u64, payload: &mut Vec<u8>) {
 
 pub fn begin_read_wal_header(io: &Arc<dyn File>) -> Result<Arc<RwLock<WalHeader>>> {
     let drop_fn = Rc::new(|_buf| {});
+    #[allow(clippy::arc_with_non_send_sync)]
     let buf = Arc::new(RefCell::new(Buffer::allocate(512, drop_fn)));
     let result = Arc::new(RwLock::new(WalHeader::default()));
     let header = result.clone();
@@ -1297,6 +1303,7 @@ pub fn begin_read_wal_frame(
         let buffer_pool = buffer_pool.clone();
         buffer_pool.put(buf);
     });
+    #[allow(clippy::arc_with_non_send_sync)]
     let buf = Arc::new(RefCell::new(Buffer::new(buf, drop_fn)));
     let frame = page.clone();
     let complete = Box::new(move |buf: Arc<RefCell<Buffer>>| {
@@ -1361,6 +1368,7 @@ pub fn begin_write_wal_frame(
         buf[20..24].copy_from_slice(&header.checksum_2.to_be_bytes());
         buf[WAL_FRAME_HEADER_SIZE..].copy_from_slice(contents.as_ptr());
 
+        #[allow(clippy::arc_with_non_send_sync)]
         (Arc::new(RefCell::new(buffer)), checksums)
     };
 
@@ -1399,6 +1407,7 @@ pub fn begin_write_wal_header(io: &Arc<dyn File>, header: &WalHeader) -> Result<
         buf[24..28].copy_from_slice(&header.checksum_1.to_be_bytes());
         buf[28..32].copy_from_slice(&header.checksum_2.to_be_bytes());
 
+        #[allow(clippy::arc_with_non_send_sync)]
         Arc::new(RefCell::new(buffer))
     };
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -283,7 +283,7 @@ pub struct WalFileShared {
     // Another memory inefficient array made to just keep track of pages that are in frame_cache.
     pages_in_frames: Vec<u64>,
     last_checksum: (u32, u32), // Check of last frame in WAL, this is a cumulative checksum over all frames in the WAL
-    file: Rc<dyn File>,
+    file: Arc<dyn File>,
     /// read_locks is a list of read locks that can coexist with the max_frame number stored in
     /// value. There is a limited amount because and unbounded amount of connections could be
     /// fatal. Therefore, for now we copy how SQLite behaves with limited amounts of read max
@@ -675,7 +675,7 @@ impl WalFile {
             });
             checkpoint_page.get().contents = Some(PageContent {
                 offset: 0,
-                buffer: Rc::new(RefCell::new(Buffer::new(buffer, drop_fn))),
+                buffer: Arc::new(RefCell::new(Buffer::new(buffer, drop_fn))),
                 overflow_cells: Vec::new(),
             });
         }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -35,16 +35,16 @@ use crate::{bail_parse_error, Connection, LimboError, Result, SymbolTable};
 use insert::translate_insert;
 use limbo_sqlite3_parser::ast::{self, fmt::ToTokens, CreateVirtualTable, Delete, Insert};
 use select::translate_select;
-use std::cell::RefCell;
 use std::fmt::Display;
 use std::rc::{Rc, Weak};
+use std::sync::{Arc, Mutex};
 use transaction::{translate_tx_begin, translate_tx_commit};
 
 /// Translate SQL statement into bytecode program.
 pub fn translate(
     schema: &Schema,
     stmt: ast::Stmt,
-    database_header: Rc<RefCell<DatabaseHeader>>,
+    database_header: Arc<Mutex<DatabaseHeader>>,
     pager: Rc<Pager>,
     connection: Weak<Connection>,
     syms: &SymbolTable,

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap,  sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use limbo_sqlite3_parser::ast;
 
@@ -90,8 +90,9 @@ fn query_is_already_ordered_by(
             Search::RowidSearch { .. } => Ok(key.is_rowid_alias_of(0)),
             Search::IndexSearch { index, .. } => {
                 let index_rc = key.check_index_scan(0, &table_reference, available_indexes)?;
-                let index_is_the_same =
-                    index_rc.map(|irc| Arc::ptr_eq(index, &irc)).unwrap_or(false);
+                let index_is_the_same = index_rc
+                    .map(|irc| Arc::ptr_eq(index, &irc))
+                    .unwrap_or(false);
                 Ok(index_is_the_same)
             }
         },

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3,7 +3,7 @@ use limbo_sqlite3_parser::ast;
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter},
-    rc::Rc,
+    rc::Rc, sync::Arc,
 };
 
 use crate::{
@@ -325,7 +325,7 @@ pub enum Search {
     },
     /// A secondary index search. Uses bytecode instructions like SeekGE, SeekGT etc.
     IndexSearch {
-        index: Rc<Index>,
+        index: Arc<Index>,
         cmp_op: ast::Operator,
         cmp_expr: WhereTerm,
     },

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3,7 +3,8 @@ use limbo_sqlite3_parser::ast;
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter},
-    rc::Rc, sync::Arc,
+    rc::Rc,
+    sync::Arc,
 };
 
 use crate::{

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -3,8 +3,8 @@
 
 use limbo_sqlite3_parser::ast;
 use limbo_sqlite3_parser::ast::PragmaName;
-use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use crate::schema::Schema;
 use crate::storage::sqlite3_ondisk::{DatabaseHeader, MIN_PAGE_CACHE_SIZE};
@@ -38,7 +38,7 @@ pub fn translate_pragma(
     schema: &Schema,
     name: &ast::QualifiedName,
     body: Option<ast::PragmaBody>,
-    database_header: Rc<RefCell<DatabaseHeader>>,
+    database_header: Arc<Mutex<DatabaseHeader>>,
     pager: Rc<Pager>,
 ) -> crate::Result<ProgramBuilder> {
     let mut program = ProgramBuilder::new(ProgramBuilderOpts {
@@ -115,7 +115,7 @@ fn update_pragma(
     pragma: PragmaName,
     schema: &Schema,
     value: ast::Expr,
-    header: Rc<RefCell<DatabaseHeader>>,
+    header: Arc<Mutex<DatabaseHeader>>,
     pager: Rc<Pager>,
     program: &mut ProgramBuilder,
 ) -> crate::Result<()> {
@@ -166,14 +166,14 @@ fn query_pragma(
     pragma: PragmaName,
     schema: &Schema,
     value: Option<ast::Expr>,
-    database_header: Rc<RefCell<DatabaseHeader>>,
+    database_header: Arc<Mutex<DatabaseHeader>>,
     program: &mut ProgramBuilder,
 ) -> crate::Result<()> {
     let register = program.alloc_register();
     match pragma {
         PragmaName::CacheSize => {
             program.emit_int(
-                database_header.borrow().default_page_cache_size.into(),
+                database_header.lock().unwrap().default_page_cache_size.into(),
                 register,
             );
             program.emit_result_row(register, 1);
@@ -261,7 +261,7 @@ fn query_pragma(
     Ok(())
 }
 
-fn update_cache_size(value: i64, header: Rc<RefCell<DatabaseHeader>>, pager: Rc<Pager>) {
+fn update_cache_size(value: i64, header: Arc<Mutex<DatabaseHeader>>, pager: Rc<Pager>) {
     let mut cache_size_unformatted: i64 = value;
     let mut cache_size = if cache_size_unformatted < 0 {
         let kb = cache_size_unformatted.abs() * 1024;
@@ -277,12 +277,12 @@ fn update_cache_size(value: i64, header: Rc<RefCell<DatabaseHeader>>, pager: Rc<
     }
 
     // update in-memory header
-    header.borrow_mut().default_page_cache_size = cache_size_unformatted
+    header.lock().unwrap().default_page_cache_size = cache_size_unformatted
         .try_into()
         .unwrap_or_else(|_| panic!("invalid value, too big for a i32 {}", value));
 
     // update in disk
-    let header_copy = header.borrow().clone();
+    let header_copy = header.lock().unwrap().clone();
     pager.write_database_header(&header_copy);
 
     // update cache size

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -173,7 +173,11 @@ fn query_pragma(
     match pragma {
         PragmaName::CacheSize => {
             program.emit_int(
-                database_header.lock().unwrap().default_page_cache_size.into(),
+                database_header
+                    .lock()
+                    .unwrap()
+                    .default_page_cache_size
+                    .into(),
                 register,
             );
             program.emit_result_row(register, 1);

--- a/core/util.rs
+++ b/core/util.rs
@@ -70,7 +70,7 @@ pub fn parse_schema_rows(
                             match row.get::<&str>(4) {
                                 Ok(sql) => {
                                     let index = schema::Index::from_sql(sql, root_page as usize)?;
-                                    schema.add_index(Rc::new(index));
+                                    schema.add_index(Arc::new(index));
                                 }
                                 _ => {
                                     // Automatic index on primary key, e.g.
@@ -105,7 +105,7 @@ pub fn parse_schema_rows(
             let table = schema.get_btree_table(&table_name).unwrap();
             let index =
                 schema::Index::automatic_from_primary_key(&table, &index_name, root_page as usize)?;
-            schema.add_index(Rc::new(index));
+            schema.add_index(Arc::new(index));
         }
     }
     Ok(())

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,7 +1,7 @@
 use std::{
-    cell::{Cell, RefCell},
+    cell::Cell,
     collections::HashMap,
-    rc::{Rc, Weak},
+    rc::{Rc, Weak}, sync::{Arc, Mutex},
 };
 
 use crate::{
@@ -38,7 +38,7 @@ pub struct ProgramBuilder {
 #[derive(Debug, Clone)]
 pub enum CursorType {
     BTreeTable(Rc<BTreeTable>),
-    BTreeIndex(Rc<Index>),
+    BTreeIndex(Arc<Index>),
     Pseudo(Rc<PseudoTable>),
     Sorter,
     VirtualTable(Rc<VirtualTable>),
@@ -437,7 +437,7 @@ impl ProgramBuilder {
 
     pub fn build(
         mut self,
-        database_header: Rc<RefCell<DatabaseHeader>>,
+        database_header: Arc<Mutex<DatabaseHeader>>,
         connection: Weak<Connection>,
         change_cnt_on: bool,
     ) -> Program {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,7 +1,8 @@
 use std::{
     cell::Cell,
     collections::HashMap,
-    rc::{Rc, Weak}, sync::{Arc, Mutex},
+    rc::{Rc, Weak},
+    sync::{Arc, Mutex},
 };
 
 use crate::{

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2998,7 +2998,7 @@ impl Program {
                         "SELECT * FROM  sqlite_schema WHERE {}",
                         where_clause
                     ))?;
-                    let mut schema = conn.schema.lock().unwrap();
+                    let mut schema = conn.schema.write();
                     // TODO: This function below is synchronous, make it async
                     parse_schema_rows(
                         Some(stmt),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -814,15 +814,13 @@ impl Program {
                         Some(&table_name),
                         &module_name,
                         args,
-                        &conn.db.syms.lock().unwrap(),
+                        &conn.syms.borrow(),
                         limbo_ext::VTabKind::VirtualTable,
                         None,
                     )?;
                     {
-                        conn.db
-                            .syms
-                            .lock()
-                            .unwrap()
+                        conn.syms
+                            .borrow_mut()
                             .vtabs
                             .insert(table_name, table.clone());
                     }
@@ -3006,7 +3004,7 @@ impl Program {
                         Some(stmt),
                         &mut schema,
                         conn.pager.io.clone(),
-                        &conn.db.syms.lock().unwrap()
+                        &conn.syms.borrow(),
                     )?;
                     state.pc += 1;
                 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -72,6 +72,7 @@ use std::collections::HashMap;
 use std::ffi::c_void;
 use std::num::NonZero;
 use std::rc::{Rc, Weak};
+use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Represents a target for a jump instruction.
@@ -318,7 +319,7 @@ pub struct Program {
     pub max_registers: usize,
     pub insns: Vec<Insn>,
     pub cursor_ref: Vec<(Option<String>, CursorType)>,
-    pub database_header: Rc<RefCell<DatabaseHeader>>,
+    pub database_header: Arc<Mutex<DatabaseHeader>>,
     pub comments: Option<HashMap<InsnReference, &'static str>>,
     pub parameters: crate::parameters::Parameters,
     pub connection: Weak<Connection>,
@@ -813,15 +814,15 @@ impl Program {
                         Some(&table_name),
                         &module_name,
                         args,
-                        &conn.db.syms.borrow(),
+                        &conn.db.syms.lock().unwrap(),
                         limbo_ext::VTabKind::VirtualTable,
                         None,
                     )?;
                     {
                         conn.db
                             .syms
-                            .as_ref()
-                            .borrow_mut()
+                            .lock()
+                            .unwrap()
                             .vtabs
                             .insert(table_name, table.clone());
                     }
@@ -2982,7 +2983,7 @@ impl Program {
                     }
                     // SQLite returns "0" on an empty database, and 2 on the first insertion,
                     // so we'll mimic that behavior.
-                    let mut pages = pager.db_header.borrow().database_size.into();
+                    let mut pages = pager.db_header.lock().unwrap().database_size.into();
                     if pages == 1 {
                         pages = 0;
                     }
@@ -2999,13 +3000,13 @@ impl Program {
                         "SELECT * FROM  sqlite_schema WHERE {}",
                         where_clause
                     ))?;
-                    let mut schema = RefCell::borrow_mut(&conn.schema);
+                    let mut schema = conn.schema.lock().unwrap();
                     // TODO: This function below is synchronous, make it async
                     parse_schema_rows(
                         Some(stmt),
                         &mut schema,
                         conn.pager.io.clone(),
-                        &conn.db.syms.borrow(),
+                        &conn.db.syms.lock().unwrap()
                     )?;
                     state.pc += 1;
                 }
@@ -3015,7 +3016,7 @@ impl Program {
                         todo!("temp databases not implemented yet");
                     }
                     let cookie_value = match cookie {
-                        Cookie::UserVersion => pager.db_header.borrow().user_version.into(),
+                        Cookie::UserVersion => pager.db_header.lock().unwrap().user_version.into(),
                         cookie => todo!("{cookie:?} is not yet implement for ReadCookie"),
                     };
                     state.registers[*dest] = OwnedValue::Integer(cookie_value);

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -220,7 +220,7 @@ fn execute_plan(
 
     if let SimConnection::Disconnected = connection {
         log::info!("connecting {}", connection_index);
-        env.connections[connection_index] = SimConnection::Connected(env.db.connect());
+        env.connections[connection_index] = SimConnection::Connected(env.db.connect().unwrap());
     } else {
         let limbo_result =
             execute_interaction(env, connection_index, interaction, &mut state.stack);

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -117,7 +117,7 @@ fn execute_plan(
 
     if let SimConnection::Disconnected = connection {
         log::info!("connecting {}", connection_index);
-        env.connections[connection_index] = SimConnection::Connected(env.db.connect());
+        env.connections[connection_index] = SimConnection::Connected(env.db.connect().unwrap());
     } else {
         match execute_interaction(env, connection_index, interaction, &mut state.stack) {
             Ok(next_execution) => {

--- a/simulator/runner/file.rs
+++ b/simulator/runner/file.rs
@@ -1,8 +1,8 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, sync::Arc};
 
 use limbo_core::{File, Result};
 pub(crate) struct SimulatorFile {
-    pub(crate) inner: Rc<dyn File>,
+    pub(crate) inner: Arc<dyn File>,
     pub(crate) fault: RefCell<bool>,
 
     /// Number of `pread` function calls (both success and failures).
@@ -22,6 +22,9 @@ pub(crate) struct SimulatorFile {
 
     pub(crate) page_size: usize,
 }
+
+unsafe impl Send for SimulatorFile {}
+unsafe impl Sync for SimulatorFile {}
 
 impl SimulatorFile {
     pub(crate) fn inject_fault(&self, fault: bool) {
@@ -88,7 +91,7 @@ impl File for SimulatorFile {
     fn pwrite(
         &self,
         pos: usize,
-        buffer: Rc<RefCell<limbo_core::Buffer>>,
+        buffer: Arc<RefCell<limbo_core::Buffer>>,
         c: limbo_core::Completion,
     ) -> Result<()> {
         *self.nr_pwrite_calls.borrow_mut() += 1;

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -98,7 +98,7 @@ fn execute_plan(
 
     if let SimConnection::Disconnected = connection {
         log::info!("connecting {}", connection_index);
-        env.connections[connection_index] = SimConnection::Connected(env.db.connect());
+        env.connections[connection_index] = SimConnection::Connected(env.db.connect().unwrap());
     } else {
         match execute_interaction(env, connection_index, interaction, &mut state.stack) {
             Ok(next_execution) => {

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -110,10 +110,7 @@ pub unsafe extern "C" fn sqlite3_open(
         Err(_) => return SQLITE_MISUSE,
     };
     let io: Arc<dyn limbo_core::IO> = match filename {
-        ":memory:" => match limbo_core::MemoryIO::new() {
-            Ok(io) => Arc::new(io),
-            Err(_) => return SQLITE_MISUSE,
-        },
+        ":memory:" => Arc::new(limbo_core::MemoryIO::new()),
         _ => match limbo_core::PlatformIO::new() {
             Ok(io) => Arc::new(io),
             Err(_) => return SQLITE_MISUSE,
@@ -121,7 +118,7 @@ pub unsafe extern "C" fn sqlite3_open(
     };
     match limbo_core::Database::open_file(io, filename) {
         Ok(db) => {
-            let conn = db.connect();
+            let conn = db.connect().unwrap();
             *db_out = Box::leak(Box::new(sqlite3::new(db, conn)));
             SQLITE_OK
         }

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -1,7 +1,9 @@
 use crate::common::{do_flush, TempDatabase};
 use limbo_core::{Connection, LimboError, Result, StepResult};
 use std::cell::RefCell;
+use std::ops::{Add, Deref};
 use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 #[allow(clippy::arc_with_non_send_sync)]
 #[test]
@@ -26,6 +28,87 @@ fn test_wal_checkpoint_result() -> Result<()> {
     assert!(res[1] > 0); // num pages in wal
     assert!(res[2] > 0); // num pages checkpointed successfully
 
+    Ok(())
+}
+
+#[test]
+#[ignore = "Multi threaded seems to not work but this tests proves the point for later fiixes"]
+fn test_wal_1_writer_1_reader() -> Result<()> {
+    let tmp_db = Arc::new(Mutex::new(TempDatabase::new("test_wal.db")));
+    let db = tmp_db.lock().unwrap().limbo_database();
+
+    {
+        let conn = db.connect().unwrap();
+        match conn.query("CREATE TABLE t (id)")? {
+            Some(ref mut rows) => loop {
+                match rows.step().unwrap() {
+                    StepResult::Row => {}
+                    StepResult::IO => {
+                        tmp_db.lock().unwrap().io.run_once().unwrap();
+                    }
+                    StepResult::Interrupt => break,
+                    StepResult::Done => break,
+                    StepResult::Busy => unreachable!(),
+                }
+            },
+            None => todo!(),
+        }
+        do_flush(&conn, tmp_db.lock().unwrap().deref()).unwrap();
+    }
+    let rows = Arc::new(std::sync::Mutex::new(0));
+    let rows_ = rows.clone();
+    const ROWS_WRITE: usize = 1000;
+    let tmp_db_w = db.clone();
+    let writer_thread = std::thread::spawn(move || {
+        let conn = tmp_db_w.connect().unwrap();
+        for i in 0..ROWS_WRITE {
+            println!("adding {}", i);
+            conn.execute(format!("INSERT INTO t values({})", i).as_str())
+                .unwrap();
+            let _ = rows_.lock().unwrap().add(1);
+        }
+    });
+    let rows_ = rows.clone();
+    let reader_thread = std::thread::spawn(move || {
+        let conn = db.connect().unwrap();
+        loop {
+            let rows = *rows_.lock().unwrap();
+            let mut i = 0;
+            // println!("reading {}", rows);
+            match conn.query("SELECT * FROM t") {
+                Ok(Some(ref mut rows)) => loop {
+                    match rows.step().unwrap() {
+                        StepResult::Row => {
+                            let row = rows.row().unwrap();
+                            let first_value = row.get_value(0);
+                            let id = match first_value {
+                                limbo_core::OwnedValue::Integer(i) => *i as i32,
+                                _ => unreachable!(),
+                            };
+                            assert_eq!(id, i);
+                            i += 1;
+                        }
+                        StepResult::IO => {
+                            tmp_db.lock().unwrap().io.run_once().unwrap();
+                        }
+                        StepResult::Interrupt => break,
+                        StepResult::Done => break,
+                        StepResult::Busy => unreachable!(),
+                    }
+                },
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("{}", err);
+                }
+            }
+            if rows == ROWS_WRITE {
+                break;
+            }
+        }
+    });
+
+    writer_thread.join().unwrap();
+    reader_thread.join().unwrap();
     Ok(())
 }
 


### PR DESCRIPTION
This is an umbrella PR for multi threading where I modify the following:
* Loaded extensions (`syms`) are now moved to `Connection` as loading extensions in SQLite is per connection and not per database.
* `Schema` is not a `RWLock` so that it behaves equally to SQLite where schema changes block preparing new statements.
* Sprinkled a bunch of `unsafe impl Send` and `unsafe impl Sync` on top of all `IO` implementations and inner structures for now in order to allow multi threading. Ideally this will be enforced with transaction locks and internal locks instead of throwing a bunch of mutexes like rust would like us to do -- this means the work is not finished and rather started for future improvements.