### PR TITLE
core/mvcc: Eliminate row generic types

### DIFF
--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -4,7 +4,7 @@ use limbo_core::mvcc::clock::LocalClock;
 use limbo_core::mvcc::database::{MvStore, Row, RowID};
 use pprof::criterion::{Output, PProfProfiler};
 
-fn bench_db() -> MvStore<LocalClock, String> {
+fn bench_db() -> MvStore<LocalClock> {
     let clock = LocalClock::default();
     let storage = limbo_core::mvcc::persistent_storage::Storage::new_noop();
     MvStore::new(clock, storage)
@@ -57,7 +57,7 @@ fn bench(c: &mut Criterion) {
                         table_id: 1,
                         row_id: 1,
                     },
-                    data: "World".to_string(),
+                    data: "World".to_string().into_bytes(),
                 },
             )
             .unwrap();
@@ -74,7 +74,7 @@ fn bench(c: &mut Criterion) {
                 table_id: 1,
                 row_id: 1,
             },
-            data: "Hello".to_string(),
+            data: "Hello".to_string().into_bytes(),
         },
     )
     .unwrap();
@@ -100,7 +100,7 @@ fn bench(c: &mut Criterion) {
                 table_id: 1,
                 row_id: 1,
             },
-            data: "Hello".to_string(),
+            data: "Hello".to_string().into_bytes(),
         },
     )
     .unwrap();
@@ -113,7 +113,7 @@ fn bench(c: &mut Criterion) {
                         table_id: 1,
                         row_id: 1,
                     },
-                    data: "World".to_string(),
+                    data: "World".to_string().into_bytes(),
                 },
             )
             .unwrap();

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -3,19 +3,15 @@ use crate::mvcc::database::{MvStore, Result, Row, RowID};
 use std::fmt::Debug;
 
 #[derive(Debug)]
-pub struct ScanCursor<'a, Clock: LogicalClock, T: Sync + Send + Clone + Debug> {
-    pub db: &'a MvStore<Clock, T>,
+pub struct ScanCursor<'a, Clock: LogicalClock> {
+    pub db: &'a MvStore<Clock>,
     pub row_ids: Vec<RowID>,
     pub index: usize,
     tx_id: u64,
 }
 
-impl<'a, Clock: LogicalClock, T: Sync + Send + Clone + Debug + 'static> ScanCursor<'a, Clock, T> {
-    pub fn new(
-        db: &'a MvStore<Clock, T>,
-        tx_id: u64,
-        table_id: u64,
-    ) -> Result<ScanCursor<'a, Clock, T>> {
+impl<'a, Clock: LogicalClock> ScanCursor<'a, Clock> {
+    pub fn new(db: &'a MvStore<Clock>, tx_id: u64, table_id: u64) -> Result<ScanCursor<'a, Clock>> {
         let row_ids = db.scan_row_ids_for_table(table_id)?;
         Ok(Self {
             db,
@@ -32,7 +28,7 @@ impl<'a, Clock: LogicalClock, T: Sync + Send + Clone + Debug + 'static> ScanCurs
         Some(self.row_ids[self.index])
     }
 
-    pub fn current_row(&self) -> Result<Option<Row<T>>> {
+    pub fn current_row(&self) -> Result<Option<Row>> {
         if self.index >= self.row_ids.len() {
             return Ok(None);
         }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::mvcc::clock::LocalClock;
 
-fn test_db() -> MvStore<LocalClock, String> {
+fn test_db() -> MvStore<LocalClock> {
     let clock = LocalClock::new();
     let storage = crate::mvcc::persistent_storage::Storage::new_noop();
     MvStore::new(clock, storage)
@@ -17,7 +17,7 @@ fn test_insert_read() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Hello".to_string(),
+        data: "Hello".to_string().into_bytes(),
     };
     db.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
@@ -71,7 +71,7 @@ fn test_delete() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Hello".to_string(),
+        data: "Hello".to_string().into_bytes(),
     };
     db.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
@@ -142,7 +142,7 @@ fn test_commit() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Hello".to_string(),
+        data: "Hello".to_string().into_bytes(),
     };
     db.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
@@ -161,7 +161,7 @@ fn test_commit() {
             table_id: 1,
             row_id: 1,
         },
-        data: "World".to_string(),
+        data: "World".to_string().into_bytes(),
     };
     db.update(tx1, tx1_updated_row.clone()).unwrap();
     let row = db
@@ -202,7 +202,7 @@ fn test_rollback() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Hello".to_string(),
+        data: "Hello".to_string().into_bytes(),
     };
     db.insert(tx1, row1.clone()).unwrap();
     let row2 = db
@@ -221,7 +221,7 @@ fn test_rollback() {
             table_id: 1,
             row_id: 1,
         },
-        data: "World".to_string(),
+        data: "World".to_string().into_bytes(),
     };
     db.update(tx1, row3.clone()).unwrap();
     let row4 = db
@@ -260,7 +260,7 @@ fn test_dirty_write() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Hello".to_string(),
+        data: "Hello".to_string().into_bytes(),
     };
     db.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
@@ -282,7 +282,7 @@ fn test_dirty_write() {
             table_id: 1,
             row_id: 1,
         },
-        data: "World".to_string(),
+        data: "World".to_string().into_bytes(),
     };
     assert!(!db.update(tx2, tx2_row).unwrap());
 
