### PR TITLE
Introduce Register struct 

### DIFF
--- a/bindings/go/rs_src/types.rs
+++ b/bindings/go/rs_src/types.rs
@@ -160,7 +160,6 @@ impl LimboValue {
             limbo_core::OwnedValue::Null => {
                 LimboValue::new(ValueType::Null, ValueUnion::from_null())
             }
-            _ => unreachable!(),
         }
     }
 

--- a/bindings/java/rs_src/limbo_statement.rs
+++ b/bindings/java/rs_src/limbo_statement.rs
@@ -116,7 +116,6 @@ fn row_to_obj_array<'local>(
             }
             limbo_core::OwnedValue::Text(s) => env.new_string(s.as_str())?.into(),
             limbo_core::OwnedValue::Blob(b) => env.byte_array_from_slice(&b)?.into(),
-            _ => unreachable!(),
         };
         if let Err(e) = env.set_object_array_element(&obj_array, i as i32, obj) {
             eprintln!("Error on parsing row: {:?}", e);

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -101,7 +101,6 @@ fn to_js_value(env: &napi::Env, value: &limbo_core::OwnedValue) -> JsUnknown {
         limbo_core::OwnedValue::Blob(b) => {
             env.create_buffer_copy(b.as_ref()).unwrap().into_unknown()
         }
-        _ => env.get_null().unwrap().into_unknown(),
     }
 }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -333,7 +333,6 @@ fn row_to_py(py: Python, row: &limbo_core::Row) -> Result<PyObject> {
             limbo_core::OwnedValue::Blob(b) => {
                 py_values.push(PyBytes::new(py, b.as_slice()).into())
             }
-            _ => unreachable!(),
         }
     }
     Ok(PyTuple::new(py, &py_values)

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -236,8 +236,6 @@ impl Row {
             limbo_core::OwnedValue::Float(f) => Ok(Value::Real(*f)),
             limbo_core::OwnedValue::Text(text) => Ok(Value::Text(text.to_string())),
             limbo_core::OwnedValue::Blob(items) => Ok(Value::Blob(items.to_vec())),
-            limbo_core::OwnedValue::Agg(_agg_context) => todo!(),
-            limbo_core::OwnedValue::Record(_record) => todo!(),
         }
     }
 }

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -191,7 +191,6 @@ fn to_js_value(value: &limbo_core::OwnedValue) -> JsValue {
         limbo_core::OwnedValue::Float(f) => JsValue::from(*f),
         limbo_core::OwnedValue::Text(t) => JsValue::from_str(t.as_str()),
         limbo_core::OwnedValue::Blob(b) => js_sys::Uint8Array::from(b.as_slice()).into(),
-        _ => unreachable!(),
     }
 }
 

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -717,7 +717,6 @@ impl<'a> Limbo<'a> {
                                         OwnedValue::Blob(b) => {
                                             format!("{}", String::from_utf8_lossy(b))
                                         }
-                                        _ => unreachable!(),
                                     }
                                     .as_bytes(),
                                 )?;
@@ -784,7 +783,6 @@ impl<'a> Limbo<'a> {
                                             String::from_utf8_lossy(b).to_string(),
                                             CellAlignment::Left,
                                         ),
-                                        _ => unreachable!(),
                                     };
                                     row.add_cell(
                                         Cell::new(content)

--- a/core/types.rs
+++ b/core/types.rs
@@ -76,8 +76,6 @@ pub enum OwnedValue {
     Float(f64),
     Text(Text),
     Blob(Rc<Vec<u8>>),
-    Agg(Box<AggContext>), // TODO(pere): make this without Box. Currently this might cause cache miss but let's leave it for future analysis
-    Record(Record),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -130,8 +128,6 @@ impl OwnedValue {
             OwnedValue::Float(_) => OwnedValueType::Float,
             OwnedValue::Text(_) => OwnedValueType::Text,
             OwnedValue::Blob(_) => OwnedValueType::Blob,
-            OwnedValue::Agg(_) => OwnedValueType::Null, // Map Agg to Null for FFI
-            OwnedValue::Record(_) => OwnedValueType::Null, // Map Record to Null for FFI
         }
     }
 }
