### PR TITLE
Enable async IO in vfs extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,7 @@ dependencies = [
  "limbo_ext",
  "log",
  "mimalloc",
+ "tokio",
 ]
 
 [[package]]
@@ -3251,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,6 +1720,7 @@ name = "limbo_ext_tests"
 version = "0.0.16"
 dependencies = [
  "env_logger 0.11.6",
+ "futures",
  "lazy_static",
  "limbo_ext",
  "log",

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -54,6 +54,11 @@ impl IO for VfsMod {
     }
 }
 
+unsafe extern "C" fn callback(result: i32, user_data: *mut c_void) {
+    let completion = Box::from_raw(user_data as *mut Completion);
+    completion.complete(result);
+}
+
 impl File for VfsFileImpl {
     fn lock_file(&self, exclusive: bool) -> Result<()> {
         let vfs = unsafe { &*self.vfs };
@@ -77,22 +82,14 @@ impl File for VfsFileImpl {
     }
 
     fn pread(&self, pos: usize, c: Completion) -> Result<()> {
-        let r = match &c {
-            Completion::Read(ref r) => r,
-            _ => unreachable!(),
-        };
-        let result = {
-            let mut buf = r.buf_mut();
-            let count = buf.len();
-            let vfs = unsafe { &*self.vfs };
-            unsafe { (vfs.read)(self.file, buf.as_mut_ptr(), count, pos as i64) }
-        };
-        if result < 0 {
-            Err(LimboError::ExtensionError("pread failed".to_string()))
-        } else {
-            c.complete(result);
-            Ok(())
-        }
+        let r = c.as_read();
+        let len = r.buf().len();
+        let buf = r.buf_mut().as_mut_slice().as_mut_ptr();
+        let vfs = unsafe { &*self.vfs };
+        let ctx = Box::into_raw(Box::new(c)) as *mut c_void;
+        let cb = limbo_ext::IOCallback::new(callback, ctx);
+        unsafe { (vfs.read)(self.file, buf, len, pos as i64, cb) };
+        Ok(())
     }
 
     fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion) -> Result<()> {
@@ -102,32 +99,28 @@ impl File for VfsFileImpl {
             return Err(LimboError::ExtensionError("VFS is null".to_string()));
         }
         let vfs = unsafe { &*self.vfs };
-        let result = unsafe {
+        let ctx = Box::into_raw(Box::new(c)) as *mut c_void;
+        // buffer is ManuallyDrop so it's safe to pass a pointer to an extension
+        // without incrementing the strong count of our Arc
+        let cb = limbo_ext::IOCallback::new(callback, ctx);
+        unsafe {
             (vfs.write)(
                 self.file,
                 buf.as_slice().as_ptr() as *mut u8,
                 count,
                 pos as i64,
+                cb,
             )
         };
-
-        if result < 0 {
-            Err(LimboError::ExtensionError("pwrite failed".to_string()))
-        } else {
-            c.complete(result);
-            Ok(())
-        }
+        Ok(())
     }
 
     fn sync(&self, c: Completion) -> Result<()> {
         let vfs = unsafe { &*self.vfs };
-        let result = unsafe { (vfs.sync)(self.file) };
-        if result < 0 {
-            Err(LimboError::ExtensionError("sync failed".to_string()))
-        } else {
-            c.complete(0);
-            Ok(())
-        }
+        let ctx = Box::into_raw(Box::new(c)) as *mut c_void;
+        let cb = limbo_ext::IOCallback::new(callback, ctx);
+        unsafe { (vfs.sync)(self.file, cb) };
+        Ok(())
     }
 
     fn size(&self) -> Result<u64> {

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -90,7 +90,7 @@ impl File for VfsFileImpl {
         if result < 0 {
             Err(LimboError::ExtensionError("pread failed".to_string()))
         } else {
-            c.complete(0);
+            c.complete(result);
             Ok(())
         }
     }

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     os::raw::{c_char, c_void},
 };
 pub use types::{ResultCode, Value, ValueType};
-pub use vfs_modules::{RegisterVfsFn, VfsFileImpl, VfsImpl};
+pub use vfs_modules::{BufferRef, CallbackFn, IOCallback, RegisterVfsFn, VfsFileImpl, VfsImpl};
 #[cfg(not(target_family = "wasm"))]
 pub use vfs_modules::{VfsExtension, VfsFile};
 

--- a/extensions/core/src/vfs_modules.rs
+++ b/extensions/core/src/vfs_modules.rs
@@ -40,7 +40,7 @@ pub trait VfsFile: Send + Sync {
     fn size(&self) -> i64;
 }
 
-/// a safe wrapper around the raw `*mut u8` buffer for extensions.
+/// a wrapper around the raw `*mut u8` buffer for extensions.
 /// core owns the underlying ManuallyDrop<Pin<Buffer>>
 #[derive(Debug)]
 #[repr(C)]
@@ -117,20 +117,19 @@ pub struct IOCallback {
     pub callback: CallbackFn,
     pub ctx: SendPtr,
 }
-
 unsafe impl Send for IOCallback {}
-unsafe impl Sync for IOCallback {}
 
 #[repr(transparent)]
+/// Wrapper type to support creating Box<dyn FnOnce()+Send> obj
+/// that needs to call a C function with an opaque pointer.
 pub struct SendPtr(*mut c_void);
+unsafe impl Send for SendPtr {}
 
 impl SendPtr {
     pub unsafe fn as_ptr(&self) -> *mut c_void {
         self.0
     }
 }
-unsafe impl Send for SendPtr {}
-unsafe impl Sync for SendPtr {}
 
 impl IOCallback {
     pub fn new(cb: CallbackFn, ctx: *mut c_void) -> Self {

--- a/extensions/tests/Cargo.toml
+++ b/extensions/tests/Cargo.toml
@@ -14,10 +14,11 @@ static= [ "limbo_ext/static" ]
 
 [dependencies]
 env_logger = "0.11.6"
+futures = "0.3.31"
 lazy_static = "1.5.0"
 limbo_ext = { workspace = true, features = ["static"] }
 log = "0.4.26"
-tokio = { version = "1.44.1", features = ["rt", "time"]}
+tokio = { version = "1.44.1", features = ["rt", "time", "macros"]}
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 mimalloc = { version = "0.1", default-features = false }

--- a/extensions/tests/Cargo.toml
+++ b/extensions/tests/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = "0.11.6"
 lazy_static = "1.5.0"
 limbo_ext = { workspace = true, features = ["static"] }
 log = "0.4.26"
+tokio = { version = "1.44.1", features = ["rt", "time"]}
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 mimalloc = { version = "0.1", default-features = false }

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -255,9 +255,9 @@ pub struct AsyncTestVFS;
 
 const PAGE_SIZE: usize = 4096;
 
-// This is just essentially the MemoryIO in core/io/memory.rs
-// with tokio + 'sleep's added to simulate async network IO
-// to ensure that we can support something like a S3 backend
+// NOTE: This dummy extension is just the MemoryIO in core/io/memory.rs
+// with tokio and 'sleep's added to simulate slow network IO
+// to ensure that we can truly support async IO with something like a S3 backend
 #[cfg(not(target_family = "wasm"))]
 #[derive(Default, VfsDerive)]
 pub struct AsyncTestVFS;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -729,19 +729,18 @@ pub fn derive_vfs_module(input: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        pub unsafe extern "C" fn #read_fn_name(file_ptr: *const ::std::ffi::c_void, buf: *mut u8, count: usize, offset: i64, cb: ::limbo_ext::IOCallback) {
+        pub unsafe extern "C" fn #read_fn_name(file_ptr: *const ::std::ffi::c_void, buf: ::limbo_ext::BufferRef, offset: i64, cb: ::limbo_ext::IOCallback) {
             if file_ptr.is_null() {
-                (cb.callback)(-1, cb.ctx);
+                (cb.callback)(-1, cb.ctx.as_ptr());
                 return;
             }
-            let callback = move | res: i32| {
-                (cb.callback)(res, cb.ctx);
-            };
+            let callback: ::std::boxed::Box<dyn FnOnce(i32) + Send> = ::std::boxed::Box::new(move | res: i32| {
+                (cb.callback)(res, cb.ctx.as_ptr());
+            });
             let vfs_file: &mut ::limbo_ext::VfsFileImpl = &mut *(file_ptr as *mut ::limbo_ext::VfsFileImpl);
-            let buff_ref = ::limbo_ext::BufferRef::new(buf, count);
             let file: &mut <#struct_name as ::limbo_ext::VfsExtension>::File =
                 &mut *(vfs_file.file as *mut <#struct_name as ::limbo_ext::VfsExtension>::File);
-            <#struct_name as ::limbo_ext::VfsExtension>::File::read(file, buff_ref, offset, callback);
+            <#struct_name as ::limbo_ext::VfsExtension>::File::read(file, buf, offset, callback);
         }
 
         #[no_mangle]
@@ -757,19 +756,18 @@ pub fn derive_vfs_module(input: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        pub unsafe extern "C" fn #write_fn_name(file_ptr: *const ::std::ffi::c_void, buf: *const u8, count: usize, offset: i64, cb: ::limbo_ext::IOCallback) {
+        pub unsafe extern "C" fn #write_fn_name(file_ptr: *const ::std::ffi::c_void, buf: ::limbo_ext::BufferRef, offset: i64, cb: ::limbo_ext::IOCallback) {
             if file_ptr.is_null() {
-                (cb.callback)(-1, cb.ctx);
+                (cb.callback)(-1, cb.ctx.as_ptr());
                 return;
             }
-            let callback = move | res: i32| {
-                (cb.callback)(res, cb.ctx);
-            };
+            let callback: ::std::boxed::Box<dyn FnOnce(i32) + Send> = ::std::boxed::Box::new(move | res: i32| {
+                (cb.callback)(res, cb.ctx.as_ptr());
+            });
             let vfs_file: &mut ::limbo_ext::VfsFileImpl = &mut *(file_ptr as *mut ::limbo_ext::VfsFileImpl);
-            let buff_ref = ::limbo_ext::BufferRef::new(buf as *mut u8, count);
             let file: &mut <#struct_name as ::limbo_ext::VfsExtension>::File =
                 &mut *(vfs_file.file as *mut <#struct_name as ::limbo_ext::VfsExtension>::File);
-            <#struct_name as ::limbo_ext::VfsExtension>::File::write(file, buff_ref, offset, callback);
+            <#struct_name as ::limbo_ext::VfsExtension>::File::write(file, buf, offset, callback);
         }
 
         #[no_mangle]
@@ -803,12 +801,12 @@ pub fn derive_vfs_module(input: TokenStream) -> TokenStream {
         #[no_mangle]
         pub unsafe extern "C" fn #sync_fn_name(file_ptr: *const ::std::ffi::c_void, cb: ::limbo_ext::IOCallback) {
             if file_ptr.is_null() {
-                (cb.callback)(-1, cb.ctx);
+                (cb.callback)(-1, cb.ctx.as_ptr());
                 return;
             }
-            let callback = move || {
-                (cb.callback)(0, cb.ctx);
-            };
+            let callback: ::std::boxed::Box<dyn FnOnce() + Send> = ::std::boxed::Box::new(move || {
+               (cb.callback)(0, cb.ctx.as_ptr());
+            });
             let vfs_file: &mut ::limbo_ext::VfsFileImpl = &mut *(file_ptr as *mut ::limbo_ext::VfsFileImpl);
             let file: &mut <#struct_name as ::limbo_ext::VfsExtension>::File =
                 &mut *(vfs_file.file as *mut <#struct_name as ::limbo_ext::VfsExtension>::File);

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -481,17 +481,32 @@ def test_vfs():
     limbo.execute_dot(".open testing/vfs.db testvfs")
     limbo.execute_dot("create table test (id integer primary key, value float);")
     limbo.execute_dot("create table vfs (id integer primary key, value blob);")
-    for i in range(50):
-        limbo.execute_dot("insert into test (value) values (randomblob(32*1024));")
+    for i in range(500):
+        limbo.execute_dot("insert into test (value) values (randomblob(1024));")
         limbo.execute_dot(f"insert into vfs (value) values ({i});")
     limbo.run_test_fn(
         "SELECT count(*) FROM test;",
-        lambda res: res == "50",
+        lambda res: res == "500",
         "Tested large write to testfs",
     )
     limbo.run_test_fn(
         "SELECT count(*) FROM vfs;",
-        lambda res: res == "50",
+        lambda res: res == "500",
+        "Tested large write to testfs",
+    )
+    limbo.execute_dot("create table test2 (id integer primary key, value float);")
+    limbo.execute_dot("create table vfs2 (id integer primary key, value blob);")
+    for i in range(500):
+        limbo.execute_dot("insert into test2 (value) values (randomblob(1024));")
+        limbo.execute_dot(f"insert into vfs2 (value) values ({i});")
+    limbo.run_test_fn(
+        "SELECT count(*) FROM test2;",
+        lambda res: res == "500",
+        "Tested large write to testfs",
+    )
+    limbo.run_test_fn(
+        "SELECT count(*) FROM vfs2;",
+        lambda res: res == "500",
         "Tested large write to testfs",
     )
     print("Tested large write to testfs")
@@ -520,13 +535,20 @@ def test_sqlite_vfs_compat():
     )
     sqlite.run_test_fn(
         "SELECT count(*) FROM test;",
-        lambda res: res == "50",
-        "Tested large write to testfs",
+        lambda res: res == "500",
     )
     sqlite.run_test_fn(
         "SELECT count(*) FROM vfs;",
-        lambda res: res == "50",
-        "Tested large write to testfs",
+        lambda res: res == "500",
+    )
+    sqlite.run_test_fn(
+        "SELECT count(*) FROM test2;",
+        lambda res: res == "500",
+        "Tested sqlite vfs compat",
+    )
+    sqlite.run_test_fn(
+        "SELECT count(*) FROM vfs2;",
+        lambda res: res == "500",
     )
     sqlite.quit()
 


### PR DESCRIPTION
This PR adds and exposes a completion callback API to vfs extensions, allowing for async IO operations.

It also adds much more thorough tests, to ensure that sqlite can properly read .db files created with a vfs ext, ensuring no corruption.

@pedrocarlo pointed this out while drafting an extension, and I realized that although the `run_once` was exposed, the completion callbacks were being called synchronously :man_facepalming: 


This also includes an async dummy module added to the `limbo_ext_tests` extension, which is intentionally extremely slow and naive, to simulate very high network latency be sure that we could support something like an s3 backend using this setup, and that all the primitives work properly. 