### PR TITLE
bindings/rust: Fix rust bindings so example runs

### DIFF
--- a/bindings/rust/src/value.rs
+++ b/bindings/rust/src/value.rs
@@ -110,6 +110,18 @@ impl Value {
     }
 }
 
+impl Into<limbo_core::OwnedValue> for Value {
+    fn into(self) -> limbo_core::OwnedValue {
+        match self {
+            Value::Null => limbo_core::OwnedValue::Null,
+            Value::Integer(n) => limbo_core::OwnedValue::Integer(n),
+            Value::Real(n) => limbo_core::OwnedValue::Float(n),
+            Value::Text(t) => limbo_core::OwnedValue::from_text(&t),
+            Value::Blob(items) => limbo_core::OwnedValue::from_blob(items),
+        }
+    }
+}
+
 impl From<i8> for Value {
     fn from(value: i8) -> Value {
         Value::Integer(value as i64)

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -542,6 +542,10 @@ impl Statement {
             .step(&mut self.state, self.mv_store.clone(), self.pager.clone())
     }
 
+    pub fn run_once(&self) -> Result<()> {
+        self.pager.io.run_once()
+    }
+
     pub fn num_columns(&self) -> usize {
         self.program.result_columns.len()
     }


### PR DESCRIPTION
Fixes the rust bindings so that `example.rs` is runnable