@@ -310,7 +310,7 @@ fn test_dirty_read() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Hello".to_string(),
+        data: "Hello".to_string().into_bytes(),
     };
     db.insert(tx1, row1).unwrap();
 
@@ -339,7 +339,7 @@ fn test_dirty_read_deleted() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Hello".to_string(),
+        data: "Hello".to_string().into_bytes(),
     };
     db.insert(tx1, tx1_row.clone()).unwrap();
     db.commit_tx(tx1).unwrap();
@@ -382,7 +382,7 @@ fn test_fuzzy_read() {
             table_id: 1,
             row_id: 1,
         },
-        data: "First".to_string(),
+        data: "First".to_string().into_bytes(),
     };
     db.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
@@ -419,7 +419,7 @@ fn test_fuzzy_read() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Second".to_string(),
+        data: "Second".to_string().into_bytes(),
     };
     db.update(tx3, tx3_row).unwrap();
     db.commit_tx(tx3).unwrap();
@@ -444,7 +444,7 @@ fn test_fuzzy_read() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Third".to_string(),
+        data: "Third".to_string().into_bytes(),
     };
     let update_result = db.update(tx2, tx2_newrow);
     assert_eq!(Err(DatabaseError::WriteWriteConflict), update_result);
@@ -461,7 +461,7 @@ fn test_lost_update() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Hello".to_string(),
+        data: "Hello".to_string().into_bytes(),
     };
     db.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
@@ -484,7 +484,7 @@ fn test_lost_update() {
             table_id: 1,
             row_id: 1,
         },
-        data: "World".to_string(),
+        data: "World".to_string().into_bytes(),
     };
     assert!(db.update(tx2, tx2_row.clone()).unwrap());
 
@@ -495,7 +495,7 @@ fn test_lost_update() {
             table_id: 1,
             row_id: 1,
         },
-        data: "Hello, world!".to_string(),
+        data: "Hello, world!".to_string().into_bytes(),
     };
     assert_eq!(
         Err(DatabaseError::WriteWriteConflict),
@@ -532,7 +532,7 @@ fn test_committed_visibility() {
             table_id: 1,
             row_id: 1,
         },
-        data: "10".to_string(),
+        data: "10".to_string().into_bytes(),
     };
     db.insert(tx1, tx1_row.clone()).unwrap();
     db.commit_tx(tx1).unwrap();
@@ -544,7 +544,7 @@ fn test_committed_visibility() {
             table_id: 1,
             row_id: 1,
         },
-        data: "20".to_string(),
+        data: "20".to_string().into_bytes(),
     };
     assert!(db.update(tx2, tx2_row.clone()).unwrap());
     let row = db
@@ -587,7 +587,7 @@ fn test_future_row() {
             table_id: 1,
             row_id: 1,
         },
-        data: "10".to_string(),
+        data: "10".to_string().into_bytes(),
     };
     db.insert(tx2, tx2_row).unwrap();
 
@@ -695,7 +695,7 @@ fn test_snapshot_isolation_tx_visible1() {
                     table_id: 1,
                     row_id: 1,
                 },
-                data: "testme".to_string(),
+                data: "testme".to_string().into_bytes(),
             },
         };
         tracing::debug!("Testing visibility of {row_version:?}");

--- a/core/mvcc/mod.rs
+++ b/core/mvcc/mod.rs
@@ -68,7 +68,7 @@ mod tests {
                     };
                     let row = Row {
                         id,
-                        data: "Hello".to_string(),
+                        data: "Hello".to_string().into_bytes(),
                     };
                     db.insert(tx, row.clone()).unwrap();
                     db.commit_tx(tx).unwrap();
@@ -90,7 +90,7 @@ mod tests {
                     };
                     let row = Row {
                         id,
-                        data: "World".to_string(),
+                        data: "World".to_string().into_bytes(),
                     };
                     db.insert(tx, row.clone()).unwrap();
                     db.commit_tx(tx).unwrap();
@@ -134,7 +134,7 @@ mod tests {
                     };
                     let row = Row {
                         id,
-                        data: format!("{prefix} @{tx}"),
+                        data: format!("{prefix} @{tx}").into_bytes(),
                     };
                     if let Err(e) = db.upsert(tx, row.clone()) {
                         tracing::trace!("upsert failed: {e}");

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -15,14 +15,14 @@ impl Storage {
 }
 
 impl Storage {
-    pub fn log_tx<T>(&self, _m: LogRecord<T>) -> Result<()> {
+    pub fn log_tx(&self, _m: LogRecord) -> Result<()> {
         match self {
             Self::Noop => (),
         }
         Ok(())
     }
 
-    pub fn read_tx_log<T>(&self) -> Result<Vec<LogRecord<T>>> {
+    pub fn read_tx_log(&self) -> Result<Vec<LogRecord>> {
         match self {
             Self::Noop => Err(DatabaseError::Io(
                 "cannot read from Noop storage".to_string(),


### PR DESCRIPTION
The logging code that writes out transactions to disk needs to write out the byte array that we actually use. The code is less hairly without the generics so drop them.