### PR TITLE
fragment bench functions

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -11,7 +11,7 @@ fn rusqlite_open() -> rusqlite::Connection {
     sqlite_conn
 }
 
-fn bench(criterion: &mut Criterion) {
+fn bench_prepare_query(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/limbo/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
@@ -30,82 +30,124 @@ fn bench(criterion: &mut Criterion) {
     for query in queries.iter() {
         let mut group = criterion.benchmark_group(format!("Prepare `{}`", query));
 
-        group.bench_with_input(BenchmarkId::new("Limbo", query), query, |b, query| {
-            b.iter(|| {
-                limbo_conn.prepare(query).unwrap();
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::new("limbo_parse_query", query),
+            query,
+            |b, query| {
+                b.iter(|| {
+                    limbo_conn.prepare(query).unwrap();
+                });
+            },
+        );
 
         if enable_rusqlite {
             let sqlite_conn = rusqlite_open();
 
-            group.bench_with_input(BenchmarkId::new("Sqlite3", query), query, |b, query| {
-                b.iter(|| {
-                    sqlite_conn.prepare(query).unwrap();
-                });
-            });
+            group.bench_with_input(
+                BenchmarkId::new("sqlite_parse_query", query),
+                query,
+                |b, query| {
+                    b.iter(|| {
+                        sqlite_conn.prepare(query).unwrap();
+                    });
+                },
+            );
         }
 
         group.finish();
     }
+}
+
+fn bench_execute_select_rows(criterion: &mut Criterion) {
+    // https://github.com/tursodatabase/limbo/issues/174
+    // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
+    let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
+
+    #[allow(clippy::arc_with_non_send_sync)]
+    let io = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT * FROM users LIMIT ?`");
 
     for i in [1, 10, 50, 100] {
-        group.bench_with_input(BenchmarkId::new("Limbo", i), &i, |b, i| {
-            // TODO: LIMIT doesn't support query parameters.
-            let mut stmt = limbo_conn
-                .prepare(format!("SELECT * FROM users LIMIT {}", *i))
-                .unwrap();
-            let io = io.clone();
-            b.iter(|| {
-                loop {
-                    match stmt.step().unwrap() {
-                        limbo_core::StepResult::Row => {}
-                        limbo_core::StepResult::IO => {
-                            let _ = io.run_once();
-                        }
-                        limbo_core::StepResult::Done => {
-                            break;
-                        }
-                        limbo_core::StepResult::Interrupt | limbo_core::StepResult::Busy => {
-                            unreachable!();
+        group.bench_with_input(
+            BenchmarkId::new("limbo_execute_select_rows", i),
+            &i,
+            |b, i| {
+                // TODO: LIMIT doesn't support query parameters.
+                let mut stmt = limbo_conn
+                    .prepare(format!("SELECT * FROM users LIMIT {}", *i))
+                    .unwrap();
+                let io = io.clone();
+                b.iter(|| {
+                    loop {
+                        match stmt.step().unwrap() {
+                            limbo_core::StepResult::Row => {
+                                black_box(stmt.row());
+                            }
+                            limbo_core::StepResult::IO => {
+                                let _ = io.run_once();
+                            }
+                            limbo_core::StepResult::Done => {
+                                break;
+                            }
+                            limbo_core::StepResult::Interrupt | limbo_core::StepResult::Busy => {
+                                unreachable!();
+                            }
                         }
                     }
-                }
-                stmt.reset();
-            });
-        });
+                    stmt.reset();
+                });
+            },
+        );
 
         if enable_rusqlite {
             let sqlite_conn = rusqlite_open();
 
-            group.bench_with_input(BenchmarkId::new("Sqlite3", i), &i, |b, i| {
-                // TODO: Use parameters once we fix the above.
-                let mut stmt = sqlite_conn
-                    .prepare(&format!("SELECT * FROM users LIMIT {}", *i))
-                    .unwrap();
-                b.iter(|| {
-                    let mut rows = stmt.raw_query();
-                    while let Some(row) = rows.next().unwrap() {
-                        black_box(row);
-                    }
-                });
-            });
+            group.bench_with_input(
+                BenchmarkId::new("sqlite_execute_select_rows", i),
+                &i,
+                |b, i| {
+                    // TODO: Use parameters once we fix the above.
+                    let mut stmt = sqlite_conn
+                        .prepare(&format!("SELECT * FROM users LIMIT {}", *i))
+                        .unwrap();
+                    b.iter(|| {
+                        let mut rows = stmt.raw_query();
+                        while let Some(row) = rows.next().unwrap() {
+                            black_box(row);
+                        }
+                    });
+                },
+            );
         }
     }
 
     group.finish();
+}
+
+fn bench_execute_select_1(criterion: &mut Criterion) {
+    // https://github.com/tursodatabase/limbo/issues/174
+    // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
+    let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
+
+    #[allow(clippy::arc_with_non_send_sync)]
+    let io = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT 1`");
 
-    group.bench_function("Limbo", |b| {
+    group.bench_function("limbo_execute_select_1", |b| {
         let mut stmt = limbo_conn.prepare("SELECT 1").unwrap();
         let io = io.clone();
         b.iter(|| {
             loop {
                 match stmt.step().unwrap() {
-                    limbo_core::StepResult::Row => {}
+                    limbo_core::StepResult::Row => {
+                        black_box(stmt.row());
+                    }
                     limbo_core::StepResult::IO => {
                         let _ = io.run_once();
                     }
@@ -124,7 +166,7 @@ fn bench(criterion: &mut Criterion) {
     if enable_rusqlite {
         let sqlite_conn = rusqlite_open();
 
-        group.bench_function("Sqlite3", |b| {
+        group.bench_function("sqlite_execute_select_1", |b| {
             let mut stmt = sqlite_conn.prepare("SELECT 1").unwrap();
             b.iter(|| {
                 let mut rows = stmt.raw_query();
@@ -141,6 +183,6 @@ fn bench(criterion: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench
+    targets = bench_prepare_query, bench_execute_select_1, bench_execute_select_rows
 }
 criterion_main!(benches);


### PR DESCRIPTION
Easier to run now with:

```
cargo bench -- "execute_select_rows/50"
```