### PR TITLE
Fix propagation of divider cell balancing interior page 

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4008,7 +4008,7 @@ mod tests {
             for insert_id in 0..inserts {
                 let size = size(&mut rng);
                 let key = {
-                    let mut result = None;
+                    let result;
                     loop {
                         let key = (rng.next_u64() % (1 << 30)) as i64;
                         if seen.contains(&key) {
@@ -4016,10 +4016,10 @@ mod tests {
                         } else {
                             seen.insert(key);
                         }
-                        result = Some(key);
+                        result = key;
                         break;
                     }
-                    result.unwrap()
+                    result
                 };
                 keys.push(key);
                 tracing::info!(

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2,7 +2,7 @@ use tracing::debug;
 
 use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::{
-    read_varint, BTreeCell, PageContent, PageType, TableInteriorCell, TableLeafCell,
+    read_u32, read_varint, BTreeCell, PageContent, PageType, TableInteriorCell, TableLeafCell,
 };
 use crate::MvCursor;
 
@@ -1697,8 +1697,12 @@ impl BTreeCursor {
                     let mut new_divider_cell = Vec::new();
                     if !is_leaf_page {
                         // Interior
+                        // Make this page's rightmost pointer point to pointer of divider cell before modification
+                        let previous_pointer_divider = read_u32(&divider_cell, 0);
                         page.get_contents()
-                            .write_u32(PAGE_HEADER_OFFSET_RIGHTMOST_PTR, page.get().id as u32);
+                            .write_u32(PAGE_HEADER_OFFSET_RIGHTMOST_PTR, previous_pointer_divider);
+                        // divider cell now points to this page
+                        divider_cell[0..4].copy_from_slice(&(page.get().id as u32).to_be_bytes());
                         new_divider_cell.extend_from_slice(divider_cell);
                     } else if leaf_data {
                         // Leaf table

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4007,8 +4007,20 @@ mod tests {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             for insert_id in 0..inserts {
                 let size = size(&mut rng);
-                let key = (rng.next_u64() % (1 << 30)) as i64;
-                assert!(seen.insert(key));
+                let key = {
+                    let mut result = None;
+                    loop {
+                        let key = (rng.next_u64() % (1 << 30)) as i64;
+                        if seen.contains(&key) {
+                            continue;
+                        } else {
+                            seen.insert(key);
+                        }
+                        result = Some(key);
+                        break;
+                    }
+                    result.unwrap()
+                };
                 keys.push(key);
                 tracing::info!(
                     "INSERT INTO t VALUES ({}, randomblob({})); -- {}",


### PR DESCRIPTION
Newly added divider cells to parent of an interior page must point to
the page in question. Moreover rightmost pointer of the page will point
to previous divider cell pointer.