### PR TITLE
Enable local file connection in Rust binding

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -45,7 +45,11 @@ impl Builder {
                 let db = limbo_core::Database::open_file(io, self.path.as_str())?;
                 Ok(Database { inner: db })
             }
-            _ => todo!(),
+            path => {
+                let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::PlatformIO::new()?);
+                let db = limbo_core::Database::open_file(io, path)?;
+                Ok(Database { inner: db })
+            }
         }
     }
 }


### PR DESCRIPTION
It's so weird that other bindings can open local file but Rust binding itself cannot.