### PR TITLE
Added 'Likely' Scalar Function

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -227,7 +227,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | like(X,Y)                    | Yes     |                                                      |
 | like(X,Y,Z)                  | Yes     |                                                      |
 | likelihood(X,Y)              | No      |                                                      |
-| likely(X)                    | No      |                                                      |
+| likely(X)                    | Yes     |                                                      |
 | load_extension(X)            | Yes     | sqlite3 extensions not yet supported                 |
 | load_extension(X,Y)          | No      |                                                      |
 | lower(X)                     | Yes     |                                                      |

--- a/core/function.rs
+++ b/core/function.rs
@@ -292,6 +292,7 @@ pub enum ScalarFunc {
     LoadExtension,
     StrfTime,
     Printf,
+    Likely,
 }
 
 impl Display for ScalarFunc {
@@ -346,6 +347,7 @@ impl Display for ScalarFunc {
             Self::LoadExtension => "load_extension".to_string(),
             Self::StrfTime => "strftime".to_string(),
             Self::Printf => "printf".to_string(),
+            Self::Likely => "likely".to_string(),
         };
         write!(f, "{}", str)
     }
@@ -596,6 +598,7 @@ impl Func {
             "sqlite_version" => Ok(Self::Scalar(ScalarFunc::SqliteVersion)),
             "sqlite_source_id" => Ok(Self::Scalar(ScalarFunc::SqliteSourceId)),
             "replace" => Ok(Self::Scalar(ScalarFunc::Replace)),
+            "likely" => Ok(Self::Scalar(ScalarFunc::Likely)),
             #[cfg(feature = "json")]
             "json" => Ok(Self::Json(JsonFunc::Json)),
             #[cfg(feature = "json")]

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1571,6 +1571,33 @@ pub fn translate_expr(
                             target_register,
                             func_ctx,
                         ),
+                        ScalarFunc::Likely => {
+                            let args = if let Some(args) = args {
+                                if args.len() != 1 {
+                                    crate::bail_parse_error!(
+                                        "likely function must have exactly 1 argument",
+                                    );
+                                }
+                                args
+                            } else {
+                                crate::bail_parse_error!("likely function with no arguments",);
+                            };
+                            let start_reg = program.alloc_register();
+                            translate_and_mark(
+                                program,
+                                referenced_tables,
+                                &args[0],
+                                start_reg,
+                                resolver,
+                            )?;
+                            program.emit_insn(Insn::Function {
+                                constant_mask: 0,
+                                start_reg,
+                                dest: target_register,
+                                func: func_ctx,
+                            });
+                            Ok(target_register)
+                        }
                     }
                 }
                 Func::Math(math_func) => match math_func.arity() {

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -195,6 +195,22 @@ do_execsql_test hex-null {
   select hex(null)
 } {}
 
+do_execsql_test likely {
+    select likely('limbo')
+} {limbo}
+
+do_execsql_test likely-int {
+    select likely(100)
+} {100}
+
+do_execsql_test likely-decimal {
+    select likely(12.34)
+} {12.34}
+
+do_execsql_test likely-null {
+    select likely(NULL)
+} {}
+
 do_execsql_test unhex-str-ab {
   SELECT unhex('6162');
 } {ab}


### PR DESCRIPTION
This patch implements the "likely(x)" scalar function, which simply returns the original value provided to it as it's result.