### PR TITLE
Improve Python bindings

### DIFF
--- a/bindings/python/example.py
+++ b/bindings/python/example.py
@@ -1,6 +1,35 @@
 import limbo
 
-con = limbo.connect("sqlite.db")
-cur = con.cursor()
-res = cur.execute("SELECT * FROM users")
-print(res.fetchone())
+# Use the context manager to automatically close the connection
+with limbo.connect("sqlite.db") as con:
+    cur = con.cursor()
+    cur.execute("""
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL,
+                email TEXT NOT NULL,
+                role TEXT NOT NULL,
+                created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+            )
+        """)
+
+    # Insert some sample data
+    sample_users = [
+         ("alice", "alice@example.com", "admin"),
+         ("bob", "bob@example.com", "user"),
+         ("charlie", "charlie@example.com", "moderator"),
+         ("diana", "diana@example.com", "user")
+     ]
+    for username, email, role in sample_users:
+         cur.execute("""
+             INSERT INTO users (username, email, role)
+             VALUES (?, ?, ?)
+         """, (username, email, role))
+
+    # Use commit to ensure the data is saved
+    con.commit()
+
+    # Query the table
+    res = cur.execute("SELECT * FROM users")
+    record = res.fetchone()
+    print(record)

--- a/bindings/python/example.py
+++ b/bindings/python/example.py
@@ -15,16 +15,19 @@ with limbo.connect("sqlite.db") as con:
 
     # Insert some sample data
     sample_users = [
-         ("alice", "alice@example.com", "admin"),
-         ("bob", "bob@example.com", "user"),
-         ("charlie", "charlie@example.com", "moderator"),
-         ("diana", "diana@example.com", "user")
-     ]
+        ("alice", "alice@example.com", "admin"),
+        ("bob", "bob@example.com", "user"),
+        ("charlie", "charlie@example.com", "moderator"),
+        ("diana", "diana@example.com", "user"),
+    ]
     for username, email, role in sample_users:
-         cur.execute("""
+        cur.execute(
+            """
              INSERT INTO users (username, email, role)
              VALUES (?, ?, ?)
-         """, (username, email, role))
+         """,
+            (username, email, role),
+        )
 
     # Use commit to ensure the data is saved
     con.commit()

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -266,6 +266,19 @@ impl Connection {
             "Transactions are not supported in this version",
         ))
     }
+
+    fn __enter__(&self) -> PyResult<Self> {
+        Ok(self.clone())
+    }
+
+    fn __exit__(
+        &self,
+        _exc_type: Option<&Bound<'_, PyAny>>,
+        _exc_val: Option<&Bound<'_, PyAny>>,
+        _exc_tb: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<()> {
+        self.close()
+    }
 }
 
 #[allow(clippy::arc_with_non_send_sync)]

--- a/bindings/python/tests/test_database.py
+++ b/bindings/python/tests/test_database.py
@@ -144,17 +144,19 @@ def test_commit(provider):
     conn.close()
     assert record
 
+
 @pytest.mark.parametrize("provider", ["sqlite3", "limbo"])
 def test_with_statement(provider):
     with connect(provider, "tests/database.db") as conn:
         conn = connect(provider, "tests/database.db")
         cursor = conn.cursor()
         cursor.execute("SELECT MAX(id) FROM users")
-    
+
         max_id = cursor.fetchone()
-    
+
         assert max_id
         assert max_id == (2,)
+
 
 def connect(provider, database):
     if provider == "limbo":

--- a/bindings/python/tests/test_database.py
+++ b/bindings/python/tests/test_database.py
@@ -144,6 +144,17 @@ def test_commit(provider):
     conn.close()
     assert record
 
+@pytest.mark.parametrize("provider", ["sqlite3", "limbo"])
+def test_with_statement(provider):
+    with connect(provider, "tests/database.db") as conn:
+        conn = connect(provider, "tests/database.db")
+        cursor = conn.cursor()
+        cursor.execute("SELECT MAX(id) FROM users")
+    
+        max_id = cursor.fetchone()
+    
+        assert max_id
+        assert max_id == (2,)
 
 def connect(provider, database):
     if provider == "limbo":


### PR DESCRIPTION
Yet another PR to close #494.

While testing the code provided in the issue I noticed that it wasn't closing the connection as it should, leading to lifetime issues like: `Connection is unsendable, but is being dropped on another thread`. The following code works fine:

```python
import limbo

def main():
    con = limbo.connect("test.db")
    cur = con.cursor()

    try:
        cur.execute("""
            CREATE TABLE IF NOT EXISTS users (
                id INTEGER PRIMARY KEY AUTOINCREMENT,
                username TEXT NOT NULL,
                email TEXT NOT NULL,
                role TEXT NOT NULL,
                created_at DATETIME NOT NULL DEFAULT (datetime('now'))
            )
        """)

        # Insert some sample data
        sample_users = [
            ("alice", "alice@example.com", "admin"),
            ("bob", "bob@example.com", "user"),
            ("charlie", "charlie@example.com", "moderator"),
            ("diana", "diana@example.com", "user")
        ]

        for username, email, role in sample_users:
            cur.execute("""
                INSERT INTO users (username, email, role)
                VALUES (?, ?, ?)
            """, (username, email, role))

        con.commit()

        # Query the table
        res = cur.execute("SELECT * FROM users")
        record = res.fetchone()
        print(record)

    finally: 
        # Ensure connection is closed on the same thread <----
        con.close()
        pass


main()
``` 
You can test it [here](https://colab.research.google.com/drive/1NJau6Y9HTRJrnYK_xp2AzwP_qEH8VsQx?usp=sharing)

To address these issues, this PR:
- Adds support for `with statement` a common resource management pattern in Python;
- Close connection if it is dropped