### PR TITLE
Support insert default values syntax

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -84,11 +84,11 @@ pub fn translate_insert(
     );
     let root_page = btree_table.root_page;
     let values = match body {
-        InsertBody::Select(select, None) => match &select.body.select.deref() {
+        InsertBody::Select(select, _) => match &select.body.select.deref() {
             OneSelect::Values(values) => values,
             _ => todo!(),
         },
-        _ => todo!(),
+        InsertBody::DefaultValues => &vec![vec![]],
     };
 
     let column_mappings = resolve_columns_for_insert(&table, columns, values)?;

--- a/testing/cli_tests/cli_test_cases.py
+++ b/testing/cli_tests/cli_test_cases.py
@@ -264,6 +264,16 @@ def test_update_with_limit():
     limbo.quit()
 
 
+def test_insert_default_values():
+    limbo = TestLimboShell(
+        "CREATE TABLE t (a integer default(42),b integer default (43),c integer default(44));"
+    )
+    for _ in range(1, 10):
+        limbo.execute_dot("INSERT INTO t DEFAULT VALUES;")
+    limbo.run_test("insert-default-values", "SELECT * FROM t;", "42|43|44\n" * 9)
+    limbo.quit()
+
+
 if __name__ == "__main__":
     print("Running all Limbo CLI tests...")
     test_basic_queries()


### PR DESCRIPTION
`INSERT INTO products DEFAULT VALUES` previously wasn't supported. Quick and easy 