### PR TITLE
Switch to using Arc everywhere

### DIFF
--- a/bindings/go/rs_src/lib.rs
+++ b/bindings/go/rs_src/lib.rs
@@ -5,7 +5,6 @@ mod types;
 use limbo_core::{Connection, Database, LimboError, IO};
 use std::{
     ffi::{c_char, c_void},
-    rc::Rc,
     sync::Arc,
 };
 
@@ -40,13 +39,13 @@ pub unsafe extern "C" fn db_open(path: *const c_char) -> *mut c_void {
 
 #[allow(dead_code)]
 struct LimboConn {
-    conn: Rc<Connection>,
+    conn: Arc<Connection>,
     io: Arc<dyn limbo_core::IO>,
     err: Option<LimboError>,
 }
 
 impl LimboConn {
-    fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
+    fn new(conn: Arc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
         LimboConn {
             conn,
             io,

--- a/bindings/go/rs_src/types.rs
+++ b/bindings/go/rs_src/types.rs
@@ -1,5 +1,5 @@
 use std::ffi::{c_char, c_void};
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[allow(dead_code)]
 #[repr(C)]
@@ -198,7 +198,7 @@ impl LimboValue {
                     return limbo_core::OwnedValue::Null;
                 }
                 let bytes = self.value.to_bytes();
-                limbo_core::OwnedValue::Blob(Rc::new(bytes.to_vec()))
+                limbo_core::OwnedValue::Blob(Arc::new(bytes.to_vec()))
             }
             ValueType::Null => limbo_core::OwnedValue::Null,
         }

--- a/bindings/java/rs_src/limbo_connection.rs
+++ b/bindings/java/rs_src/limbo_connection.rs
@@ -8,19 +8,18 @@ use jni::objects::{JByteArray, JObject};
 use jni::sys::jlong;
 use jni::JNIEnv;
 use limbo_core::Connection;
-use std::rc::Rc;
 use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct LimboConnection {
     // Because java's LimboConnection is 1:1 mapped to limbo connection, we can use Rc
-    pub(crate) conn: Rc<Connection>,
+    pub(crate) conn: Arc<Connection>,
     // Because io is shared across multiple `LimboConnection`s, wrap it with Arc
     pub(crate) io: Arc<dyn limbo_core::IO>,
 }
 
 impl LimboConnection {
-    pub fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
+    pub fn new(conn: Arc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
         LimboConnection { conn, io }
     }
 

--- a/bindings/java/rs_src/limbo_statement.rs
+++ b/bindings/java/rs_src/limbo_statement.rs
@@ -7,7 +7,7 @@ use jni::sys::{jdouble, jint, jlong};
 use jni::JNIEnv;
 use limbo_core::{OwnedValue, Statement, StepResult};
 use std::num::NonZero;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub const STEP_RESULT_ID_ROW: i32 = 10;
 #[allow(dead_code)]
@@ -264,7 +264,7 @@ pub extern "system" fn Java_tech_turso_core_LimboStatement_bindBlob<'local>(
 
     stmt.stmt.bind_at(
         NonZero::new(position as usize).unwrap(),
-        OwnedValue::Blob(Rc::new(blob)),
+        OwnedValue::Blob(Arc::new(blob)),
     );
     SQLITE_OK
 }

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(clippy::all)]
 
 use std::cell::RefCell;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use napi::{Env, JsObject, JsUnknown, Result as NapiResult};
@@ -12,7 +11,7 @@ pub struct Database {
     #[napi(writable = false)]
     pub memory: bool,
     _db: Arc<limbo_core::Database>,
-    conn: Rc<limbo_core::Connection>,
+    conn: Arc<limbo_core::Connection>,
 }
 
 #[napi]

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -7,7 +7,6 @@ pub use params::params_from_iter;
 
 use crate::params::*;
 use std::num::NonZero;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug, thiserror::Error)]
