### PR TITLE
Fix virtual table translation issues

### DIFF
--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -462,7 +462,8 @@ pub fn translate_create_virtual_table(
         approx_num_insns: 40,
         approx_num_labels: 2,
     });
-
+    let init_label = program.emit_init();
+    let start_offset = program.offset();
     let module_name_reg = program.emit_string8_new_reg(module_name_str.clone());
     let table_name_reg = program.emit_string8_new_reg(table_name.clone());
 
@@ -520,8 +521,6 @@ pub fn translate_create_virtual_table(
         where_clause: parse_schema_where_clause,
     });
 
-    let init_label = program.emit_init();
-    let start_offset = program.offset();
     program.emit_halt();
     program.resolve_label(init_label, program.offset());
     program.emit_transaction(true);

--- a/core/util.rs
+++ b/core/util.rs
@@ -58,7 +58,7 @@ pub fn parse_schema_rows(
                         "table" => {
                             let root_page: i64 = row.get::<i64>(3)?;
                             let sql: &str = row.get::<&str>(4)?;
-                            if root_page == 0 && sql.to_lowercase().contains("virtual") {
+                            if root_page == 0 && sql.to_lowercase().contains("create virtual") {
                                 let name: &str = row.get::<&str>(1)?;
                                 let vtab = syms.vtabs.get(name).unwrap().clone();
                                 schema.add_virtual_table(vtab);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4110,7 +4110,7 @@ pub fn op_parse_schema(
     let conn = program.connection.upgrade();
     let conn = conn.as_ref().unwrap();
     let stmt = conn.prepare(format!(
-        "SELECT * FROM  sqlite_schema WHERE {}",
+        "SELECT * FROM sqlite_schema WHERE {}",
         where_clause
     ))?;
     let mut schema = conn.schema.write();

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -338,16 +338,14 @@ def test_series():
 
 def test_kv():
     ext_path = "target/debug/liblimbo_ext_tests"
-    limbo = TestLimboShell()
+    limbo = TestLimboShell("")
     limbo.run_test_fn(
         "create virtual table t using kv_store;",
         lambda res: "Virtual table module not found: kv_store" in res,
     )
     limbo.execute_dot(f".load {ext_path}")
-    limbo.run_test_fn(
+    limbo.debug_print(
         "create virtual table t using kv_store;",
-        null,
-        "can create kv_store vtable",
     )
     limbo.run_test_fn(
         "insert into t values ('hello', 'world');",

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -338,7 +338,10 @@ def test_series():
 
 def test_kv():
     ext_path = "target/debug/liblimbo_ext_tests"
-    limbo = TestLimboShell("")
+    limbo = TestLimboShell()
+    # first, create a normal table to ensure no issues
+    limbo.execute_dot("CREATE TABLE other (a,b,c);")
+    limbo.execute_dot("INSERT INTO other values (23,32,23);")
     limbo.run_test_fn(
         "create virtual table t using kv_store;",
         lambda res: "Virtual table module not found: kv_store" in res,

--- a/testing/cli_tests/test_limbo_cli.py
+++ b/testing/cli_tests/test_limbo_cli.py
@@ -111,7 +111,6 @@ class TestLimboShell:
         if init_commands is None:
             # Default initialization
             init_commands = """
-.open :memory:
 CREATE TABLE users (id INTEGER PRIMARY KEY, first_name TEXT, last_name TEXT, age INTEGER);
 CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
 INSERT INTO users VALUES (1, 'Alice', 'Smith', 30), (2, 'Bob', 'Johnson', 25),


### PR DESCRIPTION
closes #1240 

some idiot (read: me) had the init label of `CREATE VIRTUAL TABLE` translation completely in the wrong place :thinking: 

