### PR TITLE
Support xBestIndex in vtab API

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -35,7 +35,7 @@ pub use io::UringIO;
 pub use io::{
     Buffer, Completion, File, MemoryIO, OpenFlags, PlatformIO, SyscallIO, WriteCompletion, IO,
 };
-use limbo_ext::{ResultCode, VTabKind, VTabModuleImpl};
+use limbo_ext::{ConstraintInfo, IndexInfo, OrderByInfo, ResultCode, VTabKind, VTabModuleImpl};
 use limbo_sqlite3_parser::{ast, ast::Cmd, lexer::sql::Parser};
 use parking_lot::RwLock;
 use schema::{Column, Schema};
@@ -641,6 +641,21 @@ impl VirtualTable {
     pub(crate) fn rowid(&self, cursor: &VTabOpaqueCursor) -> i64 {
         unsafe { (self.implementation.rowid)(cursor.as_ptr()) }
     }
+
+    pub(crate) fn best_index(
+        &self,
+        constraints: &[ConstraintInfo],
+        order_by: &[OrderByInfo],
+    ) -> IndexInfo {
+        unsafe {
+            IndexInfo::from_ffi((self.implementation.best_idx)(
+                constraints.as_ptr(),
+                constraints.len() as i32,
+                order_by.as_ptr(),
+                order_by.len() as i32,
+            ))
+        }
+    }
     /// takes ownership of the provided Args
     pub(crate) fn from_args(
         tbl_name: Option<&str>,
@@ -693,6 +708,8 @@ impl VirtualTable {
     pub fn filter(
         &self,
         cursor: &VTabOpaqueCursor,
+        idx_num: i32,
+        idx_str: Option<String>,
         arg_count: usize,
         args: Vec<OwnedValue>,
     ) -> Result<bool> {
@@ -701,8 +718,18 @@ impl VirtualTable {
             let ownedvalue_arg = args.get(i).unwrap();
             filter_args.push(ownedvalue_arg.to_ffi());
         }
+        let c_idx_str = idx_str
+            .map(|s| std::ffi::CString::new(s).unwrap())
+            .map(|cstr| cstr.into_raw())
+            .unwrap_or(std::ptr::null_mut());
         let rc = unsafe {
-            (self.implementation.filter)(cursor.as_ptr(), arg_count as i32, filter_args.as_ptr())
+            (self.implementation.filter)(
+                cursor.as_ptr(),
+                arg_count as i32,
+                filter_args.as_ptr(),
+                c_idx_str,
+                idx_num,
+            )
         };
         for arg in filter_args {
             unsafe {

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -90,6 +90,7 @@ pub struct TranslateCtx<'a> {
     // This vector holds the indexes of the result columns that we need to skip.
     pub result_columns_to_skip_in_orderby_sorter: Option<Vec<usize>>,
     pub resolver: Resolver<'a>,
+    pub omit_predicates: Vec<usize>,
 }
 
 /// Used to distinguish database operations
@@ -132,6 +133,7 @@ fn prologue<'a>(
         result_column_indexes_in_orderby_sorter: (0..result_column_count).collect(),
         result_columns_to_skip_in_orderby_sorter: None,
         resolver: Resolver::new(syms),
+        omit_predicates: Vec::new(),
     };
 
     Ok((t_ctx, init_label, start_offset))

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -396,10 +396,14 @@ pub fn open_loop(
                     });
                 }
 
-                for cond in predicates
+                for (i, cond) in predicates
                     .iter()
-                    .filter(|cond| cond.should_eval_at_loop(table_index))
+                    .enumerate()
+                    .filter(|(_, cond)| cond.should_eval_at_loop(table_index))
                 {
+                    if t_ctx.omit_predicates.contains(&i) {
+                        continue;
+                    }
                     let jump_target_when_true = program.allocate_label();
                     let condition_metadata = ConditionMetadata {
                         jump_if_condition_is_true: false,

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -1,4 +1,4 @@
-use limbo_ext::{OrderByInfo, VTabKind};
+use limbo_ext::VTabKind;
 use limbo_sqlite3_parser::ast;
 
 use crate::{
@@ -335,7 +335,8 @@ pub fn open_loop(
                                     if let ast::Expr::Binary(lhs, _, rhs) =
                                         &predicates[pred_idx].expr
                                     {
-                                        let expr = if is_rhs { rhs } else { lhs };
+                                        // translate the opposite side of the referenced vtab column
+                                        let expr = if is_rhs { lhs } else { rhs };
                                         // argv_index is 1-based; adjust to get the proper register offset.
                                         let target_reg = start_reg + (argv_index - 1) as usize;
                                         translate_expr(

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -83,6 +83,7 @@ pub fn emit_subquery<'a>(
         reg_offset: plan.offset.map(|_| program.alloc_register()),
         reg_limit_offset_sum: plan.offset.map(|_| program.alloc_register()),
         resolver: Resolver::new(t_ctx.resolver.symbol_table),
+        omit_predicates: Vec::new(),
     };
     let subquery_body_end_label = program.allocate_label();
     program.emit_insn(Insn::InitCoroutine {

--- a/core/util.rs
+++ b/core/util.rs
@@ -578,6 +578,7 @@ pub fn can_pushdown_predicate(expr: &Expr) -> bool {
                 &name.0,
                 args.as_ref().map_or(0, |a| a.len()),
             );
+            // is deterministic
             matches!(function, Ok(Func::Scalar(_)))
         }
         Expr::Like { lhs, rhs, .. } => can_pushdown_predicate(lhs) && can_pushdown_predicate(rhs),
@@ -595,10 +596,6 @@ pub fn can_pushdown_predicate(expr: &Expr) -> bool {
         Expr::InTable { lhs, .. } => can_pushdown_predicate(lhs),
         _ => false,
     }
-}
-
-fn is_deterministic(func: &Func) -> bool {
-    matches!(func, Func::Scalar(_))
 }
 
 #[derive(Debug, Default, PartialEq)]

--- a/core/util.rs
+++ b/core/util.rs
@@ -566,10 +566,11 @@ pub fn columns_from_create_table_body(body: &ast::CreateTableBody) -> crate::Res
         .collect::<Vec<_>>())
 }
 
+/// This function checks if a given expression is a constant value that can be pushed down to the database engine.
+/// It is expected to be called with the other half of a binary expression with an Expr::Column
 pub fn can_pushdown_predicate(expr: &Expr) -> bool {
     match expr {
         Expr::Literal(_) => true,
-        Expr::Column { .. } => true,
         Expr::Binary(lhs, _, rhs) => can_pushdown_predicate(lhs) && can_pushdown_predicate(rhs),
         Expr::Parenthesized(exprs) => can_pushdown_predicate(exprs.first().unwrap()),
         Expr::Unary(_, expr) => can_pushdown_predicate(expr),
@@ -589,11 +590,6 @@ pub fn can_pushdown_predicate(expr: &Expr) -> bool {
                 && can_pushdown_predicate(start)
                 && can_pushdown_predicate(end)
         }
-        Expr::Id(_) => true,
-        Expr::Name(_) => true,
-        Expr::Qualified(_, _) => true,
-        Expr::DoublyQualified(_, _, _) => true,
-        Expr::InTable { lhs, .. } => can_pushdown_predicate(lhs),
         _ => false,
     }
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -966,6 +966,8 @@ pub fn op_vfilter(
         pc_if_empty,
         arg_count,
         args_reg,
+        idx_str,
+        idx_num,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -981,7 +983,12 @@ pub fn op_vfilter(
         for i in 0..*arg_count {
             args.push(state.registers[args_reg + i].get_owned_value().clone());
         }
-        virtual_table.filter(cursor, *arg_count, args)?
+        let idx_str = if let Some(idx_str) = idx_str {
+            Some(state.registers[*idx_str].get_owned_value().to_string())
+        } else {
+            None
+        };
+        virtual_table.filter(cursor, *idx_num as i32, idx_str, *arg_count, args)?
     };
     if !has_rows {
         state.pc = pc_if_empty.to_offset_int();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -979,9 +979,14 @@ pub fn op_vfilter(
     let has_rows = {
         let mut cursor = state.get_cursor(*cursor_id);
         let cursor = cursor.as_virtual_mut();
-        let mut args = Vec::new();
+        let mut args = Vec::with_capacity(*arg_count);
         for i in 0..*arg_count {
-            args.push(state.registers[args_reg + i].get_owned_value().clone());
+            args.push(
+                state.registers[args_reg + i]
+                    .get_owned_value()
+                    .clone()
+                    .to_ffi(),
+            );
         }
         let idx_str = if let Some(idx_str) = idx_str {
             Some(state.registers[*idx_str].get_owned_value().to_string())

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -289,6 +289,8 @@ pub enum Insn {
         pc_if_empty: BranchOffset,
         arg_count: usize,
         args_reg: usize,
+        idx_str: Option<usize>,
+        idx_num: usize,
     },
 
     /// Read a column from the current row of the virtual table cursor.

--- a/extensions/completion/src/lib.rs
+++ b/extensions/completion/src/lib.rs
@@ -91,8 +91,8 @@ impl VTabModule for CompletionVTab {
         cursor.eof()
     }
 
-    fn filter(cursor: &mut Self::VCursor, args: &[Value]) -> ResultCode {
-        if args.len() == 0 || args.len() > 2 {
+    fn filter(cursor: &mut Self::VCursor, args: &[Value], _: Option<(&str, i32)>) -> ResultCode {
+        if args.is_empty() || args.len() > 2 {
             return ResultCode::InvalidArgs;
         }
         cursor.reset();

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -15,7 +15,10 @@ pub use types::{ResultCode, Value, ValueType};
 #[cfg(feature = "vfs")]
 pub use vfs_modules::{RegisterVfsFn, VfsExtension, VfsFile, VfsFileImpl, VfsImpl, VfsInterface};
 use vtabs::RegisterModuleFn;
-pub use vtabs::{VTabCursor, VTabKind, VTabModule, VTabModuleImpl};
+pub use vtabs::{
+    ConstraintInfo, ConstraintOp, ConstraintUsage, ExtIndexInfo, IndexInfo, OrderByInfo,
+    VTabCursor, VTabKind, VTabModule, VTabModuleImpl,
+};
 
 pub type ExtResult<T> = std::result::Result<T, ResultCode>;
 

--- a/extensions/core/src/vtabs.rs
+++ b/extensions/core/src/vtabs.rs
@@ -268,4 +268,5 @@ pub struct ConstraintInfo {
     pub column_index: u32,
     pub op: ConstraintOp,
     pub usable: bool,
+    pub pred_idx: usize,
 }

--- a/extensions/core/src/vtabs.rs
+++ b/extensions/core/src/vtabs.rs
@@ -158,19 +158,30 @@ pub enum ConstraintOp {
 
 #[repr(C)]
 #[derive(Copy, Clone)]
+/// Describes an ORDER BY clause in a query involving a virtual table.
+/// Passed along with the constraints to xBestIndex.
 pub struct OrderByInfo {
+    /// The index of the column referenced in the ORDER BY clause.
     pub column_index: u32,
+    /// Whether or not the clause is in descending order.
     pub desc: bool,
 }
 
+/// The internal (core) representation of an 'index' on a virtual table.
+/// Returned from xBestIndex and then processed and passed to VFilter.
 #[derive(Debug, Clone)]
 pub struct IndexInfo {
+    /// The index number, used to identify the index internally by the VTab
     pub idx_num: i32,
+    /// Optional index name. these are passed to vfilter in a tuple (idx_num, idx_str)
     pub idx_str: Option<String>,
+    /// Whether the index is used for order by
     pub order_by_consumed: bool,
     /// TODO: for eventual cost based query planning
     pub estimated_cost: f64,
+    /// Estimated number of rows that the query will return
     pub estimated_rows: u32,
+    /// List of constraints that can be used to optimize the query.
     pub constraint_usages: Vec<ConstraintUsage>,
 }
 impl Default for IndexInfo {
@@ -245,6 +256,7 @@ impl IndexInfo {
 
 #[repr(C)]
 #[derive(Clone, Debug)]
+/// FFI representation of IndexInfo.
 pub struct ExtIndexInfo {
     pub idx_num: i32,
     pub idx_str: *const u8,
@@ -256,17 +268,27 @@ pub struct ExtIndexInfo {
     pub constraint_usage_len: usize,
 }
 
+/// Returned from xBestIndex to describe how the virtual table
+/// can use the constraints in the WHERE clause of a query.
 #[derive(Debug, Clone, Copy)]
 pub struct ConstraintUsage {
-    pub argv_index: Option<u32>, // 1-based index into VFilter args
-    pub omit: bool,              // if true, core skips checking it again
+    /// 1 based index of the argument in the WHERE clause.
+    pub argv_index: Option<u32>,
+    /// If true, core can omit this constraint in the vdbe layer.
+    pub omit: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
+/// The primary argument to xBestIndex, which describes a constraint
+/// in a query involving a virtual table.
 pub struct ConstraintInfo {
+    /// The index of the column referenced in the WHERE clause.
     pub column_index: u32,
+    /// The operator used in the clause.
     pub op: ConstraintOp,
+    /// Whether or not constraint is garaunteed to be enforced.
     pub usable: bool,
+    ///
     pub pred_idx: usize,
 }

--- a/extensions/core/src/vtabs.rs
+++ b/extensions/core/src/vtabs.rs
@@ -272,7 +272,7 @@ pub struct ExtIndexInfo {
 /// can use the constraints in the WHERE clause of a query.
 #[derive(Debug, Clone, Copy)]
 pub struct ConstraintUsage {
-    /// 1 based index of the argument in the WHERE clause.
+    /// 1 based index of the argument passed
     pub argv_index: Option<u32>,
     /// If true, core can omit this constraint in the vdbe layer.
     pub omit: bool,
@@ -289,6 +289,18 @@ pub struct ConstraintInfo {
     pub op: ConstraintOp,
     /// Whether or not constraint is garaunteed to be enforced.
     pub usable: bool,
-    ///
-    pub pred_idx: usize,
+    /// packed integer with the index of the constraint in the planner,
+    /// and the side of the binary expr that the relevant column is on.
+    pub plan_info: u32,
+}
+
+impl ConstraintInfo {
+    #[inline(always)]
+    pub fn pack_plan_info(pred_idx: u32, is_right_side: bool) -> u32 {
+        ((pred_idx) << 1) | (is_right_side as u32)
+    }
+    #[inline(always)]
+    pub fn unpack_plan_info(&self) -> (usize, bool) {
+        ((self.plan_info >> 1) as usize, (self.plan_info & 1) != 0)
+    }
 }

--- a/extensions/core/src/vtabs.rs
+++ b/extensions/core/src/vtabs.rs
@@ -22,6 +22,7 @@ pub struct VTabModuleImpl {
     pub update: VtabFnUpdate,
     pub rowid: VtabRowIDFn,
     pub destroy: VtabFnDestroy,
+    pub best_idx: BestIdxFn,
 }
 
 #[cfg(feature = "core_only")]
@@ -43,8 +44,13 @@ pub type VtabFnCreateSchema = unsafe extern "C" fn(args: *const Value, argc: i32
 
 pub type VtabFnOpen = unsafe extern "C" fn(*const c_void) -> *const c_void;
 
-pub type VtabFnFilter =
-    unsafe extern "C" fn(cursor: *const c_void, argc: i32, argv: *const Value) -> ResultCode;
+pub type VtabFnFilter = unsafe extern "C" fn(
+    cursor: *const c_void,
+    argc: i32,
+    argv: *const Value,
+    idx_str: *const c_char,
+    idx_num: i32,
+) -> ResultCode;
 
 pub type VtabFnColumn = unsafe extern "C" fn(cursor: *const c_void, idx: u32) -> Value;
 
@@ -62,6 +68,12 @@ pub type VtabFnUpdate = unsafe extern "C" fn(
 ) -> ResultCode;
 
 pub type VtabFnDestroy = unsafe extern "C" fn(vtab: *const c_void) -> ResultCode;
+pub type BestIdxFn = unsafe extern "C" fn(
+    constraints: *const ConstraintInfo,
+    constraint_len: i32,
+    order_by: *const OrderByInfo,
+    order_by_len: i32,
+) -> ExtIndexInfo;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -78,7 +90,11 @@ pub trait VTabModule: 'static {
 
     fn create_schema(args: &[Value]) -> String;
     fn open(&self) -> Result<Self::VCursor, Self::Error>;
-    fn filter(cursor: &mut Self::VCursor, args: &[Value]) -> ResultCode;
+    fn filter(
+        cursor: &mut Self::VCursor,
+        args: &[Value],
+        idx_info: Option<(&str, i32)>,
+    ) -> ResultCode;
     fn column(cursor: &Self::VCursor, idx: u32) -> Result<Value, Self::Error>;
     fn next(cursor: &mut Self::VCursor) -> ResultCode;
     fn eof(cursor: &Self::VCursor) -> bool;
@@ -94,6 +110,22 @@ pub trait VTabModule: 'static {
     fn destroy(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
+    fn best_index(_constraints: &[ConstraintInfo], _order_by: &[OrderByInfo]) -> IndexInfo {
+        IndexInfo {
+            idx_num: 0,
+            idx_str: None,
+            order_by_consumed: false,
+            estimated_cost: 1_000_000.0,
+            estimated_rows: u32::MAX,
+            constraint_usages: _constraints
+                .iter()
+                .map(|_| ConstraintUsage {
+                    argv_index: Some(0),
+                    omit: false,
+                })
+                .collect(),
+        }
+    }
 }
 
 pub trait VTabCursor: Sized {
@@ -102,4 +134,138 @@ pub trait VTabCursor: Sized {
     fn column(&self, idx: u32) -> Result<Value, Self::Error>;
     fn eof(&self) -> bool;
     fn next(&mut self) -> ResultCode;
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ConstraintOp {
+    Eq = 2,
+    Lt = 4,
+    Le = 8,
+    Gt = 16,
+    Ge = 32,
+    Match = 64,
+    Like = 65,
+    Glob = 66,
+    Regexp = 67,
+    Ne = 68,
+    IsNot = 69,
+    IsNotNull = 70,
+    IsNull = 71,
+    Is = 72,
+    In = 73,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct OrderByInfo {
+    pub column_index: u32,
+    pub desc: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct IndexInfo {
+    pub idx_num: i32,
+    pub idx_str: Option<String>,
+    pub order_by_consumed: bool,
+    /// TODO: for eventual cost based query planning
+    pub estimated_cost: f64,
+    pub estimated_rows: u32,
+    pub constraint_usages: Vec<ConstraintUsage>,
+}
+impl Default for IndexInfo {
+    fn default() -> Self {
+        Self {
+            idx_num: 0,
+            idx_str: None,
+            order_by_consumed: false,
+            estimated_cost: 1_000_000.0,
+            estimated_rows: u32::MAX,
+            constraint_usages: Vec::new(),
+        }
+    }
+}
+
+impl IndexInfo {
+    ///
+    /// Converts IndexInfo to an FFI-safe `ExtIndexInfo`.
+    /// This method transfers ownership of `constraint_usages` and `idx_str`,
+    /// which must later be reclaimed using `from_ffi` to prevent leaks.
+    pub fn to_ffi(self) -> ExtIndexInfo {
+        let len = self.constraint_usages.len();
+        let ptr = Box::into_raw(self.constraint_usages.into_boxed_slice()) as *mut ConstraintUsage;
+        let idx_str_len = self.idx_str.as_ref().map(|s| s.len()).unwrap_or(0);
+        let c_idx_str = self
+            .idx_str
+            .map(|s| std::ffi::CString::new(s).unwrap().into_raw())
+            .unwrap_or(std::ptr::null_mut());
+        ExtIndexInfo {
+            idx_num: self.idx_num,
+            estimated_cost: self.estimated_cost,
+            estimated_rows: self.estimated_rows,
+            order_by_consumed: self.order_by_consumed,
+            constraint_usages_ptr: ptr,
+            constraint_usage_len: len,
+            idx_str: c_idx_str as *mut _,
+            idx_str_len,
+        }
+    }
+
+    /// Reclaims ownership of `constraint_usages` and `idx_str` from an FFI-safe `ExtIndexInfo`.
+    /// # Safety
+    /// This method is unsafe because it can cause memory leaks if not used correctly.
+    /// to_ffi and from_ffi are meant to send index info across ffi bounds then immediately reclaim it.
+    pub unsafe fn from_ffi(ffi: ExtIndexInfo) -> Self {
+        let constraint_usages = unsafe {
+            Box::from_raw(std::slice::from_raw_parts_mut(
+                ffi.constraint_usages_ptr,
+                ffi.constraint_usage_len,
+            ))
+            .to_vec()
+        };
+        let idx_str = if ffi.idx_str.is_null() {
+            None
+        } else {
+            Some(unsafe {
+                std::ffi::CString::from_raw(ffi.idx_str as *mut _)
+                    .to_string_lossy()
+                    .into_owned()
+            })
+        };
+        Self {
+            idx_num: ffi.idx_num,
+            idx_str,
+            order_by_consumed: ffi.order_by_consumed,
+            estimated_cost: ffi.estimated_cost,
+            estimated_rows: ffi.estimated_rows,
+            constraint_usages,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub struct ExtIndexInfo {
+    pub idx_num: i32,
+    pub idx_str: *const u8,
+    pub idx_str_len: usize,
+    pub order_by_consumed: bool,
+    pub estimated_cost: f64,
+    pub estimated_rows: u32,
+    pub constraint_usages_ptr: *mut ConstraintUsage,
+    pub constraint_usage_len: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ConstraintUsage {
+    pub argv_index: Option<u32>, // 1-based index into VFilter args
+    pub omit: bool,              // if true, core skips checking it again
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct ConstraintInfo {
+    pub column_index: u32,
+    pub op: ConstraintOp,
+    pub usable: bool,
 }

--- a/extensions/series/src/lib.rs
+++ b/extensions/series/src/lib.rs
@@ -240,7 +240,7 @@ mod tests {
         ];
 
         // Initialize cursor through filter
-        match GenerateSeriesVTab::filter(&mut cursor, &args) {
+        match GenerateSeriesVTab::filter(&mut cursor, &args, None) {
             ResultCode::OK => (),
             ResultCode::EOF => return Ok(vec![]),
             err => return Err(err),
@@ -293,7 +293,7 @@ mod tests {
             let expected_len = series_expected_length(&series);
             assert_eq!(
                 values.len(),
-                expected_len as usize,
+                expected_len,
                 "Series length mismatch for start={}, stop={}, step={}: expected {}, got {}, values: {:?}",
                 start,
                 stop,
@@ -546,7 +546,7 @@ mod tests {
         let start = series.start;
         let stop = series.stop;
         let step = series.step;
-        let tbl = GenerateSeriesVTab::default();
+        let tbl = GenerateSeriesVTab {};
         let mut cursor = tbl.open().unwrap();
 
         let args = vec![
@@ -556,7 +556,7 @@ mod tests {
         ];
 
         // Initialize cursor through filter
-        GenerateSeriesVTab::filter(&mut cursor, &args);
+        GenerateSeriesVTab::filter(&mut cursor, &args, None);
 
         let mut rowids = vec![];
         while !GenerateSeriesVTab::eof(&cursor) {

--- a/extensions/series/src/lib.rs
+++ b/extensions/series/src/lib.rs
@@ -45,7 +45,7 @@ impl VTabModule for GenerateSeriesVTab {
         })
     }
 
-    fn filter(cursor: &mut Self::VCursor, args: &[Value]) -> ResultCode {
+    fn filter(cursor: &mut Self::VCursor, args: &[Value], _: Option<(&str, i32)>) -> ResultCode {
         // args are the start, stop, and step
         if args.is_empty() || args.len() > 3 {
             return ResultCode::InvalidArgs;

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -54,11 +54,19 @@ impl VTabModule for KVStoreVTab {
                 && constraint.op == ConstraintOp::Eq
                 && constraint.column_index == 0
             {
+                // this extension wouldn't support order by but for testing purposes,
+                // we will consume it if we find an ASC order by clause on the value column
+                let mut consumed = false;
+                if let Some(order) = _order_by.first() {
+                    if order.column_index == 1 && !order.desc {
+                        consumed = true;
+                    }
+                }
                 log::debug!("xBestIndex: constraint found for 'key = ?'");
                 return IndexInfo {
                     idx_num: 1,
                     idx_str: Some("key_eq".to_string()),
-                    order_by_consumed: false,
+                    order_by_consumed: consumed,
                     estimated_cost: 10.0,
                     estimated_rows: 4,
                     constraint_usages: vec![ConstraintUsage {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -628,8 +628,8 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
                 order_by: *const ::limbo_ext::OrderByInfo,
                 n_order_by: i32,
             ) -> ::limbo_ext::ExtIndexInfo {
-                let constraints = std::slice::from_raw_parts(constraints, n_constraints as usize);
-                let order_by = std::slice::from_raw_parts(order_by, n_order_by as usize);
+                let constraints = if n_constraints > 0 { std::slice::from_raw_parts(constraints, n_constraints as usize) } else { &[] };
+                let order_by = if n_order_by > 0 { std::slice::from_raw_parts(order_by, n_order_by as usize) } else { &[] };
                 <#struct_name as ::limbo_ext::VTabModule>::best_index(constraints, order_by).to_ffi()
             }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -455,6 +455,7 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
     let update_fn_name = format_ident!("update_{}", struct_name);
     let rowid_fn_name = format_ident!("rowid_{}", struct_name);
     let destroy_fn_name = format_ident!("destroy_{}", struct_name);
+    let best_idx_fn_name = format_ident!("best_idx_{}", struct_name);
 
     let expanded = quote! {
         impl #struct_name {
@@ -490,13 +491,20 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
                 cursor: *const ::std::ffi::c_void,
                 argc: i32,
                 argv: *const ::limbo_ext::Value,
+                idx_str: *const ::std::ffi::c_char,
+                idx_num: i32,
             ) -> ::limbo_ext::ResultCode {
                 if cursor.is_null() {
                     return ::limbo_ext::ResultCode::Error;
                 }
                 let cursor = unsafe { &mut *(cursor as *mut <#struct_name as ::limbo_ext::VTabModule>::VCursor) };
                 let args = ::std::slice::from_raw_parts(argv, argc as usize);
-                <#struct_name as ::limbo_ext::VTabModule>::filter(cursor, args)
+                let idx_str = if idx_str.is_null() {
+                    None
+                } else {
+                    Some((unsafe { ::std::ffi::CStr::from_ptr(idx_str).to_str().unwrap() }, idx_num))
+                };
+                <#struct_name as ::limbo_ext::VTabModule>::filter(cursor, args, idx_str)
             }
 
             #[no_mangle]
@@ -614,6 +622,18 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
             }
 
             #[no_mangle]
+            pub unsafe extern "C" fn #best_idx_fn_name(
+                constraints: *const ::limbo_ext::ConstraintInfo,
+                n_constraints: i32,
+                order_by: *const ::limbo_ext::OrderByInfo,
+                n_order_by: i32,
+            ) -> ::limbo_ext::ExtIndexInfo {
+                let constraints = std::slice::from_raw_parts(constraints, n_constraints as usize);
+                let order_by = std::slice::from_raw_parts(order_by, n_order_by as usize);
+                <#struct_name as ::limbo_ext::VTabModule>::best_index(constraints, order_by).to_ffi()
+            }
+
+            #[no_mangle]
             pub unsafe extern "C" fn #register_fn_name(
                 api: *const ::limbo_ext::ExtensionApi
             ) -> ::limbo_ext::ResultCode {
@@ -636,6 +656,7 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
                     update: Self::#update_fn_name,
                     rowid: Self::#rowid_fn_name,
                     destroy: Self::#destroy_fn_name,
+                    best_idx: Self::#best_idx_fn_name,
                 };
                 (api.register_vtab_module)(api.ctx, name_c, module, <#struct_name as ::limbo_ext::VTabModule>::VTAB_KIND)
             }

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -343,7 +343,6 @@ def test_kv():
     # first, create a normal table to ensure no issues
     limbo.execute_dot("CREATE TABLE other (a,b,c);")
     limbo.execute_dot("INSERT INTO other values (23,32,23);")
-    limbo = TestLimboShell()
     limbo.run_test_fn(
         "create virtual table t using kv_store;",
         lambda res: "Module kv_store not found" in res,


### PR DESCRIPTION
closes #1185 

## The Problem:

The underlying schema of virtual tables is hidden from the query planner, and it currently has no way of optimizing select queries with vtab table refs by using indexes or removing non-constant predicates. All vtabs are currently rewound completely each time and any conditional filtering is done in the vdbe layer instead of in the `VFilter`.

## The solution:

Add xBestIndex to the vtab module API to let extensions return some `IndexInfo` that will allow the query planner to make better optimizations and possibly omit conditionals

## Examples:

table `t`: vtab: (key, value)
table `t2`: table: (a,b)

### Join where vtab is outer table: 
![image](https://github.com/user-attachments/assets/87f4233f-7d32-4a5e-8f95-4bebd3549304)
Properly pushes predicate to VFilter, which receives the idx_str `key_eq` arg, telling it that there is a useable where clause on the key "index"

### Join where vtab is inner table:
![image](https://github.com/user-attachments/assets/f8fcf6d3-42bc-41a3-ad86-16e497ec6056)
Constraint is not sent because it is marked as unusable

### Where clause on "indexed" column:
![image](https://github.com/user-attachments/assets/8817cc45-177c-404d-8323-4d33180e280c)
Pushed down and the predicate is omitted from the VDBE layer.

### Where clause on regular column:
![image](https://github.com/user-attachments/assets/85595c7f-920f-4047-8388-a7dddd01778c)
No idx info received from BestIndex, VDBE handles conditional. 


## TODO:
OrderBy info needs to be sent to xBestIndex and its not in a great position in `open_loop` currently 
