### PR TITLE
Add affinity string to MakeRecord instruction

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -507,11 +507,11 @@ pub enum Affinity {
     Numeric,
 }
 
-pub const SQLITE_AFF_NONE: char = 'a'; // Historically called NONE, but it's the same as BLOB
-pub const SQLITE_AFF_TEXT: char = 'b';
-pub const SQLITE_AFF_NUMERIC: char = 'c';
-pub const SQLITE_AFF_INTEGER: char = 'd';
-pub const SQLITE_AFF_REAL: char = 'e';
+pub const SQLITE_AFF_NONE: char = 'A'; // Historically called NONE, but it's the same as BLOB
+pub const SQLITE_AFF_TEXT: char = 'B';
+pub const SQLITE_AFF_NUMERIC: char = 'C';
+pub const SQLITE_AFF_INTEGER: char = 'D';
+pub const SQLITE_AFF_REAL: char = 'E';
 
 impl Affinity {
     /// This is meant to be used in opcodes like Eq, which state:

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -507,8 +507,8 @@ pub enum Affinity {
     Numeric,
 }
 
-pub const SQLITE_AFF_TEXT: char = 'a';
-pub const SQLITE_AFF_NONE: char = 'b'; // Historically called NONE, but it's the same as BLOB
+pub const SQLITE_AFF_NONE: char = 'a'; // Historically called NONE, but it's the same as BLOB
+pub const SQLITE_AFF_TEXT: char = 'b';
 pub const SQLITE_AFF_NUMERIC: char = 'c';
 pub const SQLITE_AFF_INTEGER: char = 'd';
 pub const SQLITE_AFF_REAL: char = 'e';

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -560,11 +560,17 @@ fn emit_update_insns(
             }
         }
     }
