### PR TITLE
Lazily parse records

### DIFF
--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -1,7 +1,7 @@
-use crate::types::Record;
+use crate::types::LazyRecord;
 
 pub struct PseudoCursor {
-    current: Option<Record>,
+    current: Option<LazyRecord>,
 }
 
 impl PseudoCursor {
@@ -9,11 +9,11 @@ impl PseudoCursor {
         Self { current: None }
     }
 
-    pub fn record(&self) -> Option<&Record> {
+    pub fn record(&self) -> Option<&LazyRecord> {
         self.current.as_ref()
     }
 
-    pub fn insert(&mut self, record: Record) {
+    pub fn insert(&mut self, record: LazyRecord) {
         self.current = Some(record);
     }
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -468,10 +468,6 @@ impl Record {
         T::from_value(value)
     }
 
-    pub fn count(&self) -> usize {
-        self.values.len()
-    }
-
     pub fn last_value(&self) -> Option<&OwnedValue> {
         self.values.last()
     }

--- a/core/types.rs
+++ b/core/types.rs
@@ -495,7 +495,9 @@ impl LazyRecord {
     fn parse_if_needed(&self) -> Result<()> {
         if self.parsed_record.get().is_none() {
             if let Some(data) = &self.raw_data {
-                let _ = self.parsed_record.set(read_record(data)?);
+                self.parsed_record
+                    .set(read_record(data)?)
+                    .expect("can't set parsed_record twice");
             } else {
                 unreachable!();
             }

--- a/core/types.rs
+++ b/core/types.rs
@@ -507,11 +507,6 @@ impl LazyRecord {
         Ok(())
     }
 
-    pub fn get<'a, T: FromValue<'a> + 'a>(&'a self, idx: usize) -> Result<T> {
-        self.parse_if_needed()?;
-        self.parsed_record.get().unwrap().get::<T>(idx)
-    }
-
     pub fn last_value(&self) -> Result<Option<&OwnedValue>> {
         self.parse_if_needed()?;
         Ok(self.parsed_record.get().unwrap().last_value())
@@ -546,12 +541,6 @@ impl LazyRecord {
             parsed_record: OnceCell::new(),
             raw_data: Some(data),
         }
-    }
-
-    pub fn serialize(&self, buf: &mut Vec<u8>) -> Result<()> {
-        self.parse_if_needed()?;
-        self.parsed_record.get().unwrap().serialize(buf);
-        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR implements lazy record parsing, as mentioned in #881

- Created `LazyRecord` that can be initialized lazily (with just a raw unparsed `Vec<u8>`), and also store a parsed record
- `BTreeCursor` (and `PseudoCursor`) now store a `LazyRecord` instead of a parsed `Record`
- Instead of calling `read_record` for parsing in `btree.rs`, methods of `LazyRecord` call `read_record` under the hood only when the raw data needs to be parsed
  - There are still some places in `btree.rs` where parsing is needed, for example:
    - (lines 465-467) Calling `record.get_values()?` for comparison with `index_key`
    - (line 453) Calling `record.last_value()?` for matching on `row_id`)
- Once the `LazyRecord` is parsed once, the parsed record is stored in the `parsed_record` field