### PR TITLE
Fix `compute_shl` negate with overflow

### DIFF
--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -975,7 +975,15 @@ pub fn exec_shift_left(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue
 }
 
 fn compute_shl(lhs: i64, rhs: i64) -> i64 {
-    compute_shr(lhs, -rhs)
+    if rhs == 0 {
+        lhs
+    } else if rhs >= 64 || rhs <= -64 {
+        0
+    } else if rhs > 0 {
+        lhs << rhs
+    } else {
+        lhs >> -rhs
+    }
 }
 
 pub fn exec_shift_right(mut lhs: &OwnedValue, mut rhs: &OwnedValue) -> OwnedValue {

--- a/testing/select.test
+++ b/testing/select.test
@@ -211,3 +211,7 @@ do_execsql_test select_shl_numeric_types {
     SELECT 1.0 << 2;
     SELECT 1.5 << 2;
 } {4 4 4}
+
+do execsql_test select_fuzz_failure_case {
+  SELECT (-9 << ((-6) << (9)) >> ((5)) % -10 - + - (-9));
+}{-16}

--- a/testing/select.test
+++ b/testing/select.test
@@ -194,3 +194,20 @@ do_execsql_test select_shl_large_shifts {
     SELECT -1 << 62, -1 << 63, -1 << 64;
 } {4611686018427387904|-9223372036854775808|0
 -4611686018427387904|-9223372036854775808|0}
+
+do_execsql_test select_shl_text_conversion {
+    SELECT '1' << '2';
+    SELECT '8' << '-2';
+    SELECT '-4' << '2';
+} {4 2 -16}
+
+do_execsql_test select_shl_chained {
+    SELECT (1 << 2) << 3;
+    SELECT (2 << 1) << (1 << 1);
+} {32 16}
+
+do_execsql_test select_shl_numeric_types {
+    SELECT CAST(1 AS INTEGER) << 2;
+    SELECT 1.0 << 2;
+    SELECT 1.5 << 2;
+} {4 4 4}

--- a/testing/select.test
+++ b/testing/select.test
@@ -212,6 +212,6 @@ do_execsql_test select_shl_numeric_types {
     SELECT 1.5 << 2;
 } {4 4 4}
 
-do execsql_test select_fuzz_failure_case {
+do_execsql_test select_fuzz_failure_case {
   SELECT (-9 << ((-6) << (9)) >> ((5)) % -10 - + - (-9));
-}{-16}
+} {-16}

--- a/testing/select.test
+++ b/testing/select.test
@@ -165,3 +165,32 @@ do_execsql_test select-not-like-expression {
 do_execsql_test select-like-expression {
     select 2 % 0.5
 } {}
+
+do_execsql_test select_shl_large_negative_float {
+    SELECT 1 << -1e19;
+    SELECT 1 << -9223372036854775808;  -- i64::MIN
+    SELECT 1 << 9223372036854775807;   -- i64::MAX
+} {0 0 0}
+
+do_execsql_test select_shl_basic {
+    SELECT 1 << 0, 1 << 1, 1 << 2, 1 << 3;
+    SELECT 2 << 0, 2 << 1, 2 << 2, 2 << 3;
+} {1|2|4|8
+2|4|8|16}
+
+do_execsql_test select_shl_negative_numbers {
+    SELECT -1 << 0, -1 << 1, -1 << 2, -1 << 3;
+    SELECT -2 << 0, -2 << 1, -2 << 2, -2 << 3;
+} {-1|-2|-4|-8
+-2|-4|-8|-16}
+do_execsql_test select_shl_negative_shifts {
+    SELECT 8 << -1, 8 << -2, 8 << -3, 8 << -4;
+    SELECT -8 << -1, -8 << -2, -8 << -3, -8 << -4;
+} {4|2|1|0
+-4|-2|-1|-1}
+
+do_execsql_test select_shl_large_shifts {
+    SELECT 1 << 62, 1 << 63, 1 << 64;
+    SELECT -1 << 62, -1 << 63, -1 << 64;
+} {4611686018427387904|-9223372036854775808|0
+-4611686018427387904|-9223372036854775808|0}


### PR DESCRIPTION
Fixes #1156 

- Changed `compute_shl` implementation to handle negation with overflow.
- Added TCL tests.