### PR TITLE
Expose 'Explain' to prepared statement to allow for alternate Writer  

### DIFF
--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -5,6 +5,8 @@ use std::{
     sync::Arc,
 };
 
+use limbo_sqlite3_parser::ast;
+
 use crate::{
     fast_lock::SpinLock,
     parameters::Parameters,
@@ -56,6 +58,15 @@ impl CursorType {
 pub enum QueryMode {
     Normal,
     Explain,
+}
+
+impl From<ast::Cmd> for QueryMode {
+    fn from(stmt: ast::Cmd) -> Self {
+        match stmt {
+            ast::Cmd::ExplainQueryPlan(_) | ast::Cmd::Explain(_) => QueryMode::Explain,
+            _ => QueryMode::Normal,
+        }
+    }
 }
 
 pub struct ProgramBuilderOpts {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -346,9 +346,11 @@ pub struct Program {
 }
 
 impl Program {
-    pub fn explain(&self) {
-        println!("addr  opcode             p1    p2    p3    p4             p5  comment");
-        println!("----  -----------------  ----  ----  ----  -------------  --  -------");
+    #[rustfmt::skip]
+    pub fn explain(&self) -> String {
+        let mut buff = String::with_capacity(1024);
+        buff.push_str("addr  opcode             p1    p2    p3    p4             p5  comment\n");
+        buff.push_str("----  -----------------  ----  ----  ----  -------------  --  -------\n");
         let mut indent_count: usize = 0;
         let indent = "  ";
         let mut prev_insn: Option<&Insn> = None;
@@ -359,9 +361,12 @@ impl Program {
                 addr as InsnReference,
                 insn,
                 indent.repeat(indent_count),
+                &mut buff,
             );
+            buff.push('\n');
             prev_insn = Some(insn);
         }
+        buff
     }
 
     #[instrument(skip_all)]
@@ -3389,7 +3394,7 @@ fn trace_insn(program: &Program, addr: InsnReference, insn: &Insn) {
     );
 }
 
-fn print_insn(program: &Program, addr: InsnReference, insn: &Insn, indent: String) {
+fn print_insn(program: &Program, addr: InsnReference, insn: &Insn, indent: String, w: &mut String) {
     let s = explain::insn_to_str(
         program,
         addr,
@@ -3400,7 +3405,7 @@ fn print_insn(program: &Program, addr: InsnReference, insn: &Insn, indent: Strin
             .as_ref()
             .and_then(|comments| comments.get(&{ addr }).copied()),
     );
-    println!("{}", s);
+    w.push_str(&s);
 }
 
 fn get_indent_count(indent_count: usize, curr_insn: &Insn, prev_insn: Option<&Insn>) -> usize {


### PR DESCRIPTION
### The problem:

I often need to copy the output of an `Explain` statement to my clipboard. Currently this is not possible because it currently will only write to stdout.

All other limbo output, I am able to run `.output file` in the CLI, then enter my query and in another tmux pane I simply `cat file | xclip -in -selection clipboard`.

### The solution:

Expose a `statement.explain()` method that returns the query explanation as a string. If the user uses something like `execute` instead of prepare, it will default to `stdout` as expected, but this allows the user to access the query plan on the prepared statement and do with it what they please. 