### PR TITLE
Format infinite float as "Inf"/"-Inf"

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -197,6 +197,12 @@ impl Display for OwnedValue {
             }
             Self::Float(fl) => {
                 let fl = *fl;
+                if fl == f64::INFINITY {
+                    return write!(f, "Inf");
+                }
+                if fl == f64::NEG_INFINITY {
+                    return write!(f, "-Inf");
+                }
                 if fl.is_nan() {
                     return write!(f, "");
                 }

--- a/testing/select.test
+++ b/testing/select.test
@@ -166,6 +166,14 @@ do_execsql_test select-like-expression {
     select 2 % 0.5
 } {}
 
+do_execsql_test select_positive_infinite_float {
+  SELECT 1.7976931348623157E+308 + 1e308; -- f64::MAX + 1e308
+} {Inf}
+
+do_execsql_test select_negative_infinite_float {
+  SELECT -1.7976931348623157E+308 - 1e308 -- f64::MIN - 1e308
+} {-Inf}
+
 do_execsql_test select_shl_large_negative_float {
     SELECT 1 << -1e19;
     SELECT 1 << -9223372036854775808;  -- i64::MIN


### PR DESCRIPTION
## Issue
Numeric values outside the range of what f64 can represent are formatted to strings as "Inf" or "-Inf" in sqlite, but they are "inf" and "-inf" in limbo.

```
sqlite> SELECT 1.7976931348623157E+309;
Inf
```

```
limbo> SELECT 1.7976931348623157E+309;
┌─────────────────────────┐
│ 1.7976931348623157E+309 │
├─────────────────────────┤
│                     inf │
└─────────────────────────┘
```

closes #1248