@@ -74,7 +73,7 @@ impl Database {
 }
 
 pub struct Connection {
-    inner: Arc<Mutex<Rc<limbo_core::Connection>>>,
+    inner: Arc<Mutex<Arc<limbo_core::Connection>>>,
 }
 
 impl Clone for Connection {

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -1,14 +1,13 @@
 use js_sys::{Array, Object};
 use limbo_core::{maybe_init_database_file, OpenFlags, Pager, Result, WalFileShared};
 use std::cell::RefCell;
-use std::rc::Rc;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 #[allow(dead_code)]
 #[wasm_bindgen]
 pub struct Database {
     db: Arc<limbo_core::Database>,
-    conn: Rc<limbo_core::Connection>,
+    conn: Arc<limbo_core::Connection>,
 }
 
 #[allow(clippy::arc_with_non_send_sync)]

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -168,7 +168,7 @@ pub struct Limbo<'a> {
     pub prompt: String,
     io: Arc<dyn limbo_core::IO>,
     writer: Box<dyn Write>,
-    conn: Rc<limbo_core::Connection>,
+    conn: Arc<limbo_core::Connection>,
     pub interrupt_count: Arc<AtomicUsize>,
     input_buff: String,
     opts: Settings,

--- a/cli/helper.rs
+++ b/cli/helper.rs
@@ -1,4 +1,3 @@
-use std::rc::Rc;
 use std::sync::Arc;
 
 use limbo_core::{Connection, StepResult};
@@ -26,7 +25,7 @@ pub struct LimboHelper {
 }
 
 impl LimboHelper {
-    pub fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
+    pub fn new(conn: Arc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
         LimboHelper {
             completer: SqlCompleter::new(conn, io),
             hinter: HistoryHinter::new(),
@@ -78,12 +77,12 @@ impl Highlighter for LimboHelper {
 }
 
 pub struct SqlCompleter {
-    conn: Rc<Connection>,
+    conn: Arc<Connection>,
     io: Arc<dyn limbo_core::IO>,
 }
 
 impl SqlCompleter {
-    pub fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
+    pub fn new(conn: Arc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
         Self { conn, io }
     }
 }

--- a/cli/import.rs
+++ b/cli/import.rs
@@ -32,14 +32,14 @@ pub struct ImportArgs {
 }
 
 pub struct ImportFile<'a> {
-    conn: Rc<Connection>,
+    conn: Arc<Connection>,
     io: Arc<dyn limbo_core::IO>,
     writer: &'a mut dyn Write,
 }
 
 impl<'a> ImportFile<'a> {
     pub fn new(
-        conn: Rc<Connection>,
+        conn: Arc<Connection>,
         io: Arc<dyn limbo_core::IO>,
         writer: &'a mut dyn Write,
     ) -> Self {

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -11,7 +11,6 @@ use limbo_ext::{
 pub use limbo_ext::{FinalizeFunction, StepFunction, Value as ExtValue, ValueType as ExtValueType};
 use std::{
     ffi::{c_char, c_void, CStr, CString},
-    rc::Rc,
     sync::Arc,
 };
 type ExternAggFunc = (InitAggFunction, StepFunction, FinalizeFunction);
@@ -19,7 +18,7 @@ type ExternAggFunc = (InitAggFunction, StepFunction, FinalizeFunction);
 #[derive(Clone)]
 pub struct VTabImpl {
     pub module_kind: VTabKind,
-    pub implementation: Rc<VTabModuleImpl>,
+    pub implementation: Arc<VTabModuleImpl>,
 }
 
 pub(crate) unsafe extern "C" fn register_scalar_function(
@@ -116,7 +115,7 @@ impl Connection {
     fn register_scalar_function_impl(&self, name: &str, func: ScalarFunction) -> ResultCode {
         self.syms.borrow_mut().functions.insert(
             name.to_string(),
-            Rc::new(ExternalFunc::new_scalar(name.to_string(), func)),
+            Arc::new(ExternalFunc::new_scalar(name.to_string(), func)),
         );
         ResultCode::OK
     }
@@ -129,7 +128,7 @@ impl Connection {
     ) -> ResultCode {
         self.syms.borrow_mut().functions.insert(
             name.to_string(),
-            Rc::new(ExternalFunc::new_aggregate(name.to_string(), args, func)),
+            Arc::new(ExternalFunc::new_aggregate(name.to_string(), args, func)),
         );
         ResultCode::OK
     }
@@ -140,7 +139,7 @@ impl Connection {
         module: VTabModuleImpl,
         kind: VTabKind,
     ) -> ResultCode {
-        let module = Rc::new(module);
+        let module = Arc::new(module);
         let vmodule = VTabImpl {
             module_kind: kind,
             implementation: module,

--- a/core/function.rs
+++ b/core/function.rs
@@ -1,7 +1,7 @@
 use limbo_ext::{FinalizeFunction, InitAggFunction, ScalarFunction, StepFunction};
 use std::fmt;
 use std::fmt::{Debug, Display};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::LimboError;
 
@@ -165,7 +165,7 @@ pub enum AggFunc {
     StringAgg,
     Sum,
     Total,
-    External(Rc<ExtFunc>),
+    External(Arc<ExtFunc>),
 }
 
 impl PartialEq for AggFunc {
@@ -179,7 +179,7 @@ impl PartialEq for AggFunc {
             | (Self::StringAgg, Self::StringAgg)
             | (Self::Sum, Self::Sum)
             | (Self::Total, Self::Total) => true,
-            (Self::External(a), Self::External(b)) => Rc::ptr_eq(a, b),
+            (Self::External(a), Self::External(b)) => Arc::ptr_eq(a, b),
             _ => false,
         }
     }
@@ -447,7 +447,7 @@ pub enum Func {
     Vector(VectorFunc),
     #[cfg(feature = "json")]
     Json(JsonFunc),
-    External(Rc<ExternalFunc>),
+    External(Arc<ExternalFunc>),
 }
 
 impl Display for Func {

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -7,7 +7,6 @@ use std::{
     fmt::Debug,
     mem::ManuallyDrop,
     pin::Pin,
-    rc::Rc,
 };
 
 pub trait File: Send + Sync {
@@ -126,7 +125,7 @@ impl SyncCompletion {
 
 pub type BufferData = Pin<Vec<u8>>;
 
-pub type BufferDropFn = Rc<dyn Fn(BufferData)>;
+pub type BufferDropFn = Arc<dyn Fn(BufferData)>;
 
 #[derive(Clone)]
 pub struct Buffer {

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -22,8 +22,8 @@ use jsonb::{ElementType, Jsonb, JsonbHeader, PathOperationMode, SearchOperation,
 use ser::to_string_pretty;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::rc::Rc;
 use std::str::FromStr;
+use std::sync::Arc;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(untagged)]
@@ -73,7 +73,7 @@ pub fn get_json(json_value: &OwnedValue, indent: Option<&str>) -> crate::Result<
             let jsonbin = Jsonb::new(b.len(), Some(b));
             jsonbin.is_valid()?;
             Ok(OwnedValue::Text(Text {
-                value: Rc::new(jsonbin.to_string()?.into_bytes()),
+                value: Arc::new(jsonbin.to_string()?.into_bytes()),
                 subtype: TextSubtype::Json,
             }))
         }
@@ -95,7 +95,7 @@ pub fn jsonb(json_value: &OwnedValue, cache: &JsonCacheCell) -> crate::Result<Ow
 
     let jsonbin = cache.get_or_insert_with(json_value, json_conv_fn);
     match jsonbin {
-        Ok(jsonbin) => Ok(OwnedValue::Blob(Rc::new(jsonbin.data()))),
+        Ok(jsonbin) => Ok(OwnedValue::Blob(Arc::new(jsonbin.data()))),
         Err(_) => {
             bail_parse_error!("malformed JSON")
         }
@@ -405,7 +405,7 @@ fn json_string_to_db_type(
 ) -> crate::Result<OwnedValue> {
     let mut json_string = json.to_string()?;
     if matches!(flag, OutputVariant::Binary) {
-        return Ok(OwnedValue::Blob(Rc::new(json.data())));
+        return Ok(OwnedValue::Blob(Arc::new(json.data())));
     }
     match element_type {
         ElementType::ARRAY | ElementType::OBJECT => Ok(OwnedValue::Text(Text::json(json_string))),
@@ -414,12 +414,12 @@ fn json_string_to_db_type(
                 json_string.remove(json_string.len() - 1);
                 json_string.remove(0);
                 Ok(OwnedValue::Text(Text {
-                    value: Rc::new(json_string.into_bytes()),
+                    value: Arc::new(json_string.into_bytes()),
                     subtype: TextSubtype::Json,
                 }))
             } else {
                 Ok(OwnedValue::Text(Text {
-                    value: Rc::new(json_string.into_bytes()),
+                    value: Arc::new(json_string.into_bytes()),
                     subtype: TextSubtype::Text,
                 }))
             }
@@ -664,8 +664,6 @@ pub fn json_quote(value: &OwnedValue) -> crate::Result<OwnedValue> {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
     use super::*;
     use crate::types::OwnedValue;
 
@@ -764,7 +762,7 @@ mod tests {
     #[test]
     fn test_get_json_blob_valid_jsonb() {
         let binary_json = vec![124, 55, 104, 101, 121, 39, 121, 111];
-        let input = OwnedValue::Blob(Rc::new(binary_json));
+        let input = OwnedValue::Blob(Arc::new(binary_json));
         let result = get_json(&input, None).unwrap();
         if let OwnedValue::Text(result_str) = result {
             assert!(result_str.as_str().contains(r#"{"hey":"yo"}"#));
@@ -777,7 +775,7 @@ mod tests {
     #[test]
     fn test_get_json_blob_invalid_jsonb() {
         let binary_json: Vec<u8> = vec![0xA2, 0x62, 0x6B, 0x31, 0x62, 0x76]; // Incomplete binary JSON
-        let input = OwnedValue::Blob(Rc::new(binary_json));
+        let input = OwnedValue::Blob(Arc::new(binary_json));
         let result = get_json(&input, None);
         println!("{:?}", result);
         match result {
@@ -832,7 +830,7 @@ mod tests {
 
     #[test]
     fn test_json_array_blob_invalid() {
-        let blob = Register::OwnedValue(OwnedValue::Blob(Rc::new("1".as_bytes().to_vec())));
+        let blob = Register::OwnedValue(OwnedValue::Blob(Arc::new("1".as_bytes().to_vec())));
 
         let input = vec![blob];
 

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -621,8 +621,8 @@ use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::cursor::{BucketScanCursor, LazyScanCursor, ScanCursor};
 use crate::mvcc::database::{MvStore, Row, RowID};
 use crate::mvcc::persistent_storage::Storage;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 // Simple atomic clock implementation for testing
 struct TestClock {
@@ -650,10 +650,10 @@ impl LogicalClock for TestClock {
     }
 }
 
-fn setup_test_db() -> (Rc<MvStore<TestClock>>, u64) {
+fn setup_test_db() -> (Arc<MvStore<TestClock>>, u64) {
     let clock = TestClock::new(1);
     let storage = Storage::new_noop();
-    let db = Rc::new(MvStore::new(clock, storage));
+    let db = Arc::new(MvStore::new(clock, storage));
     let tx_id = db.begin_tx();
 
     let table_id = 1;
@@ -677,10 +677,10 @@ fn setup_test_db() -> (Rc<MvStore<TestClock>>, u64) {
     (db, tx_id)
 }
 
-fn setup_sequential_db() -> (Rc<MvStore<TestClock>>, u64) {
+fn setup_sequential_db() -> (Arc<MvStore<TestClock>>, u64) {
     let clock = TestClock::new(1);
     let storage = Storage::new_noop();
-    let db = Rc::new(MvStore::new(clock, storage));
+    let db = Arc::new(MvStore::new(clock, storage));
     let tx_id = db.begin_tx();
 
     let table_id = 1;
@@ -848,7 +848,7 @@ fn test_scan_cursor_basic() {
 fn test_cursor_with_empty_table() {
     let clock = TestClock::new(1);
     let storage = Storage::new_noop();
-    let db = Rc::new(MvStore::new(clock, storage));
+    let db = Arc::new(MvStore::new(clock, storage));
     let tx_id = db.begin_tx();
     let table_id = 1; // Empty table
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -8,7 +8,6 @@ use limbo_sqlite3_parser::{
     lexer::sql::Parser,
 };
 use std::collections::HashMap;
-use std::rc::Rc;
 use std::sync::Arc;
 use tracing::trace;
 
@@ -30,12 +29,12 @@ impl Schema {
         Self { tables, indexes }
     }
 
-    pub fn add_btree_table(&mut self, table: Rc<BTreeTable>) {
+    pub fn add_btree_table(&mut self, table: Arc<BTreeTable>) {
         let name = normalize_ident(&table.name);
         self.tables.insert(name, Table::BTree(table).into());
     }
 
-    pub fn add_virtual_table(&mut self, table: Rc<VirtualTable>) {
+    pub fn add_virtual_table(&mut self, table: Arc<VirtualTable>) {
         let name = normalize_ident(&table.name);
         self.tables.insert(name, Table::Virtual(table).into());
     }
@@ -50,7 +49,7 @@ impl Schema {
         self.tables.remove(&name);
     }
 
-    pub fn get_btree_table(&self, name: &str) -> Option<Rc<BTreeTable>> {
+    pub fn get_btree_table(&self, name: &str) -> Option<Arc<BTreeTable>> {
         let name = normalize_ident(name);
         if let Some(table) = self.tables.get(&name) {
             table.btree()
@@ -82,9 +81,9 @@ impl Schema {
 
 #[derive(Clone, Debug)]
 pub enum Table {
-    BTree(Rc<BTreeTable>),
-    Pseudo(Rc<PseudoTable>),
-    Virtual(Rc<VirtualTable>),
+    BTree(Arc<BTreeTable>),
+    Pseudo(Arc<PseudoTable>),
+    Virtual(Arc<VirtualTable>),
 }
 
 impl Table {
@@ -120,7 +119,7 @@ impl Table {
         }
     }
 
-    pub fn btree(&self) -> Option<Rc<BTreeTable>> {
+    pub fn btree(&self) -> Option<Arc<BTreeTable>> {
         match self {
             Self::BTree(table) => Some(table.clone()),
             Self::Pseudo(_) => None,
@@ -128,7 +127,7 @@ impl Table {
         }
     }
 
-    pub fn virtual_table(&self) -> Option<Rc<VirtualTable>> {
+    pub fn virtual_table(&self) -> Option<Arc<VirtualTable>> {
         match self {
             Self::Virtual(table) => Some(table.clone()),
             _ => None,
@@ -139,9 +138,9 @@ impl Table {
 impl PartialEq for Table {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::BTree(a), Self::BTree(b)) => Rc::ptr_eq(a, b),
-            (Self::Pseudo(a), Self::Pseudo(b)) => Rc::ptr_eq(a, b),
-            (Self::Virtual(a), Self::Virtual(b)) => Rc::ptr_eq(a, b),
+            (Self::BTree(a), Self::BTree(b)) => Arc::ptr_eq(a, b),
+            (Self::Pseudo(a), Self::Pseudo(b)) => Arc::ptr_eq(a, b),
+            (Self::Virtual(a), Self::Virtual(b)) => Arc::ptr_eq(a, b),
             _ => false,
         }
     }

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use limbo_sqlite3_parser::ast;
 
@@ -179,7 +179,7 @@ pub fn emit_group_by<'a>(
         .collect::<Vec<_>>();
 
     // A pseudo table is a "fake" table to which we read one row at a time from the sorter
-    let pseudo_table = Rc::new(PseudoTable {
+    let pseudo_table = Arc::new(PseudoTable {
         columns: pseudo_columns,
     });
 

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1,5 +1,5 @@
 use std::ops::Deref;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use limbo_sqlite3_parser::ast::{
     DistinctNames, Expr, InsertBody, OneSelect, QualifiedName, ResolveType, ResultColumn, With,
@@ -446,7 +446,7 @@ fn populate_column_registers(
 
 fn translate_virtual_table_insert(
     program: &mut ProgramBuilder,
-    virtual_table: Rc<VirtualTable>,
+    virtual_table: Arc<VirtualTable>,
     columns: &Option<DistinctNames>,
     body: &InsertBody,
     on_conflict: &Option<ResolveType>,

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -38,8 +38,7 @@ use insert::translate_insert;
 use limbo_sqlite3_parser::ast::{self, Delete, Insert};
 use schema::{translate_create_table, translate_create_virtual_table, translate_drop_table};
 use select::translate_select;
-use std::rc::{Rc, Weak};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use transaction::{translate_tx_begin, translate_tx_commit};
 use update::translate_update;
 
@@ -48,7 +47,7 @@ pub fn translate(
     schema: &Schema,
     stmt: ast::Stmt,
     database_header: Arc<SpinLock<DatabaseHeader>>,
-    pager: Rc<Pager>,
+    pager: Arc<Pager>,
     connection: Weak<Connection>,
     syms: &SymbolTable,
     query_mode: QueryMode,

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use limbo_sqlite3_parser::ast;
 
@@ -105,7 +105,7 @@ pub fn emit_order_by(
             .map(|v| v.len())
             .unwrap_or(0);
 
-    let pseudo_table = Rc::new(PseudoTable {
+    let pseudo_table = Arc::new(PseudoTable {
         columns: pseudo_columns,
     });
     let pseudo_cursor = program.alloc_cursor_id(None, CursorType::Pseudo(pseudo_table.clone()));

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3,7 +3,6 @@ use limbo_sqlite3_parser::ast;
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter},
-    rc::Rc,
     sync::Arc,
 };
 
@@ -267,13 +266,13 @@ pub enum Operation {
 
 impl TableReference {
     /// Returns the btree table for this table reference, if it is a BTreeTable.
-    pub fn btree(&self) -> Option<Rc<BTreeTable>> {
+    pub fn btree(&self) -> Option<Arc<BTreeTable>> {
         match &self.table {
             Table::BTree(_) => self.table.btree(),
             _ => None,
         }
     }
-    pub fn virtual_table(&self) -> Option<Rc<VirtualTable>> {
+    pub fn virtual_table(&self) -> Option<Arc<VirtualTable>> {
         match &self.table {
             Table::Virtual(_) => self.table.virtual_table(),
             _ => None,
@@ -282,7 +281,7 @@ impl TableReference {
 
     /// Creates a new TableReference for a subquery.
     pub fn new_subquery(identifier: String, plan: SelectPlan, join_info: Option<JoinInfo>) -> Self {
-        let table = Table::Pseudo(Rc::new(PseudoTable::new_with_columns(
+        let table = Table::Pseudo(Arc::new(PseudoTable::new_with_columns(
             plan.result_columns
                 .iter()
                 .map(|rc| Column {

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -3,7 +3,6 @@
 
 use limbo_sqlite3_parser::ast;
 use limbo_sqlite3_parser::ast::PragmaName;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::fast_lock::SpinLock;
@@ -40,7 +39,7 @@ pub fn translate_pragma(
     name: &ast::QualifiedName,
     body: Option<ast::PragmaBody>,
     database_header: Arc<SpinLock<DatabaseHeader>>,
-    pager: Rc<Pager>,
+    pager: Arc<Pager>,
 ) -> crate::Result<ProgramBuilder> {
     let mut program = ProgramBuilder::new(ProgramBuilderOpts {
         query_mode,
@@ -117,7 +116,7 @@ fn update_pragma(
     schema: &Schema,
     value: ast::Expr,
     header: Arc<SpinLock<DatabaseHeader>>,
-    pager: Rc<Pager>,
+    pager: Arc<Pager>,
     program: &mut ProgramBuilder,
 ) -> crate::Result<()> {
     match pragma {
@@ -262,7 +261,7 @@ fn query_pragma(
     Ok(())
 }
 
-fn update_cache_size(value: i64, header: Arc<SpinLock<DatabaseHeader>>, pager: Rc<Pager>) {
+fn update_cache_size(value: i64, header: Arc<SpinLock<DatabaseHeader>>, pager: Arc<Pager>) {
     let mut cache_size_unformatted: i64 = value;
     let mut cache_size = if cache_size_unformatted < 0 {
         let kb = cache_size_unformatted.abs() * 1024;

--- a/core/types.rs
+++ b/core/types.rs
@@ -11,8 +11,7 @@ use crate::Result;
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::pin::Pin;
-use std::rc::Rc;
-
+use std::sync::Arc;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum OwnedValueType {
     Null,
@@ -31,7 +30,7 @@ pub enum TextSubtype {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Text {
-    pub value: Rc<Vec<u8>>,
+    pub value: Arc<Vec<u8>>,
     pub subtype: TextSubtype,
 }
 
@@ -48,14 +47,14 @@ impl Text {
 
     pub fn new(value: &str) -> Self {
         Self {
-            value: Rc::new(value.as_bytes().to_vec()),
+            value: Arc::new(value.as_bytes().to_vec()),
             subtype: TextSubtype::Text,
         }
     }
 
     pub fn json(value: String) -> Self {
         Self {
-            value: Rc::new(value.into_bytes()),
+            value: Arc::new(value.into_bytes()),
             subtype: TextSubtype::Json,
         }
     }
@@ -75,7 +74,7 @@ pub enum OwnedValue {
     Integer(i64),
     Float(f64),
     Text(Text),
-    Blob(Rc<Vec<u8>>),
+    Blob(Arc<Vec<u8>>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -107,7 +106,7 @@ impl OwnedValue {
     }
 
     pub fn from_blob(data: Vec<u8>) -> Self {
-        OwnedValue::Blob(std::rc::Rc::new(data))
+        OwnedValue::Blob(std::sync::Arc::new(data))
     }
 
     pub fn to_text(&self) -> Option<&str> {
@@ -200,7 +199,7 @@ impl OwnedValue {
                 let Some(blob) = v.to_blob() else {
                     return Ok(OwnedValue::Null);
                 };
-                Ok(OwnedValue::Blob(Rc::new(blob)))
+                Ok(OwnedValue::Blob(Arc::new(blob)))
             }
             ExtValueType::Error => {
                 let Some(err) = v.to_error_details() else {
@@ -559,10 +558,10 @@ impl RefValue {
             RefValue::Integer(i) => OwnedValue::Integer(*i),
             RefValue::Float(f) => OwnedValue::Float(*f),
             RefValue::Text(text_ref) => OwnedValue::Text(Text {
-                value: Rc::new(text_ref.value.to_slice().to_vec()),
+                value: Arc::new(text_ref.value.to_slice().to_vec()),
                 subtype: text_ref.subtype.clone(),
             }),
-            RefValue::Blob(b) => OwnedValue::Blob(Rc::new(b.to_slice().to_vec())),
+            RefValue::Blob(b) => OwnedValue::Blob(Arc::new(b.to_slice().to_vec())),
         }
     }
 }
@@ -972,7 +971,6 @@ impl RawSlice {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::rc::Rc;
 
     #[test]
     fn test_serialize_null() {
@@ -1107,7 +1105,7 @@ mod tests {
 
     #[test]
     fn test_serialize_blob() {
-        let blob = Rc::new(vec![1, 2, 3, 4, 5]);
+        let blob = Arc::new(vec![1, 2, 3, 4, 5]);
         let record = Record::new(vec![OwnedValue::Blob(blob.clone())]);
         let mut buf = Vec::new();
         record.serialize(&mut buf);

--- a/core/util.rs
+++ b/core/util.rs
@@ -1,5 +1,5 @@
 use limbo_sqlite3_parser::ast::{self, CreateTableBody, Expr, FunctionTail, Literal};
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
     schema::{self, Column, Schema, Type},
@@ -64,7 +64,7 @@ pub fn parse_schema_rows(
                                 schema.add_virtual_table(vtab);
                             } else {
                                 let table = schema::BTreeTable::from_sql(sql, root_page as usize)?;
-                                schema.add_btree_table(Rc::new(table));
+                                schema.add_btree_table(Arc::new(table));
                             }
                         }
                         "index" => {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,8 +1,7 @@
 use std::{
     cell::Cell,
     collections::HashMap,
-    rc::{Rc, Weak},
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 
 use limbo_sqlite3_parser::ast;
@@ -41,11 +40,11 @@ pub struct ProgramBuilder {
 
 #[derive(Debug, Clone)]
 pub enum CursorType {
-    BTreeTable(Rc<BTreeTable>),
+    BTreeTable(Arc<BTreeTable>),
     BTreeIndex(Arc<Index>),
-    Pseudo(Rc<PseudoTable>),
+    Pseudo(Arc<PseudoTable>),
     Sorter,
-    VirtualTable(Rc<VirtualTable>),
+    VirtualTable(Arc<VirtualTable>),
 }
 
 impl CursorType {

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -2,7 +2,7 @@ use crate::vdbe::builder::CursorType;
 
 use super::{Insn, InsnReference, OwnedValue, Program};
 use crate::function::{Func, ScalarFunc};
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub fn insn_to_str(
     program: &Program,
@@ -672,7 +672,7 @@ pub fn insn_to_str(
                 0,
                 *dest as i32,
                 0,
-                OwnedValue::Blob(Rc::new(value.clone())),
+                OwnedValue::Blob(Arc::new(value.clone())),
                 0,
                 format!(
                     "r[{}]={} (len={})",
@@ -1146,7 +1146,7 @@ pub fn insn_to_str(
                 *root as i32,
                 *former_root_reg as i32,
                 *is_temp as i32,
-                OwnedValue::build_text(&Rc::new("".to_string())),
+                OwnedValue::build_text(&Arc::new("".to_string())),
                 0,
                 format!(
                     "root iDb={} former_root={} is_temp={}",
@@ -1163,7 +1163,7 @@ pub fn insn_to_str(
                 *db as i32,
                 0,
                 0,
-                OwnedValue::build_text(&Rc::new(table_name.clone())),
+                OwnedValue::build_text(&Arc::new(table_name.clone())),
                 0,
                 format!("DROP TABLE {}", table_name),
             ),

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, path::Path, rc::Rc, vec};
+use std::{fmt::Display, path::Path, sync::Arc, vec};
 
 use limbo_core::{Connection, Result, StepResult};
 use serde::{Deserialize, Serialize};
@@ -470,7 +470,7 @@ impl Interaction {
             Self::Assumption(_) | Self::Assertion(_) | Self::Fault(_) => vec![],
         }
     }
-    pub(crate) fn execute_query(&self, conn: &mut Rc<Connection>) -> ResultSet {
+    pub(crate) fn execute_query(&self, conn: &mut Arc<Connection>) -> ResultSet {
         if let Self::Query(query) = self {
             let query_str = query.to_string();
             let rows = conn.query(&query_str);

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use limbo_core::{Connection, Database};
@@ -114,7 +113,7 @@ pub trait ConnectionTrait {
 
 #[derive(Clone)]
 pub(crate) enum SimConnection {
-    Connected(Rc<Connection>),
+    Connected(Arc<Connection>),
     Disconnected,
 }
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -4,7 +4,6 @@
 use log::trace;
 use std::ffi::{self, CStr, CString};
 
-use std::rc::Rc;
 use std::sync::Arc;
 
 macro_rules! stub {
@@ -40,7 +39,7 @@ use util::sqlite3_safety_check_sick_or_ok;
 
 pub struct sqlite3 {
     pub(crate) _db: Arc<limbo_core::Database>,
-    pub(crate) conn: Rc<limbo_core::Connection>,
+    pub(crate) conn: Arc<limbo_core::Connection>,
     pub(crate) err_code: ffi::c_int,
     pub(crate) err_mask: ffi::c_int,
     pub(crate) malloc_failed: bool,
@@ -49,7 +48,7 @@ pub struct sqlite3 {
 }
 
 impl sqlite3 {
-    pub fn new(db: Arc<limbo_core::Database>, conn: Rc<limbo_core::Connection>) -> Self {
+    pub fn new(db: Arc<limbo_core::Database>, conn: Arc<limbo_core::Connection>) -> Self {
         Self {
             _db: db,
             conn,

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -1,7 +1,6 @@
 use limbo_core::{CheckpointStatus, Connection, Database, IO};
 use rand::{rng, RngCore};
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -40,7 +39,7 @@ impl TempDatabase {
         Self { path, io }
     }
 
-    pub fn connect_limbo(&self) -> Rc<limbo_core::Connection> {
+    pub fn connect_limbo(&self) -> Arc<limbo_core::Connection> {
         log::debug!("conneting to limbo");
         let db = Database::open_file(self.io.clone(), self.path.to_str().unwrap(), false).unwrap();
 
@@ -55,7 +54,7 @@ impl TempDatabase {
     }
 }
 
-pub(crate) fn do_flush(conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
+pub(crate) fn do_flush(conn: &Arc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
     loop {
         match conn.cacheflush()? {
             CheckpointStatus::Done(_) => {

--- a/tests/integration/fuzz/grammar_generator.rs
+++ b/tests/integration/fuzz/grammar_generator.rs
@@ -14,7 +14,7 @@
 ///
 /// The idea behind this code is to provide a way to "build" grammar generator with all these rules and their dependencies and after that
 /// we can randomly sample strings from this generator easily.
-use std::{cell::RefCell, collections::HashMap, ops::Range, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, ops::Range, sync::Arc};
 
 use rand::Rng;
 use rand_chacha::ChaCha8Rng;
@@ -82,7 +82,7 @@ enum GrammarFrontierNode {
 }
 
 #[derive(Clone)]
-pub struct GrammarGenerator(Rc<RefCell<GrammarGeneratorInner>>);
+pub struct GrammarGenerator(Arc<RefCell<GrammarGeneratorInner>>);
 
 struct GrammarGeneratorInner {
     last_symbol_id: i32,
@@ -91,7 +91,7 @@ struct GrammarGeneratorInner {
 
 impl GrammarGenerator {
     pub fn new() -> Self {
-        GrammarGenerator(Rc::new(RefCell::new(GrammarGeneratorInner {
+        GrammarGenerator(Arc::new(RefCell::new(GrammarGeneratorInner {
             last_symbol_id: 0,
             symbols: HashMap::new(),
         })))

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -2,7 +2,7 @@ pub mod grammar_generator;
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
@@ -49,7 +49,7 @@ mod tests {
 
     fn limbo_exec_rows(
         db: &TempDatabase,
-        conn: &Rc<limbo_core::Connection>,
+        conn: &Arc<limbo_core::Connection>,
         query: &str,
     ) -> Vec<Vec<rusqlite::types::Value>> {
         let mut stmt = conn.prepare(query).unwrap();

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -2,7 +2,7 @@ use crate::common;
 use crate::common::{compare_string, do_flush, TempDatabase};
 use limbo_core::{Connection, StepResult};
 use log::debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[test]
 #[ignore]
@@ -400,7 +400,7 @@ fn test_wal_restart() -> anyhow::Result<()> {
     let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);");
     // threshold is 1000 by default
 
-    fn insert(i: usize, conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
+    fn insert(i: usize, conn: &Arc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
         debug!("inserting {}", i);
         let insert_query = format!("INSERT INTO test VALUES ({})", i);
         match conn.query(insert_query) {
@@ -423,7 +423,7 @@ fn test_wal_restart() -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn count(conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<usize> {
+    fn count(conn: &Arc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<usize> {
         debug!("counting");
         let list_query = "SELECT count(x) FROM test";
         loop {

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -2,7 +2,6 @@ use crate::common::{do_flush, TempDatabase};
 use limbo_core::{Connection, LimboError, Result, StepResult};
 use std::cell::RefCell;
 use std::ops::Deref;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -130,11 +129,11 @@ fn maybe_setup_tracing() {
 /// Execute a statement and get strings result
 pub(crate) fn execute_and_get_strings(
     tmp_db: &TempDatabase,
-    conn: &Rc<Connection>,
+    conn: &Arc<Connection>,
     sql: &str,
 ) -> Result<Vec<String>> {
     let statement = conn.prepare(sql)?;
-    let stmt = Rc::new(RefCell::new(statement));
+    let stmt = Arc::new(RefCell::new(statement));
     let mut result = Vec::new();
 
     let mut stmt = stmt.borrow_mut();
@@ -158,11 +157,11 @@ pub(crate) fn execute_and_get_strings(
 /// Execute a statement and get integers
 pub(crate) fn execute_and_get_ints(
     tmp_db: &TempDatabase,
-    conn: &Rc<Connection>,
+    conn: &Arc<Connection>,
     sql: &str,
 ) -> Result<Vec<i64>> {
     let statement = conn.prepare(sql)?;
-    let stmt = Rc::new(RefCell::new(statement));
+    let stmt = Arc::new(RefCell::new(statement));
     let mut result = Vec::new();
 
     let mut stmt = stmt.borrow_mut();


### PR DESCRIPTION
The language bindings need to use `Arc<Mutex<T>>` to wrap up the various Limbo data structures. Let's switch to Arc instead of Rc to make that a bit easier.