### PR TITLE
Create plan for Update queries

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -539,20 +539,25 @@ fn emit_update_insns(
                     .iter()
                     .position(|c| Some(&c.name) == table_column.name.as_ref())
             });
-            program.emit_insn(Insn::Column {
-                cursor_id: *index
-                    .as_ref()
-                    .and_then(|(_, id)| {
-                        if column_idx_in_index.is_some() {
-                            Some(id)
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap_or(&cursor_id),
-                column: column_idx_in_index.unwrap_or(idx),
-                dest: first_col_reg + idx,
-            });
+            let dest = first_col_reg + idx;
+            if table_column.primary_key {
+                program.emit_null(dest, None);
+            } else {
+                program.emit_insn(Insn::Column {
+                    cursor_id: *index
+                        .as_ref()
+                        .and_then(|(_, id)| {
+                            if column_idx_in_index.is_some() {
+                                Some(id)
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or(&cursor_id),
+                    column: column_idx_in_index.unwrap_or(idx),
+                    dest,
+                });
+            }
         }
     }
     let record_reg = program.alloc_register();

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -423,6 +423,13 @@ fn emit_program_for_update(
         plan.returning.as_ref().map_or(0, |r| r.len()),
     )?;
 
+    // Exit on LIMIT 0
+    if let Some(0) = plan.limit {
+        epilogue(program, init_label, start_offset, false)?;
+        program.result_columns = plan.returning.unwrap_or_default();
+        program.table_references = plan.table_references;
+        return Ok(());
+    }
     let after_main_loop_label = program.allocate_label();
     t_ctx.label_main_loop_end = Some(after_main_loop_label);
     if plan.contains_constant_false_condition {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -176,7 +176,7 @@ pub struct UpdatePlan {
     pub set_clauses: Vec<(usize, ast::Expr)>,
     pub where_clause: Vec<WhereTerm>,
     pub order_by: Option<Vec<(ast::Expr, Direction)>>,
-    // TODO: full support of optional LIMIT
+    // TODO: support OFFSET
     pub limit: Option<isize>,
     // TODO: optional RETURNING clause
     pub returning: Option<Vec<ResultSetColumn>>,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use limbo_sqlite3_parser::ast::{self, SortOrder};
+use limbo_sqlite3_parser::ast;
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter},
@@ -188,14 +188,6 @@ pub struct UpdatePlan {
 pub enum IterationDirection {
     Forwards,
     Backwards,
-}
-impl From<SortOrder> for IterationDirection {
-    fn from(order: SortOrder) -> Self {
-        match order {
-            SortOrder::Asc => IterationDirection::Forwards,
-            SortOrder::Desc => IterationDirection::Backwards,
-        }
-    }
 }
 
 pub fn select_star(tables: &[TableReference], out_columns: &mut Vec<ResultSetColumn>) {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -170,22 +170,21 @@ pub struct DeletePlan {
 
 #[derive(Debug, Clone)]
 pub struct UpdatePlan {
-    // list of table references, table being updated is always first
+    // table being updated is always first
     pub table_references: Vec<TableReference>,
-    // which columns are being updated and what they are being set to
-    pub set_clauses: Vec<(usize, ast::Expr)>, // (column_index, expression)
-    // where clause split into a vec at 'AND' boundaries.
+    // (colum index, new value) pairs
+    pub set_clauses: Vec<(usize, ast::Expr)>,
     pub where_clause: Vec<WhereTerm>,
     pub order_by: Option<Vec<(ast::Expr, Direction)>>,
-    // TODO: support optional LIMIT
+    // TODO: full support of optional LIMIT
     pub limit: Option<isize>,
-    // optional RETURNING clause
+    // TODO: optional RETURNING clause
     pub returning: Option<Vec<ResultSetColumn>>,
     // whether the WHERE clause is always false
     pub contains_constant_false_condition: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum IterationDirection {
     Forwards,
     Backwards,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use limbo_sqlite3_parser::ast;
+use limbo_sqlite3_parser::ast::{self, SortOrder};
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter},
@@ -188,6 +188,14 @@ pub struct UpdatePlan {
 pub enum IterationDirection {
     Forwards,
     Backwards,
+}
+impl From<SortOrder> for IterationDirection {
+    fn from(order: SortOrder) -> Self {
+        match order {
+            SortOrder::Asc => IterationDirection::Forwards,
+            SortOrder::Desc => IterationDirection::Backwards,
+        }
+    }
 }
 
 pub fn select_star(tables: &[TableReference], out_columns: &mut Vec<ResultSetColumn>) {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -7,15 +7,12 @@ use std::{
     sync::Arc,
 };
 
+use crate::schema::{PseudoTable, Type};
 use crate::{
     function::AggFunc,
     schema::{BTreeTable, Column, Index, Table},
     vdbe::BranchOffset,
     VirtualTable,
-};
-use crate::{
-    schema::{PseudoTable, Type},
-    translate::plan::Plan::{Delete, Select},
 };
 
 #[derive(Debug, Clone)]
@@ -112,6 +109,7 @@ impl Ord for EvalAt {
 pub enum Plan {
     Select(SelectPlan),
     Delete(DeletePlan),
+    Update(UpdatePlan),
 }
 
 /// The type of the query, either top level or subquery
@@ -167,6 +165,23 @@ pub struct DeletePlan {
     /// offset clause
     pub offset: Option<isize>,
     /// query contains a constant condition that is always false
+    pub contains_constant_false_condition: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdatePlan {
+    // list of table references, table being updated is always first
+    pub table_references: Vec<TableReference>,
+    // which columns are being updated and what they are being set to
+    pub set_clauses: Vec<(usize, ast::Expr)>, // (column_index, expression)
+    // where clause split into a vec at 'AND' boundaries.
+    pub where_clause: Vec<WhereTerm>,
+    pub order_by: Option<Vec<(ast::Expr, Direction)>>,
+    // TODO: support optional LIMIT
+    pub limit: Option<isize>,
+    // optional RETURNING clause
+    pub returning: Option<Vec<ResultSetColumn>>,
+    // whether the WHERE clause is always false
     pub contains_constant_false_condition: bool,
 }
 
@@ -370,8 +385,9 @@ impl Display for Aggregate {
 impl Display for Plan {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Select(select_plan) => select_plan.fmt(f),
-            Delete(delete_plan) => delete_plan.fmt(f),
+            Self::Select(select_plan) => select_plan.fmt(f),
+            Self::Delete(delete_plan) => delete_plan.fmt(f),
+            Self::Update(update_plan) => update_plan.fmt(f),
         }
     }
 }
@@ -458,6 +474,80 @@ impl Display for DeletePlan {
                 }
             }
         }
+        Ok(())
+    }
+}
+
+impl fmt::Display for UpdatePlan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "QUERY PLAN")?;
+
+        for (i, reference) in self.table_references.iter().enumerate() {
+            let is_last = i == self.table_references.len() - 1;
+            let indent = if i == 0 {
+                if is_last { "`--" } else { "|--" }.to_string()
+            } else {
+                format!(
+                    "   {}{}",
+                    "|  ".repeat(i - 1),
+                    if is_last { "`--" } else { "|--" }
+                )
+            };
+
+            match &reference.op {
+                Operation::Scan { .. } => {
+                    let table_name = if reference.table.get_name() == reference.identifier {
+                        reference.identifier.clone()
+                    } else {
+                        format!("{} AS {}", reference.table.get_name(), reference.identifier)
+                    };
+
+                    if i == 0 {
+                        writeln!(f, "{}UPDATE {}", indent, table_name)?;
+                    } else {
+                        writeln!(f, "{}SCAN {}", indent, table_name)?;
+                    }
+                }
+                Operation::Search(search) => match search {
+                    Search::RowidEq { .. } | Search::RowidSearch { .. } => {
+                        writeln!(
+                            f,
+                            "{}SEARCH {} USING INTEGER PRIMARY KEY (rowid=?)",
+                            indent, reference.identifier
+                        )?;
+                    }
+                    Search::IndexSearch { index, .. } => {
+                        writeln!(
+                            f,
+                            "{}SEARCH {} USING INDEX {}",
+                            indent, reference.identifier, index.name
+                        )?;
+                    }
+                },
+                Operation::Subquery { plan, .. } => {
+                    writeln!(f, "{}SUBQUERY {}", indent, reference.identifier)?;
+                    for line in format!("{}", plan).lines() {
+                        writeln!(f, "{}   {}", indent, line)?;
+                    }
+                }
+            }
+        }
+        if let Some(order_by) = &self.order_by {
+            writeln!(f, "ORDER BY:")?;
+            for (expr, dir) in order_by {
+                writeln!(f, "  - {} {}", expr, dir)?;
+            }
+        }
+        if let Some(limit) = self.limit {
+            writeln!(f, "LIMIT: {}", limit)?;
+        }
+        if let Some(ret) = &self.returning {
+            writeln!(f, "RETURNING:")?;
+            for col in ret {
+                writeln!(f, "  - {}", col.expr)?;
+            }
+        }
+
         Ok(())
     }
 }

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -70,7 +70,7 @@ pub fn prepare_update_plan(schema: &Schema, body: &mut Update) -> crate::Result<
         None => bail_parse_error!("Parse error: no such table: {}", table_name),
     };
     let Some(btree_table) = table.btree() else {
-        bail_parse_error!("Parse error: no such table: {}", table_name);
+        bail_parse_error!("Error: {} is not a btree table", table_name);
     };
     let mut iter_dir = None;
     if let Some(order_by) = body.order_by.as_ref() {
@@ -113,7 +113,6 @@ pub fn prepare_update_plan(schema: &Schema, body: &mut Update) -> crate::Result<
                 })?;
 
             let _ = bind_column_references(&mut set.expr, &table_references, None);
-
             Ok((col_index, set.expr.clone()))
         })
         .collect::<Result<Vec<(usize, Expr)>, crate::LimboError>>()?;

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -72,10 +72,14 @@ pub fn prepare_update_plan(schema: &Schema, body: &mut Update) -> crate::Result<
     let Some(btree_table) = table.btree() else {
         bail_parse_error!("Error: {} is not a btree table", table_name);
     };
-    let iter_dir: Option<IterationDirection> = body
-        .order_by
-        .as_ref()
-        .and_then(|order_by| order_by.first().and_then(|ob| ob.order.map(|o| o.into())));
+    let iter_dir: Option<IterationDirection> = body.order_by.as_ref().and_then(|order_by| {
+        order_by.first().and_then(|ob| {
+            ob.order.map(|o| match o {
+                SortOrder::Asc => IterationDirection::Forwards,
+                SortOrder::Desc => IterationDirection::Backwards,
+            })
+        })
+    });
     let table_references = vec![TableReference {
         table: Table::BTree(btree_table.clone()),
         identifier: table_name.0.clone(),

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -155,7 +155,7 @@ pub fn prepare_update_plan(schema: &Schema, body: &mut Update) -> crate::Result<
         Some(&result_columns),
         &mut where_clause,
     )?;
-    let limit = if let Some(Ok((_, limit))) = body.limit.as_ref().map(|l| parse_limit(*l.clone())) {
+    let limit = if let Some(Ok((limit, _))) = body.limit.as_ref().map(|l| parse_limit(*l.clone())) {
         limit
     } else {
         None

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3203,8 +3203,7 @@ impl Program {
                         let mut cursor = state.get_cursor(*cursor);
                         let cursor = cursor.as_btree_mut();
                         // TODO: make io handle rng
-                        let rowid = return_if_io!(get_new_rowid(cursor, thread_rng()));
-                        rowid
+                        return_if_io!(get_new_rowid(cursor, thread_rng()))
                     };
                     state.registers[*rowid_reg] = Register::OwnedValue(OwnedValue::Integer(rowid));
                     state.pc += 1;
@@ -3256,10 +3255,7 @@ impl Program {
                         let mut cursor =
                             must_be_btree_cursor!(*cursor, self.cursor_ref, state, "NotExists");
                         let cursor = cursor.as_btree_mut();
-                        let exists = return_if_io!(
-                            cursor.exists(state.registers[*rowid_reg].get_owned_value())
-                        );
-                        exists
+                        return_if_io!(cursor.exists(state.registers[*rowid_reg].get_owned_value()))
                     };
                     if exists {
                         state.pc += 1;

--- a/testing/cli_tests/cli_test_cases.py
+++ b/testing/cli_tests/cli_test_cases.py
@@ -242,6 +242,28 @@ def test_table_patterns():
     shell.quit()
 
 
+def test_update_with_limit():
+    limbo = TestLimboShell(
+        "CREATE TABLE t (a,b,c); insert into t values (1,2,3), (4,5,6), (7,8,9), (1,2,3),(4,5,6), (7,8,9);"
+    )
+    limbo.run_test("update-limit", "UPDATE t SET a = 10 LIMIT 1;", "")
+    limbo.run_test("update-limit-result", "SELECT COUNT(*) from t WHERE a = 10;", "1")
+    limbo.run_test("update-limit-zero", "UPDATE t SET a = 100 LIMIT 0;", "")
+    limbo.run_test(
+        "update-limit-zero-result", "SELECT COUNT(*) from t WHERE a = 100;", "0"
+    )
+    limbo.run_test("update-limit-all", "UPDATE t SET a = 100 LIMIT -1;", "")
+    # negative limit is treated as no limit in sqlite due to check for --val = 0
+    limbo.run_test("update-limit-result", "SELECT COUNT(*) from t WHERE a = 100;", "6")
+    limbo.run_test(
+        "udpate-limit-where", "UPDATE t SET a = 333 WHERE b = 5 LIMIT 1;", ""
+    )
+    limbo.run_test(
+        "update-limit-where-result", "SELECT COUNT(*) from t WHERE a = 333;", "1"
+    )
+    limbo.quit()
+
+
 if __name__ == "__main__":
     print("Running all Limbo CLI tests...")
     test_basic_queries()
@@ -259,4 +281,5 @@ if __name__ == "__main__":
     test_import_csv_verbose()
     test_import_csv_skip()
     test_table_patterns()
+    test_update_with_limit()
     print("All tests have passed")

--- a/testing/update.test
+++ b/testing/update.test
@@ -52,27 +52,6 @@ do_execsql_test_on_specific_db {:memory:} update-all-many {
 	select COUNT(*) from temp where a = 1234234234234234;
 } {8}
 
-do_execsql_test_on_specific_db {:memory:} update-limit {
-    create table temp (a,b,c);
-    insert into temp values (1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33);
-	update temp set a = 44 LIMIT 3;
-	select COUNT(*) from temp where a = 44;
-} {3}
-
-do_execsql_test_on_specific_db {:memory:} update-limit-zero {
-    create table temp (a,b,c);
-    insert into temp values (1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33);
-	update temp set a = 44 LIMIT 0;
-	select COUNT(*) from temp where a = 44;
-} {0}
-
-do_execsql_test_on_specific_db {:memory:} update-limit-negative {
-    create table temp (a,b,c);
-    insert into temp values (1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33);
-	update temp set a = 44 LIMIT -1;
-	select COUNT(*) from temp where a = 44;
-} {8}
-
 do_execsql_test_on_specific_db {:memory:} update-large-small {
 	create table temp (a,b,c);
 	insert into temp values (randomblob(1024), 1, 2);

--- a/testing/update.test
+++ b/testing/update.test
@@ -52,6 +52,27 @@ do_execsql_test_on_specific_db {:memory:} update-all-many {
 	select COUNT(*) from temp where a = 1234234234234234;
 } {8}
 
+do_execsql_test_on_specific_db {:memory:} update-limit {
+    create table temp (a,b,c);
+    insert into temp values (1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33);
+	update temp set a = 44 LIMIT 3;
+	select COUNT(*) from temp where a = 44;
+} {3}
+
+do_execsql_test_on_specific_db {:memory:} update-limit-zero {
+    create table temp (a,b,c);
+    insert into temp values (1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33);
+	update temp set a = 44 LIMIT 0;
+	select COUNT(*) from temp where a = 44;
+} {0}
+
+do_execsql_test_on_specific_db {:memory:} update-limit-negative {
+    create table temp (a,b,c);
+    insert into temp values (1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33),(1,22,33);
+	update temp set a = 44 LIMIT -1;
+	select COUNT(*) from temp where a = 44;
+} {8}
+
 do_execsql_test_on_specific_db {:memory:} update-large-small {
 	create table temp (a,b,c);
 	insert into temp values (randomblob(1024), 1, 2);


### PR DESCRIPTION
closes #1186, or at least works towards it by implementing an actual Plan for update queries instead of translating everything inline. This allows for actually using index's, rewriting const expressions, pushing predicates instead of hardcoding a full scan in the translation.

### TODOs:
1.  `RETURNING` clause/result columns
2.  `OFFSET` clauses
3. on conflict


### LIMIT:
By supporting `LIMIT` directly in update queries, we'll have to put the tests outside of the compatibility tests, maybe in the CLI tests. 