### PR TITLE
Fix IdxCmp insn comparisons

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -40,8 +40,8 @@ use crate::storage::wal::CheckpointResult;
 use crate::storage::{btree::BTreeCursor, pager::Pager};
 use crate::translate::plan::{ResultSetColumn, TableReference};
 use crate::types::{
-    compare_immutable, AggContext, Cursor, CursorResult, ExternalAggState, ImmutableRecord,
-    OwnedValue, SeekKey, SeekOp,
+    AggContext, Cursor, CursorResult, ExternalAggState, ImmutableRecord, OwnedValue, SeekKey,
+    SeekOp,
 };
 use crate::util::{
     cast_real_to_integer, cast_text_to_integer, cast_text_to_numeric, cast_text_to_real,
@@ -1700,10 +1700,9 @@ impl Program {
                         let record_from_regs = make_record(&state.registers, start_reg, num_regs);
                         let pc = if let Some(ref idx_record) = *cursor.record() {
                             // Compare against the same number of values
-                            let ord = compare_immutable(
-                                &idx_record.get_values()[..record_from_regs.len()],
-                                &record_from_regs.get_values(),
-                            );
+                            let ord = idx_record.get_values()[..record_from_regs.len()]
+                                .partial_cmp(&record_from_regs.get_values()[..])
+                                .unwrap();
                             if ord.is_ge() {
                                 target_pc.to_offset_int()
                             } else {
@@ -1729,11 +1728,10 @@ impl Program {
                         let record_from_regs = make_record(&state.registers, start_reg, num_regs);
                         let pc = if let Some(ref idx_record) = *cursor.record() {
                             // Compare against the same number of values
-                            if idx_record.get_values()[..record_from_regs.len()]
-                                .iter()
-                                .zip(&record_from_regs.get_values()[..])
-                                .all(|(a, b)| a <= b)
-                            {
+                            let ord = idx_record.get_values()[..record_from_regs.len()]
+                                .partial_cmp(&record_from_regs.get_values()[..])
+                                .unwrap();
+                            if ord.is_le() {
                                 target_pc.to_offset_int()
                             } else {
                                 state.pc + 1
@@ -1758,11 +1756,10 @@ impl Program {
                         let record_from_regs = make_record(&state.registers, start_reg, num_regs);
                         let pc = if let Some(ref idx_record) = *cursor.record() {
                             // Compare against the same number of values
-                            if idx_record.get_values()[..record_from_regs.len()]
-                                .iter()
-                                .zip(&record_from_regs.get_values()[..])
-                                .all(|(a, b)| a > b)
-                            {
+                            let ord = idx_record.get_values()[..record_from_regs.len()]
+                                .partial_cmp(&record_from_regs.get_values()[..])
+                                .unwrap();
+                            if ord.is_gt() {
                                 target_pc.to_offset_int()
                             } else {
                                 state.pc + 1
@@ -1787,11 +1784,10 @@ impl Program {
                         let record_from_regs = make_record(&state.registers, start_reg, num_regs);
                         let pc = if let Some(ref idx_record) = *cursor.record() {
                             // Compare against the same number of values
-                            if idx_record.get_values()[..record_from_regs.len()]
-                                .iter()
-                                .zip(&record_from_regs.get_values()[..])
-                                .all(|(a, b)| a < b)
-                            {
+                            let ord = idx_record.get_values()[..record_from_regs.len()]
+                                .partial_cmp(&record_from_regs.get_values()[..])
+                                .unwrap();
+                            if ord.is_lt() {
                                 target_pc.to_offset_int()
                             } else {
                                 state.pc + 1


### PR DESCRIPTION
We never hit bugs due to these because of 1. not having multi column indexes in our TCL test databases, 2. otherwise not really having Rust tests involving indexes, and 3. `IdxLt` and `IdxLe` not actually being used anywhere yet

Also as @PThorpe92 pointed out there are some nuances to the comparison logic we may need to eventually implement regarding comparisons with uneven number of keys: https://github.com/sqlite/sqlite/blob/master/src/vdbeaux.c#L4719