### PR TITLE
Support Create Index

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -550,6 +550,7 @@ Modifiers:
 | SeekLe         | No     |         |
 | SeekLt         | No     |         |
 | SeekRowid      | Yes    |         |
+| SeekEnd        | Yes    |         |
 | Sequence       | No     |         |
 | SetCookie      | No     |         |
 | ShiftLeft      | Yes    |         |

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -56,7 +56,7 @@ Limbo aims to be fully compatible with SQLite, with opt-in features not supporte
 | ATTACH DATABASE           | No      |                                                                                   |
 | BEGIN TRANSACTION         | Partial | Transaction names are not supported.                                              |
 | COMMIT TRANSACTION        | Partial | Transaction names are not supported.                                              |
-| CREATE INDEX              | No      |                                                                                   |
+| CREATE INDEX              | Yes     |                                                                                   |
 | CREATE TABLE              | Partial |                                                                                   |
 | CREATE TRIGGER            | No      |                                                                                   |
 | CREATE VIEW               | No      |                                                                                   |
@@ -461,6 +461,8 @@ Modifiers:
 | IdxDelete      | No     |         |
 | IdxGE          | Yes    |         |
 | IdxInsert      | No     |         |
+| IdxInsertAsync | Yes    |         |
+| IdxInsertAwait | Yes    |         |
 | IdxLE          | Yes    |         |
 | IdxLT          | Yes    |         |
 | IdxRowid       | No     |         |

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -177,13 +177,19 @@ pub enum BTreeKey<'a> {
     IndexKey(&'a ImmutableRecord),
 }
 