@@ -160,18 +156,6 @@ impl Display for OwnedValue {
             Self::Float(fl) => write!(f, "{:?}", fl),
             Self::Text(s) => write!(f, "{}", s.as_str()),
             Self::Blob(b) => write!(f, "{}", String::from_utf8_lossy(b)),
-            Self::Agg(a) => match a.as_ref() {
-                AggContext::Avg(acc, _count) => write!(f, "{}", acc),
-                AggContext::Sum(acc) => write!(f, "{}", acc),
-                AggContext::Count(count) => write!(f, "{}", count),
-                AggContext::Max(max) => write!(f, "{}", max.as_ref().unwrap_or(&Self::Null)),
-                AggContext::Min(min) => write!(f, "{}", min.as_ref().unwrap_or(&Self::Null)),
-                AggContext::GroupConcat(s) => write!(f, "{}", s),
-                AggContext::External(v) => {
-                    write!(f, "{}", v.finalized_value.as_ref().unwrap_or(&Self::Null))
-                }
-            },
-            Self::Record(r) => write!(f, "{:?}", r),
         }
     }
 }
@@ -184,8 +168,6 @@ impl OwnedValue {
             Self::Float(fl) => ExtValue::from_float(*fl),
             Self::Text(text) => ExtValue::from_text(text.as_str().to_string()),
             Self::Blob(blob) => ExtValue::from_blob(blob.to_vec()),
-            Self::Agg(_) => todo!(),
-            Self::Record(_) => todo!("Record values not yet supported"),
         }
     }
 
@@ -290,9 +272,6 @@ impl PartialEq<OwnedValue> for OwnedValue {
             }
             (Self::Blob(blob_left), Self::Blob(blob_right)) => blob_left.eq(blob_right),
             (Self::Null, Self::Null) => true,
-            (Self::Agg(a), Self::Agg(b)) => a.eq(b),
-            (Self::Agg(a), other) => a.final_value().eq(other),
-            (other, Self::Agg(b)) => other.eq(b.final_value()),
             _ => false,
         }
     }
@@ -335,9 +314,6 @@ impl PartialOrd<OwnedValue> for OwnedValue {
             (Self::Null, Self::Null) => Some(std::cmp::Ordering::Equal),
             (Self::Null, _) => Some(std::cmp::Ordering::Less),
             (_, Self::Null) => Some(std::cmp::Ordering::Greater),
-            (Self::Agg(a), Self::Agg(b)) => a.partial_cmp(b),
-            (Self::Agg(a), other) => a.final_value().partial_cmp(other),
-            (other, Self::Agg(b)) => other.partial_cmp(b.final_value()),
             other => todo!("{:?}", other),
         }
     }
@@ -836,8 +812,6 @@ impl From<&OwnedValue> for SerialType {
             OwnedValue::Blob(b) => SerialType::Blob {
                 content_size: b.len(),
             },
-            OwnedValue::Agg(_) => unreachable!(),
-            OwnedValue::Record(_) => unreachable!(),
         }
     }
 }
@@ -896,9 +870,6 @@ impl Record {
                 OwnedValue::Float(f) => buf.extend_from_slice(&f.to_be_bytes()),
                 OwnedValue::Text(t) => buf.extend_from_slice(&t.value),
                 OwnedValue::Blob(b) => buf.extend_from_slice(b),
-                // non serializable
-                OwnedValue::Agg(_) => unreachable!(),
-                OwnedValue::Record(_) => unreachable!(),
             };
         }
 

--- a/core/types.rs
+++ b/core/types.rs
@@ -314,7 +314,6 @@ impl PartialOrd<OwnedValue> for OwnedValue {
             (Self::Null, Self::Null) => Some(std::cmp::Ordering::Equal),
             (Self::Null, _) => Some(std::cmp::Ordering::Less),
             (_, Self::Null) => Some(std::cmp::Ordering::Greater),
-            other => todo!("{:?}", other),
         }
     }
 }
@@ -654,7 +653,6 @@ impl PartialOrd<OwnedValue> for RefValue {
             (Self::Null, OwnedValue::Null) => Some(std::cmp::Ordering::Equal),
             (Self::Null, _) => Some(std::cmp::Ordering::Less),
             (_, OwnedValue::Null) => Some(std::cmp::Ordering::Greater),
-            other => todo!("{:?}", other),
         }
     }
 }
@@ -698,7 +696,6 @@ impl PartialOrd<RefValue> for OwnedValue {
             (Self::Null, RefValue::Null) => Some(std::cmp::Ordering::Equal),
             (Self::Null, _) => Some(std::cmp::Ordering::Less),
             (_, RefValue::Null) => Some(std::cmp::Ordering::Greater),
-            other => todo!("{:?}", other),
         }
     }
 }

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -1,11 +1,12 @@
 use crate::types::OwnedValue;
+use crate::vdbe::Register;
 use crate::LimboError;
 use crate::Result;
 
 pub mod vector_types;
 use vector_types::*;
 
