### PR TITLE
chore: gitignore files with an extension *.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 .tmp/
 
 
+*.db
 **/*.db-wal
 **/*.db-shm
 **/*-wal


### PR DESCRIPTION
For example the commmand `cargo run --package limbo_cli --bin limbo database.db` will generate a `database.db` file, and it's unlikely we'll ever need to track such files **if they are placed inside the root of the project**.