-impl<'a> BTreeKey<'_> {
-    pub fn new_table_rowid(rowid: u64, record: Option<&'a ImmutableRecord>) -> BTreeKey<'a> {
+impl BTreeKey<'_> {
+    /// Create a new table rowid key from a rowid and an optional immutable record.
+    /// The record is optional because it may not be available when the key is created.
+    pub fn new_table_rowid(rowid: u64, record: Option<&ImmutableRecord>) -> BTreeKey<'_> {
         BTreeKey::TableRowId((rowid, record))
     }
-    pub fn new_index_key(record: &'a ImmutableRecord) -> BTreeKey<'a> {
+
+    /// Create a new index key from an immutable record.
+    pub fn new_index_key(record: &ImmutableRecord) -> BTreeKey<'_> {
         BTreeKey::IndexKey(record)
     }
+
+    /// Get the record, if present. Index will always be present,
     fn get_record(&self) -> Option<&'_ ImmutableRecord> {
         match self {
             BTreeKey::TableRowId((_, record)) => *record,
@@ -191,6 +197,7 @@ impl<'a> BTreeKey<'_> {
         }
     }
 
+    /// Get the rowid, if present. Index will never be present.
     fn maybe_rowid(&self) -> Option<u64> {
         match self {
             BTreeKey::TableRowId((rowid, _)) => Some(*rowid),
@@ -198,18 +205,18 @@ impl<'a> BTreeKey<'_> {
         }
     }
 
-    /// Assert that the key is a rowid and return it.
+    /// Assert that the key is an integer rowid and return it.
     fn to_rowid(&self) -> u64 {
         match self {
             BTreeKey::TableRowId((rowid, _)) => *rowid,
-            BTreeKey::IndexKey(_) => panic!("BTreeKey::assert_rowid() called on IndexKey"),
+            BTreeKey::IndexKey(_) => panic!("BTreeKey::to_rowid called on IndexKey"),
         }
     }
 
     /// Assert that the key is an index key and return it.
     fn to_index_key_values(&self) -> &'_ Vec<RefValue> {
         match self {
-            BTreeKey::TableRowId(_) => panic!("BTreeKey::assert_index_key() called on TableRowId"),
+            BTreeKey::TableRowId(_) => panic!("BTreeKey::to_index_key called on TableRowId"),
             BTreeKey::IndexKey(key) => key.get_values(),
         }
     }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2017,6 +2017,8 @@ impl BTreeCursor {
             {
                 BTreeCell::IndexInteriorCell(IndexInteriorCell { payload, .. })
                 | BTreeCell::IndexLeafCell(IndexLeafCell { payload, .. }) => {
+                    // TODO: implement efficient comparison of records
+                    // e.g. https://github.com/sqlite/sqlite/blob/master/src/vdbeaux.c#L4719
                     read_record(
                         payload,
                         self.get_immutable_record_or_create().as_mut().unwrap(),
@@ -2027,10 +2029,7 @@ impl BTreeCursor {
                         self.get_immutable_record().as_ref().unwrap().get_values(),
                     );
                     match order {
-                        Ordering::Less => {
-                            break;
-                        }
-                        Ordering::Equal => {
+                        Ordering::Less | Ordering::Equal => {
                             break;
                         }
                         Ordering::Greater => {}
@@ -2044,7 +2043,7 @@ impl BTreeCursor {
     }
 
     pub fn seek_end(&mut self) -> Result<CursorResult<()>> {
-        assert!(self.mv_cursor.is_none());
+        assert!(self.mv_cursor.is_none()); // unsure about this -_-
         self.move_to_root();
         loop {
             let mem_page = self.stack.top();

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4196,7 +4196,7 @@ mod tests {
             for (key, size) in sequence.iter() {
                 run_until_done(
                     || {
-                        let key = SeekKey::TableRowId(*key as u64);
+                        let key = SeekKey::TableRowId(*key);
                         cursor.move_to(key, SeekOp::EQ)
                     },
                     pager.deref(),
@@ -4217,7 +4217,7 @@ mod tests {
                 );
             }
             for (key, _) in sequence.iter() {
-                let seek_key = SeekKey::TableRowId(*key as u64);
+                let seek_key = SeekKey::TableRowId(*key);
                 assert!(
                     matches!(
                         cursor.seek(seek_key, SeekOp::EQ).unwrap(),
@@ -5166,7 +5166,6 @@ mod tests {
         for i in 0..10000 {
             let mut cursor = BTreeCursor::new(None, pager.clone(), root_page);
             tracing::info!("INSERT INTO t VALUES ({});", i,);
-            let key = OwnedValue::Integer(i);
             let value =
                 ImmutableRecord::from_registers(&[Register::OwnedValue(OwnedValue::Integer(i))]);
             tracing::trace!("before insert {}", i);
@@ -5246,7 +5245,6 @@ mod tests {
         // Insert 10,000 records in to the BTree.
         for i in 1..=10000 {
             let mut cursor = BTreeCursor::new(None, pager.clone(), root_page);
-            let key = OwnedValue::Integer(i);
             let value = ImmutableRecord::from_registers(&[Register::OwnedValue(OwnedValue::Text(
                 Text::new("hello world"),
             ))]);
@@ -5323,7 +5321,6 @@ mod tests {
         for i in 0..iterations {
             let mut cursor = BTreeCursor::new(None, pager.clone(), root_page);
             tracing::info!("INSERT INTO t VALUES ({});", i,);
-            let key = OwnedValue::Integer(i as i64);
             let value =
                 ImmutableRecord::from_registers(&[Register::OwnedValue(OwnedValue::Text(Text {
                     value: huge_texts[i].as_bytes().to_vec(),

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2161,13 +2161,15 @@ impl BTreeCursor {
             },
             None => {
                 if !moved_before {
-                    return_if_io!(self.move_to(
-                        match key {
-                            BTreeKey::IndexKey(_) => SeekKey::IndexKey(key.get_record().unwrap()),
-                            BTreeKey::TableRowId(_) => SeekKey::TableRowId(key.to_rowid()),
-                        },
-                        SeekOp::EQ
-                    ));
+                    match key {
+                        BTreeKey::IndexKey(_) => {
+                            return_if_io!(self
+                                .move_to(SeekKey::IndexKey(key.get_record().unwrap()), SeekOp::GE))
+                        }
+                        BTreeKey::TableRowId(_) => return_if_io!(
+                            self.move_to(SeekKey::TableRowId(key.to_rowid()), SeekOp::EQ)
+                        ),
+                    }
                 }
                 return_if_io!(self.insert_into_page(key));
                 if key.maybe_rowid().is_some() {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,0 +1,321 @@
+use std::sync::Arc;
+
+use crate::{
+    schema::{BTreeTable, Column, Index, IndexColumn, PseudoTable, Schema},
+    types::Record,
+    util::normalize_ident,
+    vdbe::{
+        builder::{CursorType, ProgramBuilder, QueryMode},
+        insn::{IdxInsertFlags, Insn},
+    },
+    OwnedValue,
+};
+use limbo_sqlite3_parser::ast::{self, Expr, Id, SortOrder, SortedColumn};
+
+use super::schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID};
+
+pub fn translate_create_index(
+    mode: QueryMode,
+    unique_if_not_exists: (bool, bool),
+    idx_name: &str,
+    tbl_name: &str,
+    columns: &[SortedColumn],
+    schema: &Schema,
+) -> crate::Result<ProgramBuilder> {
+    let idx_name = normalize_ident(idx_name);
+    let tbl_name = normalize_ident(tbl_name);
+    let mut program = ProgramBuilder::new(crate::vdbe::builder::ProgramBuilderOpts {
+        query_mode: mode,
+        num_cursors: 5,
+        approx_num_insns: 40,
+        approx_num_labels: 5,
+    });
+
+    // Check if the index is being created on a valid btree table and
+    // the name is globally unique in the schema.
+    if !schema.is_unique_idx_name(&idx_name) {
+        crate::bail_parse_error!("Error: index with name '{idx_name}' already exists.");
+    }
+    let Some(tbl) = schema.tables.get(&tbl_name) else {
+        crate::bail_parse_error!("Error: table '{tbl_name}' does not exist.");
+    };
+    let Some(tbl) = tbl.btree() else {
+        crate::bail_parse_error!("Error: table '{tbl_name}' is not a b-tree table.");
+    };
+    let columns = resolve_sorted_columns(&tbl, columns)?;
+
+    // Prologue:
+    let init_label = program.emit_init();
+    let start_offset = program.offset();
+
+    let idx = Arc::new(Index {
+        name: idx_name.clone(),
+        table_name: tbl.name.clone(),
+        root_page: 0, //  we dont have access till its created, after we parse the schema table
+        columns: columns
+            .iter()
+            .map(|c| IndexColumn {
+                name: c.0 .1.name.as_ref().unwrap().clone(),
+                order: c.1,
+            })
+            .collect(),
+        unique: unique_if_not_exists.0,
+    });
+
+    // Allocate the necessary cursors.
+    //
+    // 1. sqlite_schema_cursor_id - for the sqlite_schema table
+    // 2. btree_cursor_id - for the index btree
+    // 3. table_cursor_id - for the table we are creating the index on
+    // 4. sorter_cursor_id - for the sorter
+    // 5. pseudo_cursor_id - for the pseudo table to store the sorted index values
+    let sqlite_table = schema.get_btree_table(SQLITE_TABLEID).unwrap();
+    let sqlite_schema_cursor_id = program.alloc_cursor_id(
+        Some(SQLITE_TABLEID.to_owned()),
+        CursorType::BTreeTable(sqlite_table.clone()),
+    );
+    let btree_cursor_id = program.alloc_cursor_id(
+        Some(idx_name.to_owned()),
+        CursorType::BTreeIndex(idx.clone()),
+    );
+    let table_cursor_id = program.alloc_cursor_id(
+        Some(tbl_name.to_owned()),
+        CursorType::BTreeTable(tbl.clone()),
+    );
+    let sorter_cursor_id = program.alloc_cursor_id(None, CursorType::Sorter);
+    let pseudo_table = PseudoTable::new_with_columns(tbl.columns.clone());
+    let pseudo_cursor_id = program.alloc_cursor_id(None, CursorType::Pseudo(pseudo_table.into()));
+
+    // Create a new B-Tree and store the root page index in a register
+    let root_page_reg = program.alloc_register();
+    program.emit_insn(Insn::CreateBtree {
+        db: 0,
+        root: root_page_reg,
+        flags: 2, // index leaf
+    });
+
+    // open the sqlite schema table for writing and create a new entry for the index
+    program.emit_insn(Insn::OpenWriteAsync {
+        cursor_id: sqlite_schema_cursor_id,
+        root_page: sqlite_table.root_page,
+        is_new_idx: false,
+    });
+    program.emit_insn(Insn::OpenWriteAwait {});
+    let sql = create_idx_stmt_to_sql(&tbl_name, &idx_name, unique_if_not_exists, &columns);
+    emit_schema_entry(
+        &mut program,
+        sqlite_schema_cursor_id,
+        SchemaEntryType::Index,
+        &idx_name,
+        &tbl_name,
+        root_page_reg,
+        Some(sql),
+    );
+
+    // determine the order of the columns in the index for the sorter
+    let order = idx
+        .columns
+        .iter()
+        .map(|c| {
+            OwnedValue::Integer(match c.order {
+                SortOrder::Asc => 0,
+                SortOrder::Desc => 1,
+            })
+        })
+        .collect();
+    // open the sorter and the pseudo table
+    program.emit_insn(Insn::SorterOpen {
+        cursor_id: sorter_cursor_id,
+        columns: columns.len(),
+        order: Record::new(order),
+    });
+    let content_reg = program.alloc_register();
+    program.emit_insn(Insn::OpenPseudo {
+        cursor_id: pseudo_cursor_id,
+        content_reg,
+        num_fields: columns.len() + 1,
+    });
+
+    // open the table we are creating the index on for reading
+    program.emit_insn(Insn::OpenReadAsync {
+        cursor_id: table_cursor_id,
+        root_page: tbl.root_page,
+    });
+    program.emit_insn(Insn::OpenReadAwait {});
+
+    program.emit_insn(Insn::RewindAsync {
+        cursor_id: table_cursor_id,
+    });
+    let loop_start_label = program.allocate_label();
+    let loop_end_label = program.allocate_label();
+    program.emit_insn(Insn::RewindAwait {
+        cursor_id: table_cursor_id,
+        pc_if_empty: loop_end_label,
+    });
+
+    program.resolve_label(loop_start_label, program.offset());
+
+    // Loop start:
+    // Collect index values into start_reg..rowid_reg
+    // emit MakeRecord (index key + rowid) into record_reg.
+    //
+    // Then insert the record into the sorter
+    let start_reg = program.alloc_registers(columns.len() + 1);
+    for (i, (col, _)) in columns.iter().enumerate() {
+        program.emit_insn(Insn::Column {
+            cursor_id: table_cursor_id,
+            column: col.0,
+            dest: start_reg + i,
+        });
+    }
+    let rowid_reg = start_reg + columns.len();
+    program.emit_insn(Insn::RowId {
+        cursor_id: table_cursor_id,
+        dest: rowid_reg,
+    });
+    let record_reg = program.alloc_register();
+    program.emit_insn(Insn::MakeRecord {
+        start_reg,
+        count: columns.len() + 1,
+        dest_reg: record_reg,
+    });
+    program.emit_insn(Insn::SorterInsert {
+        cursor_id: sorter_cursor_id,
+        record_reg,
+    });
+
+    program.emit_insn(Insn::NextAsync {
+        cursor_id: table_cursor_id,
+    });
+    program.emit_insn(Insn::NextAwait {
+        cursor_id: table_cursor_id,
+        pc_if_next: loop_start_label,
+    });
+    program.resolve_label(loop_end_label, program.offset());
+
+    // Open the index btree we created for writing to insert the
+    // newly sorted index records.
+    program.emit_insn(Insn::OpenWriteAsync {
+        cursor_id: btree_cursor_id,
+        root_page: root_page_reg,
+        is_new_idx: true,
+    });
+    program.emit_insn(Insn::OpenWriteAwait {});
+
+    let sorted_loop_start = program.allocate_label();
+    let sorted_loop_end = program.allocate_label();
+
+    // Sort the index records in the sorter
+    program.emit_insn(Insn::SorterSort {
+        cursor_id: sorter_cursor_id,
+        pc_if_empty: sorted_loop_end,
+    });
+    program.resolve_label(sorted_loop_start, program.offset());
+    let sorted_record_reg = program.alloc_register();
+    program.emit_insn(Insn::SorterData {
+        pseudo_cursor: pseudo_cursor_id,
+        cursor_id: sorter_cursor_id,
+        dest_reg: sorted_record_reg,
+    });
+
+    // seek to the end of the index btree to position the cursor for appending
+    program.emit_insn(Insn::SeekEnd {
+        cursor_id: btree_cursor_id,
+    });
+    // insert new index record
+    program.emit_insn(Insn::IdxInsertAsync {
+        cursor_id: btree_cursor_id,
+        record_reg: sorted_record_reg,
+        unpacked_start: None, // TODO: optimize with these to avoid decoding record twice
+        unpacked_count: None,
+        flags: IdxInsertFlags::new().use_seek(false),
+    });
+    program.emit_insn(Insn::IdxInsertAwait {
+        cursor_id: btree_cursor_id,
+    });
+    program.emit_insn(Insn::SorterNext {
+        cursor_id: sorter_cursor_id,
+        pc_if_next: sorted_loop_start,
+    });
+    program.resolve_label(sorted_loop_end, program.offset());
+
+    // End of the outer loop
+    //
+    // Keep schema table open to emit ParseSchema, close the other cursors.
+    program.close_cursors(&[sorter_cursor_id, table_cursor_id, btree_cursor_id]);
+
+    // TODO: SetCookie for schema change
+    //
+    // Parse the schema table to get the index root page and add new index to Schema
+    let parse_schema_where_clause = format!("name = '{}' AND type = 'index'", idx_name);
+    program.emit_insn(Insn::ParseSchema {
+        db: sqlite_schema_cursor_id,
+        where_clause: parse_schema_where_clause,
+    });
+    // Close the final sqlite_schema cursor
+    program.emit_insn(Insn::Close {
+        cursor_id: sqlite_schema_cursor_id,
+    });
+
+    // Epilogue:
+    program.emit_halt();
+    program.resolve_label(init_label, program.offset());
+    program.emit_transaction(true);
+    program.emit_constant_insns();
+    program.emit_goto(start_offset);
+
+    Ok(program)
+}
+
+fn resolve_sorted_columns<'a>(
+    table: &'a BTreeTable,
+    cols: &[SortedColumn],
+) -> crate::Result<Vec<((usize, &'a Column), SortOrder)>> {
+    let mut resolved = Vec::with_capacity(cols.len());
+    for sc in cols {
+        let ident = normalize_ident(match &sc.expr {
+            Expr::Id(Id(col_name)) | Expr::Name(ast::Name(col_name)) => col_name,
+            _ => crate::bail_parse_error!("Error: cannot use expressions in CREATE INDEX"),
+        });
+        let Some(col) = table.get_column(&ident) else {
+            crate::bail_parse_error!(
+                "Error: column '{ident}' does not exist in table '{}'",
+                table.name
+            );
+        };
+        resolved.push((col, sc.order.unwrap_or(SortOrder::Asc)));
+    }
+    Ok(resolved)
+}
+
+fn create_idx_stmt_to_sql(
+    tbl_name: &str,
+    idx_name: &str,
+    unique_if_not_exists: (bool, bool),
+    cols: &[((usize, &Column), SortOrder)],
+) -> String {
+    let mut sql = String::new();
+    sql.push_str("CREATE ");
+    if unique_if_not_exists.0 {
+        sql.push_str("UNIQUE ");
+    }
+    sql.push_str("INDEX ");
+    if unique_if_not_exists.1 {
+        sql.push_str("IF NOT EXISTS ");
+    }
+    sql.push_str(idx_name);
+    sql.push_str(" ON ");
+    sql.push_str(tbl_name);
+    sql.push_str(" (");
+    for (i, (col, order)) in cols.iter().enumerate() {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str(col.1.name.as_ref().unwrap());
+        if *order == SortOrder::Desc {
+            sql.push_str(" DESC");
+        }
+    }
+    sql.push(')');
+    sql
+}

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -62,13 +62,13 @@ pub fn translate_create_index(
         unique: unique_if_not_exists.0,
     });
 
-    // Allocate the necessary cursors.
+    // Allocate the necessary cursors:
     //
-    // 1. sqlite_schema_cursor_id - for the sqlite_schema table
-    // 2. btree_cursor_id - for the index btree
-    // 3. table_cursor_id - for the table we are creating the index on
-    // 4. sorter_cursor_id - for the sorter
-    // 5. pseudo_cursor_id - for the pseudo table to store the sorted index values
+    // 1. sqlite_schema_cursor_id - sqlite_schema table
+    // 2. btree_cursor_id         - new index btree
+    // 3. table_cursor_id         - table we are creating the index on
+    // 4. sorter_cursor_id        - sorter
+    // 5. pseudo_cursor_id        - pseudo table to store the sorted index values
     let sqlite_table = schema.get_btree_table(SQLITE_TABLEID).unwrap();
     let sqlite_schema_cursor_id = program.alloc_cursor_id(
         Some(SQLITE_TABLEID.to_owned()),
@@ -292,7 +292,7 @@ fn create_idx_stmt_to_sql(
     unique_if_not_exists: (bool, bool),
     cols: &[((usize, &Column), SortOrder)],
 ) -> String {
-    let mut sql = String::new();
+    let mut sql = String::with_capacity(128);
     sql.push_str("CREATE ");
     if unique_if_not_exists.0 {
         sql.push_str("UNIQUE ");

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -6,7 +6,7 @@ use crate::{
     util::normalize_ident,
     vdbe::{
         builder::{CursorType, ProgramBuilder, QueryMode},
-        insn::{IdxInsertFlags, Insn},
+        insn::{IdxInsertFlags, Insn, RegisterOrLiteral},
     },
     OwnedValue,
 };
@@ -97,8 +97,7 @@ pub fn translate_create_index(
     // open the sqlite schema table for writing and create a new entry for the index
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: sqlite_schema_cursor_id,
-        root_page: sqlite_table.root_page,
-        is_new_idx: false,
+        root_page: RegisterOrLiteral::Literal(sqlite_table.root_page),
     });
     program.emit_insn(Insn::OpenWriteAwait {});
     let sql = create_idx_stmt_to_sql(&tbl_name, &idx_name, unique_if_not_exists, &columns);
@@ -197,8 +196,7 @@ pub fn translate_create_index(
     // newly sorted index records.
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: btree_cursor_id,
-        root_page: root_page_reg,
-        is_new_idx: true,
+        root_page: RegisterOrLiteral::Register(root_page_reg),
     });
     program.emit_insn(Insn::OpenWriteAwait {});
 

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -153,6 +153,7 @@ pub fn translate_insert(
         program.emit_insn(Insn::OpenWriteAsync {
             cursor_id,
             root_page,
+            is_new_idx: false,
         });
         program.emit_insn(Insn::OpenWriteAwait {});
 
@@ -169,6 +170,7 @@ pub fn translate_insert(
         program.emit_insn(Insn::OpenWriteAsync {
             cursor_id,
             root_page,
+            is_new_idx: false,
         });
         program.emit_insn(Insn::OpenWriteAwait {});
 

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -9,6 +9,7 @@ use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
 use crate::schema::Table;
 use crate::util::normalize_ident;
 use crate::vdbe::builder::{ProgramBuilderOpts, QueryMode};
+use crate::vdbe::insn::RegisterOrLiteral;
 use crate::vdbe::BranchOffset;
 use crate::{
     schema::{Column, Schema},
@@ -152,8 +153,7 @@ pub fn translate_insert(
 
         program.emit_insn(Insn::OpenWriteAsync {
             cursor_id,
-            root_page,
-            is_new_idx: false,
+            root_page: RegisterOrLiteral::Literal(root_page),
         });
         program.emit_insn(Insn::OpenWriteAwait {});
 
@@ -169,8 +169,7 @@ pub fn translate_insert(
         // Single row - populate registers directly
         program.emit_insn(Insn::OpenWriteAsync {
             cursor_id,
-            root_page,
-            is_new_idx: false,
+            root_page: RegisterOrLiteral::Literal(root_page),
         });
         program.emit_insn(Insn::OpenWriteAwait {});
 

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -102,8 +102,7 @@ pub fn init_loop(
                         let root_page = btree.root_page;
                         program.emit_insn(Insn::OpenWriteAsync {
                             cursor_id,
-                            root_page,
-                            is_new_idx: false,
+                            root_page: root_page.into(),
                         });
                         program.emit_insn(Insn::OpenWriteAwait {});
                     }
@@ -111,8 +110,7 @@ pub fn init_loop(
                         let root_page = btree.root_page;
                         program.emit_insn(Insn::OpenWriteAsync {
                             cursor_id,
-                            root_page,
-                            is_new_idx: false,
+                            root_page: root_page.into(),
                         });
                         program.emit_insn(Insn::OpenWriteAwait {});
                     }
@@ -146,16 +144,14 @@ pub fn init_loop(
                     OperationMode::DELETE => {
                         program.emit_insn(Insn::OpenWriteAsync {
                             cursor_id: table_cursor_id,
-                            root_page: table.table.get_root_page(),
-                            is_new_idx: false,
+                            root_page: table.table.get_root_page().into(),
                         });
                         program.emit_insn(Insn::OpenWriteAwait {});
                     }
                     OperationMode::UPDATE => {
                         program.emit_insn(Insn::OpenWriteAsync {
                             cursor_id: table_cursor_id,
-                            root_page: table.table.get_root_page(),
-                            is_new_idx: false,
+                            root_page: table.table.get_root_page().into(),
                         });
                         program.emit_insn(Insn::OpenWriteAwait {});
                     }
@@ -181,16 +177,14 @@ pub fn init_loop(
                         OperationMode::DELETE => {
                             program.emit_insn(Insn::OpenWriteAsync {
                                 cursor_id: index_cursor_id,
-                                root_page: index.root_page,
-                                is_new_idx: false,
+                                root_page: index.root_page.into(),
                             });
                             program.emit_insn(Insn::OpenWriteAwait {});
                         }
                         OperationMode::UPDATE => {
                             program.emit_insn(Insn::OpenWriteAsync {
                                 cursor_id: index_cursor_id,
-                                root_page: index.root_page,
-                                is_new_idx: false,
+                                root_page: index.root_page.into(),
                             });
                             program.emit_insn(Insn::OpenWriteAwait {});
                         }

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -103,6 +103,7 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWriteAsync {
                             cursor_id,
                             root_page,
+                            is_new_idx: false,
                         });
                         program.emit_insn(Insn::OpenWriteAwait {});
                     }
@@ -111,6 +112,7 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWriteAsync {
                             cursor_id,
                             root_page,
+                            is_new_idx: false,
                         });
                         program.emit_insn(Insn::OpenWriteAwait {});
                     }
@@ -145,6 +147,7 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWriteAsync {
                             cursor_id: table_cursor_id,
                             root_page: table.table.get_root_page(),
+                            is_new_idx: false,
                         });
                         program.emit_insn(Insn::OpenWriteAwait {});
                     }
@@ -152,6 +155,7 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWriteAsync {
                             cursor_id: table_cursor_id,
                             root_page: table.table.get_root_page(),
+                            is_new_idx: false,
                         });
                         program.emit_insn(Insn::OpenWriteAwait {});
                     }
@@ -178,6 +182,7 @@ pub fn init_loop(
                             program.emit_insn(Insn::OpenWriteAsync {
                                 cursor_id: index_cursor_id,
                                 root_page: index.root_page,
+                                is_new_idx: false,
                             });
                             program.emit_insn(Insn::OpenWriteAwait {});
                         }
@@ -185,6 +190,7 @@ pub fn init_loop(
                             program.emit_insn(Insn::OpenWriteAsync {
                                 cursor_id: index_cursor_id,
                                 root_page: index.root_page,
+                                is_new_idx: false,
                             });
                             program.emit_insn(Insn::OpenWriteAwait {});
                         }

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -7,7 +7,6 @@ use crate::translate::ProgramBuilderOpts;
 use crate::translate::QueryMode;
 use crate::util::PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX;
 use crate::vdbe::builder::CursorType;
-use crate::vdbe::insn::RegisterOrLiteral;
 use crate::vdbe::insn::{CmpInsFlags, Insn};
 use crate::LimboError;
 use crate::{bail_parse_error, Result};

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -7,6 +7,7 @@ use crate::translate::ProgramBuilderOpts;
 use crate::translate::QueryMode;
 use crate::util::PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX;
 use crate::vdbe::builder::CursorType;
+use crate::vdbe::insn::RegisterOrLiteral;
 use crate::vdbe::insn::{CmpInsFlags, Insn};
 use crate::LimboError;
 use crate::{bail_parse_error, Result};
@@ -103,8 +104,7 @@ pub fn translate_create_table(
     );
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: sqlite_schema_cursor_id,
-        root_page: 1,
-        is_new_idx: false,
+        root_page: 1usize.into(),
     });
     program.emit_insn(Insn::OpenWriteAwait {});
 
@@ -501,8 +501,7 @@ pub fn translate_create_virtual_table(
     );
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: sqlite_schema_cursor_id,
-        root_page: 1,
-        is_new_idx: false,
+        root_page: 1usize.into(),
     });
     program.emit_insn(Insn::OpenWriteAwait {});
 
@@ -581,8 +580,7 @@ pub fn translate_drop_table(
     );
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: sqlite_schema_cursor_id,
-        root_page: 1,
-        is_new_idx: false,
+        root_page: 1usize.into(),
     });
     program.emit_insn(Insn::OpenWriteAwait {});
 

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -104,6 +104,7 @@ pub fn translate_create_table(
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1,
+        is_new_idx: false,
     });
     program.emit_insn(Insn::OpenWriteAwait {});
 
@@ -155,8 +156,8 @@ pub fn translate_create_table(
     Ok(program)
 }
 
-#[derive(Debug)]
-enum SchemaEntryType {
+#[derive(Debug, Clone, Copy)]
+pub enum SchemaEntryType {
     Table,
     Index,
 }
@@ -169,9 +170,9 @@ impl SchemaEntryType {
         }
     }
 }
-const SQLITE_TABLEID: &str = "sqlite_schema";
+pub const SQLITE_TABLEID: &str = "sqlite_schema";
 
-fn emit_schema_entry(
+pub fn emit_schema_entry(
     program: &mut ProgramBuilder,
     sqlite_schema_cursor_id: usize,
     entry_type: SchemaEntryType,
@@ -501,6 +502,7 @@ pub fn translate_create_virtual_table(
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1,
+        is_new_idx: false,
     });
     program.emit_insn(Insn::OpenWriteAwait {});
 
@@ -572,7 +574,7 @@ pub fn translate_drop_table(
     let row_id_reg = program.alloc_register(); //  r5
 
     let table_name = "sqlite_schema";
-    let schema_table = schema.get_btree_table(&table_name).unwrap();
+    let schema_table = schema.get_btree_table(table_name).unwrap();
     let sqlite_schema_cursor_id = program.alloc_cursor_id(
         Some(table_name.to_string()),
         CursorType::BTreeTable(schema_table.clone()),
@@ -580,6 +582,7 @@ pub fn translate_drop_table(
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1,
+        is_new_idx: false,
     });
     program.emit_insn(Insn::OpenWriteAwait {});
 

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -131,6 +131,12 @@ impl ProgramBuilder {
         self.insns.push((insn, function));
     }
 
+    pub fn close_cursors(&mut self, cursors: &[CursorID]) {
+        for cursor in cursors {
+            self.emit_insn(Insn::Close { cursor_id: *cursor });
+        }
+    }
+
     pub fn emit_string8(&mut self, value: String, dest: usize) {
         self.emit_insn(Insn::String8 { value, dest });
     }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1,4 +1,4 @@
-use crate::vdbe::builder::CursorType;
+use crate::vdbe::{builder::CursorType, insn::RegisterOrLiteral};
 
 use super::{Insn, InsnReference, OwnedValue, Program};
 use crate::function::{Func, ScalarFunc};
@@ -1134,7 +1134,10 @@ pub fn insn_to_str(
             } => (
                 "OpenWriteAsync",
                 *cursor_id as i32,
-                *root_page as i32,
+                match root_page {
+                    RegisterOrLiteral::Literal(i) => *i as _,
+                    RegisterOrLiteral::Register(i) => *i as _,
+                },
                 0,
                 OwnedValue::build_text(""),
                 0,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -760,6 +760,39 @@ pub fn insn_to_str(
                 0,
                 "".to_string(),
             ),
+            Insn::SeekEnd { cursor_id } => (
+                "SeekEnd",
+                *cursor_id as i32,
+                0,
+                0,
+                OwnedValue::build_text(""),
+                0,
+                "".to_string(),
+            ),
+            Insn::IdxInsertAsync {
+                cursor_id,
+                record_reg,
+                unpacked_start,
+                flags,
+                ..
+            } => (
+                "IdxInsertAsync",
+                *cursor_id as i32,
+                *record_reg as i32,
+                unpacked_start.unwrap_or(0) as i32,
+                OwnedValue::build_text(""),
+                flags.0 as u16,
+                format!("key=r[{}]", record_reg),
+            ),
+            Insn::IdxInsertAwait { cursor_id } => (
+                "IdxInsertAwait",
+                *cursor_id as i32,
+                0,
+                0,
+                OwnedValue::build_text(""),
+                0,
+                "".to_string(),
+            ),
             Insn::IdxGT {
                 cursor_id,
                 start_reg,
@@ -1097,6 +1130,7 @@ pub fn insn_to_str(
             Insn::OpenWriteAsync {
                 cursor_id,
                 root_page,
+                ..
             } => (
                 "OpenWriteAsync",
                 *cursor_id as i32,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -76,6 +76,18 @@ impl IdxInsertFlags {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum RegisterOrLiteral<T: Copy> {
+    Register(usize),
+    Literal(T),
+}
+
+impl From<PageIdx> for RegisterOrLiteral<PageIdx> {
+    fn from(value: PageIdx) -> Self {
+        RegisterOrLiteral::Literal(value)
+    }
+}
+
 #[derive(Description, Debug)]
 pub enum Insn {
     /// Initialize the program state and jump to the given PC.
@@ -640,8 +652,7 @@ pub enum Insn {
 
     OpenWriteAsync {
         cursor_id: CursorID,
-        root_page: PageIdx,
-        is_new_idx: bool,
+        root_page: RegisterOrLiteral<PageIdx>,
     },
 
     OpenWriteAwait {},
@@ -1296,8 +1307,6 @@ impl Insn {
             Insn::IdxGT { .. } => execute::op_idx_gt,
             Insn::IdxLE { .. } => execute::op_idx_le,
             Insn::IdxLT { .. } => execute::op_idx_lt,
-            Insn::IdxInsertAsync { .. } => execute::op_idx_insert_async,
-            Insn::IdxInsertAwait { .. } => execute::op_idx_insert_await,
             Insn::DecrJumpZero { .. } => execute::op_decr_jump_zero,
 
             Insn::AggStep { .. } => execute::op_agg_step,
@@ -1315,7 +1324,8 @@ impl Insn {
             Insn::Yield { .. } => execute::op_yield,
             Insn::InsertAsync { .. } => execute::op_insert_async,
             Insn::InsertAwait { .. } => execute::op_insert_await,
-
+            Insn::IdxInsertAsync { .. } => execute::op_idx_insert_async,
+            Insn::IdxInsertAwait { .. } => execute::op_idx_insert_await,
             Insn::DeleteAsync { .. } => execute::op_delete_async,
 
             Insn::DeleteAwait { .. } => execute::op_delete_await,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -484,10 +484,10 @@ pub enum Insn {
         target_pc: BranchOffset,
     },
 
-    // cursor_id is a cursor pointing to a B-Tree index that uses integer keys, this op writes the value obtained from MakeRecord into the index.
-    // P3 + P4 are for the original column values that make up that key in unpacked (pre-serialized) form.
-    // If P5 has the OPFLAG_APPEND bit set, that is a hint to the b-tree layer that this insert is likely to be an append.
-    // OPFLAG_NCHANGE bit set, then the change counter is incremented by this instruction. If the OPFLAG_NCHANGE bit is clear, then the change counter is unchanged
+    /// cursor_id is a cursor pointing to a B-Tree index that uses integer keys, this op writes the value obtained from MakeRecord into the index.
+    /// P3 + P4 are for the original column values that make up that key in unpacked (pre-serialized) form.
+    /// If P5 has the OPFLAG_APPEND bit set, that is a hint to the b-tree layer that this insert is likely to be an append.
+    /// OPFLAG_NCHANGE bit set, then the change counter is incremented by this instruction. If the OPFLAG_NCHANGE bit is clear, then the change counter is unchanged
     IdxInsertAsync {
         cursor_id: CursorID,
         record_reg: usize, // P2 the register containing the record to insert
@@ -498,6 +498,9 @@ pub enum Insn {
     IdxInsertAwait {
         cursor_id: CursorID,
     },
+
+    /// The P4 register values beginning with P3 form an unpacked index key that omits the PRIMARY KEY. Compare this key value against the index that P1 is currently pointing to, ignoring the PRIMARY KEY or ROWID fields at the end.
+    /// If the P1 index entry is greater or equal than the key value then jump to P2. Otherwise fall through to the next instruction.
     IdxGE {
         cursor_id: CursorID,
         start_reg: usize,

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -342,6 +342,7 @@ def test_kv():
     # first, create a normal table to ensure no issues
     limbo.execute_dot("CREATE TABLE other (a,b,c);")
     limbo.execute_dot("INSERT INTO other values (23,32,23);")
+    limbo = TestLimboShell()
     limbo.run_test_fn(
         "create virtual table t using kv_store;",
         lambda res: "Virtual table module not found: kv_store" in res,
@@ -350,6 +351,7 @@ def test_kv():
     limbo.debug_print(
         "create virtual table t using kv_store;",
     )
+    limbo.run_test_fn(".schema", lambda res: "CREATE VIRTUAL TABLE t" in res)
     limbo.run_test_fn(
         "insert into t values ('hello', 'world');",
         null,
@@ -496,12 +498,6 @@ def test_vfs():
         "Tested large write to testfs",
     )
     print("Tested large write to testfs")
-    # Pere: I commented this out because it added an extra row that made the test test_sqlite_vfs_compat fail
-    # it didn't segfault from my side so maybe this is necessary?
-    # # open regular db file to ensure we don't segfault when vfs file is dropped
-    # limbo.execute_dot(".open testing/vfs.db")
-    # limbo.execute_dot("create table test (id integer primary key, value float);")
-    # limbo.execute_dot("insert into test (value) values (1.0);")
     limbo.quit()
 
 
@@ -548,10 +544,10 @@ if __name__ == "__main__":
         test_aggregates()
         test_crypto()
         test_series()
-        test_kv()
         test_ipaddr()
         test_vfs()
         test_sqlite_vfs_compat()
+        test_kv()
     except Exception as e:
         print(f"Test FAILED: {e}")
         cleanup()


### PR DESCRIPTION
Closes #1193  


```console
│limbo> explain create index idxp on products(price);                                                                                                                        
│addr  opcode             p1    p2    p3    p4             p5  comment
│----  -----------------  ----  ----  ----  -------------  --  -------
│0     Init               0     39    0                    0   Start at 39
│1     CreateBtree        0     1     2                    0   r[1]=root iDb=0 flags=2
│2     OpenWriteAsync     0     1     0                    0
│3     OpenWriteAwait     0     0     0                    0
│4     NewRowId           0     2     0                    0
│5     String8            0     3     0     index          0   r[3]='index'
│6     String8            0     4     0     idxp           0   r[4]='idxp'
│7     String8            0     5     0     products       0   r[5]='products'
│8     Copy               1     6     1                    0   r[6]=r[1]
│9     String8            0     7     0     CREATE INDEX idxp ON products (price)  0   r[7]='CREATE INDEX idxp ON products (price)'
│10    MakeRecord         3     5     8                    0   r[8]=mkrec(r[3..7])
│11    InsertAsync        0     8     2                    0
│12    InsertAwait        0     0     0                    0
│13    SorterOpen         3     1     0     k(1,B)         0   cursor=3
│14    OpenPseudo         4     9     2                    0   2 columns in r[9]
│15    OpenReadAsync      2     273   0                    0   table=products, root=273
│16    OpenReadAwait      0     0     0                    0
│17    RewindAsync        2     0     0                    0
│18    RewindAwait        2     25    0                    0   Rewind table products
│19      Column           2     2     10                   0   r[10]=products.price
│20      RowId            2     11    0                    0   r[11]=products.rowid
│21      MakeRecord       10    2     12                   0   r[12]=mkrec(r[10..11])
│22      SorterInsert     3     12    0     0              0   key=r[12]
│23    NextAsync          2     0     0                    0
│24    NextAwait          2     19    0                    0
│25    OpenWriteAsync     1     1     0                    0
│26    OpenWriteAwait     0     0     0                    0
│27    SorterSort         3     33    0                    0
│28      SorterData       3     13    4                    0   r[13]=data
│29      SeekEnd          1     0     0                    0
│30      IdxInsertAsync   1     13    0                    0   key=r[13]
│31      IdxInsertAwait   1     0     0                    0
│32    SorterNext         3     28    0                    0
│33    Close              3     0     0                    0
│34    Close              2     0     0                    0
│35    Close              1     0     0                    0
│36    ParseSchema        0     0     0     name = 'idxp' AND type = 'index'  0   name = 'idxp' AND type = 'index'
│37    Close              0     0     0                    0
│38    Halt               0     0     0                    0
│39    Transaction        0     1     0                    0   write=true
│40    Goto               0     1     0                    0
```

This will create the initial index btree and insert whatever relevant records that need to be inserted, it doesn't handle the case of inserting new index keys when normal records are created afterwards. That will prob be added in next PR to keep this one concise.

Limbo will properly use the index in a subsequent query:
![image](https://github.com/user-attachments/assets/eb41e985-4a70-49a5-8218-62c25e4d16c5)


Creating a unique index on a column that has 2 existing identical rows:
![image](https://github.com/user-attachments/assets/ea46c720-5235-4451-81f0-25497ed9ee92)


