### PR TITLE
Impl Copy on some types in the pager to prevent explicit clones

### DIFF
--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -32,10 +32,7 @@ unsafe impl Sync for FileStorage {}
 #[cfg(feature = "fs")]
 impl DatabaseStorage for FileStorage {
     fn read_page(&self, page_idx: usize, c: Completion) -> Result<()> {
-        let r = match c {
-            Completion::Read(ref r) => r,
-            _ => unreachable!(),
-        };
+        let r = c.as_read();
         let size = r.buf().len();
         assert!(page_idx > 0);
         if !(512..=65536).contains(&size) || size & (size - 1) != 0 {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -122,7 +122,7 @@ impl Page {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 enum FlushState {
     Start,
     WaitAppendFrames,
@@ -132,7 +132,7 @@ enum FlushState {
     WaitSyncDbFile,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 enum CheckpointState {
     Checkpoint,
     SyncDbFile,
@@ -347,7 +347,7 @@ impl Pager {
     pub fn cacheflush(&self) -> Result<CheckpointStatus> {
         let mut checkpoint_result = CheckpointResult::new();
         loop {
-            let state = self.flush_info.borrow().state.clone();
+            let state = self.flush_info.borrow().state;
             trace!("cacheflush {:?}", state);
             match state {
                 FlushState::Start => {
@@ -425,7 +425,7 @@ impl Pager {
     pub fn checkpoint(&self) -> Result<CheckpointStatus> {
         let mut checkpoint_result = CheckpointResult::new();
         loop {
-            let state = self.checkpoint_state.borrow().clone();
+            let state = *self.checkpoint_state.borrow();
             trace!("pager_checkpoint(state={:?})", state);
             match state {
                 CheckpointState::Checkpoint => {
@@ -456,8 +456,7 @@ impl Pager {
                     }
                 }
                 CheckpointState::CheckpointDone => {
-                    let in_flight = self.checkpoint_inflight.clone();
-                    return if *in_flight.borrow() > 0 {
+                    return if *self.checkpoint_inflight.borrow() > 0 {
                         Ok(CheckpointStatus::IO)
                     } else {
                         self.checkpoint_state.replace(CheckpointState::Checkpoint);

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -156,7 +156,7 @@ pub const WAL_MAGIC_BE: u32 = 0x377f0683;
 /// The Write-Ahead Log (WAL) header.
 /// The first 32 bytes of a WAL file comprise the WAL header.
 /// The WAL header is divided into the following fields stored in big-endian order.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy)]
 #[repr(C)] // This helps with encoding because rust does not respect the order in structs, so in
            // this case we want to keep the order
 pub struct WalHeader {
@@ -190,7 +190,7 @@ pub struct WalHeader {
 /// Each frame consists of a 24-byte frame-header followed by <page-size> bytes of page data.
 /// The frame-header is six big-endian 32-bit unsigned integer values, as follows:
 #[allow(dead_code)]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct WalFrameHeader {
     /// Page number
     page_number: u32,
@@ -296,8 +296,8 @@ fn finish_read_database_header(
 }
 
 pub fn begin_write_database_header(header: &DatabaseHeader, pager: &Pager) -> Result<()> {
-    let header = Rc::new(header.clone());
     let page_source = pager.page_io.clone();
+    let header = Rc::new(header.clone());
 
     let drop_fn = Rc::new(|_buf| {});
     #[allow(clippy::arc_with_non_send_sync)]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -26,7 +26,7 @@ pub const NO_LOCK: u32 = 0;
 pub const SHARED_LOCK: u32 = 1;
 pub const WRITE_LOCK: u32 = 2;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct CheckpointResult {
     /// number of frames in WAL
     pub num_wal_frames: u64,
@@ -43,7 +43,7 @@ impl CheckpointResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum CheckpointMode {
     Passive,
     Full,
@@ -199,6 +199,7 @@ pub enum CheckpointState {
     Done,
 }
 
+#[derive(Debug, Copy, Clone)]
 pub enum CheckpointStatus {
     Done(CheckpointResult),
     IO,


### PR DESCRIPTION
Tried to keep this as small and focused as possible, just a few that I ran into while debugging the page cache