### PR TITLE
investigate weird clickbench perf in CI

### DIFF
--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -65,7 +65,7 @@ jobs:
           gh-repository: null
 
   clickbench:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -65,7 +65,7 @@ jobs:
           gh-repository: null
 
   clickbench:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
@@ -74,55 +74,3 @@ jobs:
 
       - name: Clickbench
         run: make clickbench
-
-      - name: Analyze LIMBO result with Nyrkiö
-        uses: nyrkio/github-action-benchmark@HEAD
-        with:
-          name: clickbench/limbo
-          tool: time
-          output-file-path: clickbench-limbo.txt
-          # What to do if a change is immediately detected by Nyrkiö.
-          # Note that smaller changes are only detected with delay, usually after a change
-          # persisted over 2-7 commits. Go to nyrkiö.com to view those or configure alerts.
-          # Note that Nyrkiö will find all changes, also improvements. This means fail-on-alert
-          # on pull events isn't compatible with this workflow being required to pass branch protection.
-          fail-on-alert: false
-          comment-on-alert: true
-          comment-always: false
-          # Nyrkiö configuration
-          nyrkio-enable: true
-          # Get yours from https://nyrkio.com/docs/getting-started
-          nyrkio-token: ${{ secrets.NYRKIO_JWT_TOKEN }}
-          # You may not want share the NYRKIO_JWT_TOKEN token with pull requests, for example.
-          # In that case this task would unnecessarily fail for random contributors. Don't want that:
-          never-fail: true
-          # Make results and change points public, so that any oss contributor can see them
-          nyrkio-public: true
-
-          nyrkio-api-root: https://nyrkio.com/api/v0
-          # Team support = results are visible and manageable to everyone in the same Github org
-          # nyrkio-org: tursodatabase
-
-          # Old way...
-          # Explicitly set this to null. We don't want threshold based alerts today.
-          external-data-json-path: null
-          gh-repository: null
-
-      - name: Analyze SQLITE3 result with Nyrkiö
-        uses: nyrkio/github-action-benchmark@HEAD
-        with:
-          name: clickbench/sqlite3
-          tool: time
-          output-file-path: clickbench-sqlite3.txt
-          fail-on-alert: false
-          comment-on-alert: true
-          comment-always: false
-          nyrkio-enable: true
-          nyrkio-token: ${{ secrets.NYRKIO_JWT_TOKEN }}
-          never-fail: true
-          nyrkio-public: true
-          nyrkio-api-root: https://nyrkio.com/api/v0
-          # nyrkio-org: tursodatabase
-
-          external-data-json-path: null
-          gh-repository: null

--- a/perf/clickbench/run.sh
+++ b/perf/clickbench/run.sh
@@ -36,11 +36,14 @@ grep -v '^--' "$CLICKBENCH_DIR/queries.sql" | while read -r query; do
     ((echo "$count $query") 2>&1) | tee -a clickbench-sqlite3.txt >/dev/null
     for _ in $(seq 1 $TRIES); do
         clear_caches
-        echo "----limbo----"
-        ((time "$RELEASE_BUILD_DIR/limbo" --quiet "$CLICKBENCH_DIR/mydb" <<< "${query}") 2>&1) | tee -a clickbench-limbo.txt
+        echo "----limbo syscall IO ----"
+        ((time "$RELEASE_BUILD_DIR/limbo" --vfs syscall --quiet "$CLICKBENCH_DIR/mydb" <<< "${query}") 2>&1) | tee -a clickbench-limbo.txt
         clear_caches
-        echo
+        echo "----limbo io_uring IO ----"
+        clear_caches
+        ((time "$RELEASE_BUILD_DIR/limbo" --quiet "$CLICKBENCH_DIR/mydb" <<< "${query}") 2>&1) | tee -a clickbench-limbo.txt
         echo "----sqlite----"
+        clear_caches
         ((time sqlite3 "$CLICKBENCH_DIR/mydb" <<< "${query}") 2>&1) | tee -a clickbench-sqlite3.txt
     done;
     count=$(($count+1))

--- a/perf/clickbench/run.sh
+++ b/perf/clickbench/run.sh
@@ -24,7 +24,7 @@ clear_caches() {
 
 # Clear caches once
 echo "The script might ask you to enter the password for sudo, in order to clear system caches."
-clear_caches
+#clear_caches
 count=1;
 
 # Run the queries, skipping any that are commented out
@@ -35,15 +35,15 @@ grep -v '^--' "$CLICKBENCH_DIR/queries.sql" | while read -r query; do
     ((echo "$count $query") 2>&1) | tee -a clickbench-limbo.txt > /dev/null
     ((echo "$count $query") 2>&1) | tee -a clickbench-sqlite3.txt >/dev/null
     for _ in $(seq 1 $TRIES); do
-        clear_caches
+        #clear_caches
         echo "----limbo syscall IO ----"
         ((time "$RELEASE_BUILD_DIR/limbo" --vfs syscall --quiet "$CLICKBENCH_DIR/mydb" <<< "${query}") 2>&1) | tee -a clickbench-limbo.txt
         clear_caches
         echo "----limbo io_uring IO ----"
-        clear_caches
+        #clear_caches
         ((time "$RELEASE_BUILD_DIR/limbo" --quiet "$CLICKBENCH_DIR/mydb" <<< "${query}") 2>&1) | tee -a clickbench-limbo.txt
         echo "----sqlite----"
-        clear_caches
+        #clear_caches
         ((time sqlite3 "$CLICKBENCH_DIR/mydb" <<< "${query}") 2>&1) | tee -a clickbench-sqlite3.txt
     done;
     count=$(($count+1))


### PR DESCRIPTION
on my local machine (🍎 ) we are 1.5-2x slower in clickbench for most queries compared to sqlite. in CI we are 30 times slower. lmao

ok so the mac CI runner is roughly as fast in comparison as my local machine:
https://github.com/tursodatabase/limbo/actions/runs/14336989758/job/40186495209?pr=1273

what the hell is going on in the linux version