### PR TITLE
VTabs: Proper handling of re-opened db files without the relevant extensions loaded

### DIFF
--- a/core/ext/dynamic.rs
+++ b/core/ext/dynamic.rs
@@ -51,7 +51,7 @@ impl Connection {
             extensions
                 .lock()
                 .map_err(|_| {
-                    LimboError::ExtensionError("Error unlocking extension libraries".to_string())
+                    LimboError::ExtensionError("Error locking extension libraries".to_string())
                 })?
                 .push((Arc::new(lib), api_ref));
             {

--- a/core/ext/dynamic.rs
+++ b/core/ext/dynamic.rs
@@ -54,7 +54,9 @@ impl Connection {
                     LimboError::ExtensionError("Error unlocking extension libraries".to_string())
                 })?
                 .push((Arc::new(lib), api_ref));
-            self.parse_schema_rows()?;
+            {
+                self.parse_schema_rows()?;
+            }
             Ok(())
         } else {
             if !api_ptr.is_null() {

--- a/core/ext/dynamic.rs
+++ b/core/ext/dynamic.rs
@@ -6,6 +6,7 @@ use libloading::{Library, Symbol};
 use limbo_ext::{ExtensionApi, ExtensionApiRef, ExtensionEntryPoint, ResultCode, VfsImpl};
 use std::{
     ffi::{c_char, CString},
+    rc::Rc,
     sync::{Arc, Mutex, OnceLock},
 };
 
@@ -29,7 +30,10 @@ unsafe impl Send for VfsMod {}
 unsafe impl Sync for VfsMod {}
 
 impl Connection {
-    pub fn load_extension<P: AsRef<std::ffi::OsStr>>(&self, path: P) -> crate::Result<()> {
+    pub fn load_extension<P: AsRef<std::ffi::OsStr>>(
+        self: &Rc<Connection>,
+        path: P,
+    ) -> crate::Result<()> {
         use limbo_ext::ExtensionApiRef;
 
         let api = Box::new(self.build_limbo_ext());
@@ -44,7 +48,13 @@ impl Connection {
         let result_code = unsafe { entry(api_ptr) };
         if result_code.is_ok() {
             let extensions = get_extension_libraries();
-            extensions.lock().unwrap().push((Arc::new(lib), api_ref));
+            extensions
+                .lock()
+                .map_err(|_| {
+                    LimboError::ExtensionError("Error unlocking extension libraries".to_string())
+                })?
+                .push((Arc::new(lib), api_ref));
+            self.parse_schema_rows()?;
             Ok(())
         } else {
             if !api_ptr.is_null() {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -157,9 +157,9 @@ impl Database {
             let mut schema = schema
                 .try_write()
                 .expect("lock on schema should succeed first try");
-            let syms = conn.syms.borrow_mut();
+            let syms = conn.syms.borrow();
             if let Err(LimboError::ExtensionError(e)) =
-                parse_schema_rows(rows, &mut schema, io, syms, None)
+                parse_schema_rows(rows, &mut schema, io, &syms, None)
             {
                 // this means that a vtab exists and we no longer have the module loaded. we print
                 // a warning to the user to load the module
@@ -533,9 +533,9 @@ impl Connection {
             .try_write()
             .expect("lock on schema should succeed first try");
         {
-            let syms = self.syms.borrow_mut();
+            let syms = self.syms.borrow();
             if let Err(LimboError::ExtensionError(e)) =
-                parse_schema_rows(rows, &mut schema, self.pager.io.clone(), syms, None)
+                parse_schema_rows(rows, &mut schema, self.pager.io.clone(), &syms, None)
             {
                 // this means that a vtab exists and we no longer have the module loaded. we print
                 // a warning to the user to load the module

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -135,6 +135,7 @@ fn prologue<'a>(
     Ok((t_ctx, init_label, start_offset))
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum TransactionMode {
     None,
     Read,

--- a/core/util.rs
+++ b/core/util.rs
@@ -61,7 +61,7 @@ pub fn parse_schema_rows(
                             if root_page == 0 && sql.to_lowercase().contains("create virtual") {
                                 let name: &str = row.get::<&str>(1)?;
                                 let Some(vtab) = syms.vtabs.get(name) else {
-                                    return Err(LimboError::InvalidArgument(format!(
+                                    return Err(LimboError::ExtensionError(format!(
                                         "Virtual table Module for {} not found in symbol table,
                                         please load extension first",
                                         name

--- a/core/util.rs
+++ b/core/util.rs
@@ -60,8 +60,14 @@ pub fn parse_schema_rows(
                             let sql: &str = row.get::<&str>(4)?;
                             if root_page == 0 && sql.to_lowercase().contains("create virtual") {
                                 let name: &str = row.get::<&str>(1)?;
-                                let vtab = syms.vtabs.get(name).unwrap().clone();
-                                schema.add_virtual_table(vtab);
+                                let Some(vtab) = syms.vtabs.get(name) else {
+                                    return Err(LimboError::InvalidArgument(format!(
+                                        "Virtual table Module for {} not found in symbol table,
+                                        please load extension first",
+                                        name
+                                    )));
+                                };
+                                schema.add_virtual_table(vtab.clone());
                             } else {
                                 let table = schema::BTreeTable::from_sql(sql, root_page as usize)?;
                                 schema.add_btree_table(Rc::new(table));

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4236,13 +4236,15 @@ pub fn op_parse_schema(
     ))?;
     let mut schema = conn.schema.write();
     // TODO: This function below is synchronous, make it async
-    parse_schema_rows(
-        Some(stmt),
-        &mut schema,
-        conn.pager.io.clone(),
-        conn.syms.borrow_mut(),
-        state.mv_tx_id,
-    )?;
+    {
+        parse_schema_rows(
+            Some(stmt),
+            &mut schema,
+            conn.pager.io.clone(),
+            &conn.syms.borrow(),
+            state.mv_tx_id,
+        )?;
+    }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1542,8 +1542,8 @@ pub fn op_transaction(
         }
     } else {
         let connection = program.connection.upgrade().unwrap();
-        let current_state = connection.transaction_state.borrow().clone();
-        let (new_transaction_state, updated) = match (&current_state, write) {
+        let current_state = connection.transaction_state.get();
+        let (new_transaction_state, updated) = match (current_state, write) {
             (TransactionState::Write, true) => (TransactionState::Write, false),
             (TransactionState::Write, false) => (TransactionState::Write, false),
             (TransactionState::Read, true) => (TransactionState::Write, true),
@@ -1597,7 +1597,7 @@ pub fn op_auto_commit(
         };
     }
 
-    if *auto_commit != *conn.auto_commit.borrow() {
+    if *auto_commit != conn.auto_commit.get() {
         if *rollback {
             todo!("Rollback is not implemented");
         } else {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -917,12 +917,21 @@ pub fn op_vcreate(
             "Failed to upgrade Connection".to_string(),
         ));
     };
+    let mod_type = conn
+        .syms
+        .borrow()
+        .vtab_modules
+        .get(&module_name)
+        .ok_or_else(|| {
+            crate::LimboError::ExtensionError(format!("Module {} not found", module_name))
+        })?
+        .module_kind;
     let table = crate::VirtualTable::from_args(
         Some(&table_name),
         &module_name,
         args,
         &conn.syms.borrow(),
-        limbo_ext::VTabKind::VirtualTable,
+        mod_type,
         None,
     )?;
     {
@@ -4231,7 +4240,7 @@ pub fn op_parse_schema(
         Some(stmt),
         &mut schema,
         conn.pager.io.clone(),
-        &conn.syms.borrow(),
+        conn.syms.borrow_mut(),
         state.mv_tx_id,
     )?;
     state.pc += 1;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -386,7 +386,7 @@ impl Program {
     ) -> Result<StepResult> {
         if let Some(mv_store) = mv_store {
             let conn = self.connection.upgrade().unwrap();
-            let auto_commit = *conn.auto_commit.borrow();
+            let auto_commit = conn.auto_commit.get();
             if auto_commit {
                 let mut mv_transactions = conn.mv_transactions.borrow_mut();
                 for tx_id in mv_transactions.iter() {
@@ -400,7 +400,7 @@ impl Program {
                 .connection
                 .upgrade()
                 .expect("only weak ref to connection?");
-            let auto_commit = *connection.auto_commit.borrow();
+            let auto_commit = connection.auto_commit.get();
             tracing::trace!("Halt auto_commit {}", auto_commit);
             assert!(
                 program_state.halt_state.is_none()
@@ -409,7 +409,7 @@ impl Program {
             if program_state.halt_state.is_some() {
                 self.step_end_write_txn(&pager, &mut program_state.halt_state, connection.deref())
             } else if auto_commit {
-                let current_state = connection.transaction_state.borrow().clone();
+                let current_state = connection.transaction_state.get();
                 match current_state {
                     TransactionState::Write => self.step_end_write_txn(
                         &pager,

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -345,10 +345,10 @@ def test_kv():
     limbo = TestLimboShell()
     limbo.run_test_fn(
         "create virtual table t using kv_store;",
-        lambda res: "Virtual table module not found: kv_store" in res,
+        lambda res: "Module kv_store not found" in res,
     )
     limbo.execute_dot(f".load {ext_path}")
-    limbo.debug_print(
+    limbo.execute_dot(
         "create virtual table t using kv_store;",
     )
     limbo.run_test_fn(".schema", lambda res: "CREATE VIRTUAL TABLE t" in res)


### PR DESCRIPTION
closes #1239 
![image](https://github.com/user-attachments/assets/69b9f370-f622-45db-9c61-301991176da9)

warns the user if a .db file is opened that contains a schema entry of a vtab created with a module that is no longer loaded.

If the module is loaded for that connection, the user can properly query the table.