+    let affinity_string = table_ref
+        .columns()
+        .iter()
+        .map(|col| col.affinity().aff_mask())
+        .collect::<String>();
     let record_reg = program.alloc_register();
     program.emit_insn(Insn::MakeRecord {
         start_reg: first_col_reg,
         count: table_ref.columns().len(),
         dest_reg: record_reg,
+        affinity_string: Some(affinity_string),
     });
     program.emit_insn(Insn::InsertAsync {
         cursor: cursor_id,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -252,7 +252,7 @@ pub fn translate_insert(
     let affinity_string = btree_table
         .columns
         .iter()
-        .map(|col| col.affinity().aff_mask().to_ascii_uppercase())
+        .map(|col| col.affinity().aff_mask())
         .collect::<String>();
 
     // Create and insert the record

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -249,12 +249,18 @@ pub fn translate_insert(
 
         program.resolve_label(make_record_label, program.offset());
     }
+    let affinity_string = btree_table
+        .columns
+        .iter()
+        .map(|col| col.affinity().aff_mask().to_ascii_uppercase())
+        .collect::<String>();
 
     // Create and insert the record
     program.emit_insn(Insn::MakeRecord {
         start_reg: column_registers_start,
         count: num_cols,
         dest_reg: record_register,
+        affinity_string: Some(affinity_string),
     });
 
     program.emit_insn(Insn::InsertAsync {

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -245,6 +245,7 @@ pub fn sorter_insert(
         start_reg,
         count: column_count,
         dest_reg: record_reg,
+        affinity_string: None,
     });
     program.emit_insn(Insn::SorterInsert {
         cursor_id,

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -104,7 +104,7 @@ pub fn translate_create_table(
     let affinity_string = table
         .columns
         .iter()
-        .map(|col| col.affinity().aff_mask().to_ascii_uppercase())
+        .map(|col| col.affinity().aff_mask())
         .collect::<String>();
     program.emit_insn(Insn::OpenWriteAsync {
         cursor_id: sqlite_schema_cursor_id,

--- a/core/types.rs
+++ b/core/types.rs
@@ -41,6 +41,15 @@ pub struct TextRef {
     pub subtype: TextSubtype,
 }
 
+impl From<String> for Text {
+    fn from(value: String) -> Self {
+        Self {
+            value: value.into_bytes(),
+            subtype: TextSubtype::Text,
+        }
+    }
+}
+
 impl Text {
     pub fn from_str<S: Into<String>>(value: S) -> Self {
         Self::new(&value.into())

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -532,12 +532,13 @@ pub fn insn_to_str(
                 start_reg,
                 count,
                 dest_reg,
+                affinity_string,
             } => (
                 "MakeRecord",
                 *start_reg as i32,
                 *count as i32,
                 *dest_reg as i32,
-                OwnedValue::build_text(""),
+                OwnedValue::build_text(affinity_string.as_ref().unwrap_or(&String::new())),
                 0,
                 format!(
                     "r[{}]=mkrec(r[{}..{}])",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -294,9 +294,10 @@ pub enum Insn {
 
     // Make a record and write it to destination register.
     MakeRecord {
-        start_reg: usize, // P1
-        count: usize,     // P2
-        dest_reg: usize,  // P3
+        start_reg: usize,                // P1
+        count: usize,                    // P2
+        dest_reg: usize,                 // P3
+        affinity_string: Option<String>, // P4
     },
 
     // Emit a row of results.

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -16,3 +16,454 @@ do_execsql_test_on_specific_db {:memory:} must-be-int-insert {
 2
 3
 4}
+
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-setup {
+
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+    INSERT INTO affinity_test VALUES (
+        123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123
+    );
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type)
+    FROM affinity_test;
+
+} {integer|integer|text|text|text|text|real|real|real|integer|integer|integer|integer}
+
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-text-value {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+
+    INSERT INTO affinity_test VALUES (
+        '456', '456', '456', '456', '456', '456', '456', '456', '456', '456', '456', '456', '456'
+    );
+
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type)
+    FROM affinity_test;
+} {integer|integer|text|text|text|text|real|real|real|integer|integer|text|text}
+
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-real-value {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+    INSERT INTO affinity_test VALUES (
+        789.5, 789.5, 789.5, 789.5, 789.5, 789.5, 789.5, 789.5, 789.5, 789.5, 789.5, 789.5, 789.5
+    );
+
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type)
+    FROM affinity_test;
+} {real|real|text|text|text|text|real|real|real|real|real|real|real}
+
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-int-like-text {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+
+    INSERT INTO affinity_test VALUES (
+        '3.0e+5', '3.0e+5', '3.0e+5', '3.0e+5', '3.0e+5', '3.0e+5',
+        '3.0e+5', '3.0e+5', '3.0e+5', '3.0e+5', '3.0e+5', '3.0e+5', '3.0e+5'
+    );
+
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type),
+        col_integer,
+        col_numeric,
+        col_real
+    FROM affinity_test;
+} {integer|integer|text|text|text|text|real|real|real|integer|integer|text|text|300000|300000|300000.0}
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-hex-integer {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+    INSERT INTO affinity_test VALUES (
+        '0xFF', '0xFF', '0xFF', '0xFF', '0xFF', '0xFF',
+        '0xFF', '0xFF', '0xFF', '0xFF', '0xFF', '0xFF', '0xFF'
+    );
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type),
+        col_integer,
+        col_numeric,
+        col_real
+    FROM affinity_test;
+} {text|text|text|text|text|text|text|text|text|text|text|text|text|0xFF|0xFF|0xFF}
+
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-null-value {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+    INSERT INTO affinity_test VALUES (
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
+    );
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type)
+    FROM affinity_test;
+} {null|null|null|null|null|null|null|null|null|null|null|null|null}
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-blob-value {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+
+    INSERT INTO affinity_test VALUES (
+        X'ABCD', X'ABCD', X'ABCD', X'ABCD', X'ABCD', X'ABCD',
+        X'ABCD', X'ABCD', X'ABCD', X'ABCD', X'ABCD', X'ABCD', X'ABCD'
+    );
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type)
+    FROM affinity_test;
+} {blob|blob|blob|blob|blob|blob|blob|blob|blob|blob|blob|blob|blob}
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-non-numeric-text {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+    INSERT INTO affinity_test VALUES (
+        'abc', 'abc', 'abc', 'abc', 'abc', 'abc',
+        'abc', 'abc', 'abc', 'abc', 'abc', 'abc', 'abc'
+    );
+
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type)
+    FROM affinity_test;
+} {text|text|text|text|text|text|text|text|text|text|text|text|text}
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-large-int {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+    INSERT INTO affinity_test VALUES (
+        '9223372036854775807', '9223372036854775807', '9223372036854775807', '9223372036854775807',
+        '9223372036854775807', '9223372036854775807', '9223372036854775807', '9223372036854775807',
+        '9223372036854775807', '9223372036854775807', '9223372036854775807', '9223372036854775807',
+        '9223372036854775807'
+    );
+
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type)
+    FROM affinity_test;
+} {integer|integer|text|text|text|text|real|real|real|integer|integer|text|text}
+
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-too-large-int {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+    INSERT INTO affinity_test VALUES (
+        '9223372036854775808', '9223372036854775808', '9223372036854775808', '9223372036854775808',
+        '9223372036854775808', '9223372036854775808', '9223372036854775808', '9223372036854775808',
+        '9223372036854775808', '9223372036854775808', '9223372036854775808', '9223372036854775808',
+        '9223372036854775808'
+    );
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type)
+    FROM affinity_test;
+} {real|real|text|text|text|text|real|real|real|real|real|text|text}
+
+
+do_execsql_test_on_specific_db {:memory:} affinity-test-int-as-real {
+    CREATE TABLE affinity_test (
+        col_integer INTEGER,
+        col_int INT,
+        col_text TEXT,
+        col_varchar VARCHAR(10),
+        col_char CHAR(10),
+        col_clob CLOB,
+        col_real REAL,
+        col_float FLOAT,
+        col_double DOUBLE,
+        col_numeric NUMERIC,
+        col_decimal DECIMAL,
+        col_blob BLOB,
+        col_no_type
+    );
+
+    INSERT INTO affinity_test VALUES (
+        4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0
+    );
+
+    SELECT
+        typeof(col_integer),
+        typeof(col_int),
+        typeof(col_text),
+        typeof(col_varchar),
+        typeof(col_char),
+        typeof(col_clob),
+        typeof(col_real),
+        typeof(col_float),
+        typeof(col_double),
+        typeof(col_numeric),
+        typeof(col_decimal),
+        typeof(col_blob),
+        typeof(col_no_type),
+        col_integer,
+        col_real
+    FROM affinity_test;
+} {integer|integer|text|text|text|text|real|real|real|integer|integer|real|real|4|4.0}


### PR DESCRIPTION
Fixes #1118

Adds affinity string to MakeRecord instruction for affined insertions. 

FYI: SQLite stores floats that fits into i64 without decimal part as i64 on disc but shows them as floats anyway. This optimization is missing in this PR.