-pub fn vector32(args: &[OwnedValue]) -> Result<OwnedValue> {
+pub fn vector32(args: &[Register]) -> Result<OwnedValue> {
     if args.len() != 1 {
         return Err(LimboError::ConversionError(
             "vector32 requires exactly one argument".to_string(),
@@ -22,7 +23,7 @@ pub fn vector32(args: &[OwnedValue]) -> Result<OwnedValue> {
     }
 }
 
-pub fn vector64(args: &[OwnedValue]) -> Result<OwnedValue> {
+pub fn vector64(args: &[Register]) -> Result<OwnedValue> {
     if args.len() != 1 {
         return Err(LimboError::ConversionError(
             "vector64 requires exactly one argument".to_string(),
@@ -39,14 +40,14 @@ pub fn vector64(args: &[OwnedValue]) -> Result<OwnedValue> {
     }
 }
 
-pub fn vector_extract(args: &[OwnedValue]) -> Result<OwnedValue> {
+pub fn vector_extract(args: &[Register]) -> Result<OwnedValue> {
     if args.len() != 1 {
         return Err(LimboError::ConversionError(
             "vector_extract requires exactly one argument".to_string(),
         ));
     }
 
-    let blob = match &args[0] {
+    let blob = match &args[0].get_owned_value() {
         OwnedValue::Blob(b) => b,
         _ => {
             return Err(LimboError::ConversionError(
@@ -64,7 +65,7 @@ pub fn vector_extract(args: &[OwnedValue]) -> Result<OwnedValue> {
     Ok(OwnedValue::build_text(&vector_to_text(&vector)))
 }
 
-pub fn vector_distance_cos(args: &[OwnedValue]) -> Result<OwnedValue> {
+pub fn vector_distance_cos(args: &[Register]) -> Result<OwnedValue> {
     if args.len() != 2 {
         return Err(LimboError::ConversionError(
             "vector_distance_cos requires exactly two arguments".to_string(),

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -1,4 +1,5 @@
 use crate::types::{OwnedValue, OwnedValueType};
+use crate::vdbe::Register;
 use crate::{LimboError, Result};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -103,11 +104,14 @@ pub fn parse_string_vector(vector_type: VectorType, value: &OwnedValue) -> Resul
     })
 }
 
-pub fn parse_vector(value: &OwnedValue, vec_ty: Option<VectorType>) -> Result<Vector> {
-    match value.value_type() {
-        OwnedValueType::Text => parse_string_vector(vec_ty.unwrap_or(VectorType::Float32), value),
+pub fn parse_vector(value: &Register, vec_ty: Option<VectorType>) -> Result<Vector> {
+    match value.get_owned_value().value_type() {
+        OwnedValueType::Text => parse_string_vector(
+            vec_ty.unwrap_or(VectorType::Float32),
+            value.get_owned_value(),
+        ),
         OwnedValueType::Blob => {
-            let Some(blob) = value.to_blob() else {
+            let Some(blob) = value.get_owned_value().to_blob() else {
                 return Err(LimboError::ConversionError(
                     "Invalid vector value".to_string(),
                 ));

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -501,7 +501,6 @@ impl Interaction {
                                     Value::Text(t.as_str().to_string())
                                 }
                                 limbo_core::OwnedValue::Blob(b) => Value::Blob(b.to_vec()),
-                                _ => unreachable!(),
                             };
                             r.push(v);
                         }

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -572,7 +572,6 @@ pub unsafe extern "C" fn sqlite3_value_type(value: *mut ffi::c_void) -> ffi::c_i
         limbo_core::OwnedValue::Float(_) => 2,
         limbo_core::OwnedValue::Text(_) => 3,
         limbo_core::OwnedValue::Blob(_) => 4,
-        _ => unreachable!(),
     }
 }
 

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -79,7 +79,6 @@ mod tests {
                     limbo_core::OwnedValue::Float(x) => rusqlite::types::Value::Real(*x),
                     limbo_core::OwnedValue::Text(x) => rusqlite::types::Value::Text(x.to_string()),
                     limbo_core::OwnedValue::Blob(x) => rusqlite::types::Value::Blob(x.to_vec()),
-                    _ => unreachable!(),
                 })
                 .collect();
             rows.push(row);


### PR DESCRIPTION
OwnedValue has become a powerhouse of madness, mainly because I decided
to do it like that when I first introduced AggContext. I decided it was
enough and I introduced a `Register` struct that contains `OwnedValue`,
`Record` and `Aggregation`, this way we don't use `OwnedValue` for
everything make everyone's life harder.

This is the next step towards making ImmutableRecords the default
because I want to remove unnecessary allocations. Right now we clone
OwnedValues when we generate a record more than needed.