### PR TITLE
simulator: Add Bug Database(BugBase)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ dist/
 # testing
 testing/limbo_output.txt
 **/limbo_output.txt
+.bugbase

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -734,8 +743,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1669,7 +1690,7 @@ dependencies = [
  "comfy-table",
  "csv",
  "ctrlc",
- "dirs",
+ "dirs 5.0.1",
  "env_logger 0.10.2",
  "limbo_core",
  "miette",
@@ -1836,6 +1857,7 @@ version = "0.0.19-pre.4"
 dependencies = [
  "anarchist-readable-name-generator-lib",
  "clap",
+ "dirs 6.0.0",
  "env_logger 0.10.2",
  "limbo_core",
  "log",
@@ -1847,7 +1869,6 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "tempfile",
 ]
 
 [[package]]
@@ -2780,6 +2801,17 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -19,7 +19,6 @@ limbo_core = { path = "../core" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 log = "0.4.20"
-tempfile = "3.0.7"
 env_logger = "0.10.1"
 regex = "1.11.1"
 regex-syntax = { version = "0.8.5", default-features = false, features = [
@@ -31,3 +30,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 notify = "8.0.0"
 rusqlite = { version = "0.34", features = ["bundled"] }
+dirs = "6.0.0"

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -38,7 +38,7 @@ impl InteractionPlan {
         let interactions = interactions.lines().collect::<Vec<_>>();
 
         let plan: InteractionPlan = serde_json::from_str(
-            std::fs::read_to_string(plan_path.with_extension("plan.json"))
+            std::fs::read_to_string(plan_path.with_extension("json"))
                 .unwrap()
                 .as_str(),
         )
@@ -71,7 +71,6 @@ impl InteractionPlan {
                     let _ = plan[j].split_off(k);
                     break;
                 }
-
                 if interactions[i].contains(plan[j][k].to_string().as_str()) {
                     i += 1;
                     k += 1;
@@ -86,7 +85,7 @@ impl InteractionPlan {
                 j += 1;
             }
         }
-
+        let _ = plan.split_off(j);
         plan
     }
 }

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -407,7 +407,7 @@ impl Property {
                         match (select_predicate, select_star) {
                             (Ok(rows1), Ok(rows2)) => {
                                 // If rows1 results have more than 1 column, there is a problem
-                                if rows1.iter().find(|vs| vs.len() > 1).is_some() {
+                                if rows1.iter().any(|vs| vs.len() > 1) {
                                     return Err(LimboError::InternalError(
                                         "Select query without the star should return only one column".to_string(),
                                     ));

--- a/simulator/runner/bugbase.rs
+++ b/simulator/runner/bugbase.rs
@@ -1,0 +1,241 @@
+use std::{
+    collections::HashMap,
+    io::{self, Write},
+    path::PathBuf,
+    process::Command,
+};
+
+use crate::{InteractionPlan, Paths};
+
+/// A bug is a run that has been identified as buggy.
+#[derive(Clone)]
+pub(crate) enum Bug {
+    Unloaded { seed: u64 },
+    Loaded { seed: u64, plan: InteractionPlan },
+}
+
+impl Bug {
+    /// Check if the bug is loaded.
+    pub(crate) fn is_loaded(&self) -> bool {
+        match self {
+            Bug::Unloaded { .. } => false,
+            Bug::Loaded { .. } => true,
+        }
+    }
+
+    /// Get the seed of the bug.
+    pub(crate) fn seed(&self) -> u64 {
+        match self {
+            Bug::Unloaded { seed } => *seed,
+            Bug::Loaded { seed, .. } => *seed,
+        }
+    }
+}
+
+/// Bug Base is a local database of buggy runs.
+pub(crate) struct BugBase {
+    /// Path to the bug base directory.
+    path: PathBuf,
+    /// The list of buggy runs, uniquely identified by their seed
+    bugs: HashMap<u64, Bug>,
+}
+
+impl BugBase {
+    /// Create a new bug base.
+    fn new(path: PathBuf) -> Result<Self, String> {
+        let mut bugs = HashMap::new();
+        // list all the bugs in the path as directories
+        if let Ok(entries) = std::fs::read_dir(&path) {
+            for entry in entries.flatten() {
+                if entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+                    let seed = entry
+                        .file_name()
+                        .to_string_lossy()
+                        .to_string()
+                        .parse::<u64>()
+                        .or(Err(format!(
+                            "failed to parse seed from directory name {}",
+                            entry.file_name().to_string_lossy()
+                        )))?;
+                    bugs.insert(seed, Bug::Unloaded { seed });
+                }
+            }
+        }
+
+        Ok(Self { path, bugs })
+    }
+
+    /// Load the bug base from one of the potential paths.
+    pub(crate) fn load() -> Result<Self, String> {
+        let potential_paths = vec![
+            // limbo project directory
+            BugBase::get_limbo_project_dir()?,
+            // home directory
+            dirs::home_dir().ok_or("should be able to get home directory".to_string())?,
+            // current directory
+            std::env::current_dir()
+                .or(Err("should be able to get current directory".to_string()))?,
+        ];
+
+        for path in potential_paths {
+            let path = path.join(".bugbase");
+            if path.exists() {
+                return BugBase::new(path);
+            }
+        }
+
+        println!("select bug base location:");
+        println!("1. limbo project directory");
+        println!("2. home directory");
+        println!("3. current directory");
+        print!("> ");
+        io::stdout().flush().unwrap();
+        let mut choice = String::new();
+        io::stdin()
+            .read_line(&mut choice)
+            .expect("failed to read line");
+
+        let choice = choice
+            .trim()
+            .parse::<u32>()
+            .or(Err(format!("invalid choice {choice}")))?;
+        let path = match choice {
+            1 => BugBase::get_limbo_project_dir()?.join(".bugbase"),
+            2 => {
+                let home = std::env::var("HOME").or(Err("failed to get home directory"))?;
+                PathBuf::from(home).join(".bugbase")
+            }
+            3 => PathBuf::from(".bugbase"),
+            _ => return Err(format!("invalid choice {choice}")),
+        };
+
+        if path.exists() {
+            unreachable!("bug base already exists at {}", path.display());
+        } else {
+            std::fs::create_dir_all(&path).or(Err("failed to create bug base"))?;
+            log::info!("bug base created at {}", path.display());
+            BugBase::new(path)
+        }
+    }
+
+    /// Add a new bug to the bug base.
+    pub(crate) fn add_bug(&mut self, seed: u64, plan: InteractionPlan) -> Result<(), String> {
+        log::debug!("adding bug with seed {}", seed);
+        if self.bugs.contains_key(&seed) {
+            return Err(format!("Bug with hash {} already exists", seed));
+        }
+        self.save_bug(seed, &plan)?;
+        self.bugs.insert(seed, Bug::Loaded { seed, plan });
+        Ok(())
+    }
+
+    /// Get a bug from the bug base.
+    pub(crate) fn get_bug(&self, seed: u64) -> Option<&Bug> {
+        self.bugs.get(&seed)
+    }
+
+    /// Save a bug to the bug base.
+    pub(crate) fn save_bug(&self, seed: u64, plan: &InteractionPlan) -> Result<(), String> {
+        let bug_path = self.path.join(seed.to_string());
+        std::fs::create_dir_all(&bug_path)
+            .or(Err("should be able to create bug directory".to_string()))?;
+
+        let seed_path = bug_path.join("seed.txt");
+        std::fs::write(&seed_path, seed.to_string())
+            .or(Err("should be able to write seed file".to_string()))?;
+
+        // At some point we might want to save the commit hash of the current
+        // version of Limbo.
+        // let commit_hash = Self::get_current_commit_hash()?;
+        // let commit_hash_path = bug_path.join("commit_hash.txt");
+        // std::fs::write(&commit_hash_path, commit_hash)
+        //     .or(Err("should be able to write commit hash file".to_string()))?;
+
+        let plan_path = bug_path.join("plan.json");
+        std::fs::write(
+            &plan_path,
+            serde_json::to_string(plan).or(Err("should be able to serialize plan".to_string()))?,
+        )
+        .or(Err("should be able to write plan file".to_string()))?;
+
+        let readable_plan_path = bug_path.join("plan.sql");
+        std::fs::write(&readable_plan_path, plan.to_string())
+            .or(Err("should be able to write readable plan file".to_string()))?;
+        Ok(())
+    }
+
+    pub(crate) fn load_bug(&mut self, seed: u64) -> Result<InteractionPlan, String> {
+        let seed_match = self.bugs.get(&seed);
+
+        match seed_match {
+            None => Err(format!("No bugs found for seed {}", seed)),
+            Some(Bug::Unloaded { .. }) => {
+                let plan =
+                    std::fs::read_to_string(self.path.join(seed.to_string()).join("plan.json"))
+                        .or(Err("should be able to read plan file".to_string()))?;
+                let plan: InteractionPlan = serde_json::from_str(&plan)
+                    .or(Err("should be able to deserialize plan".to_string()))?;
+
+                let bug = Bug::Loaded {
+                    seed,
+                    plan: plan.clone(),
+                };
+                self.bugs.insert(seed, bug);
+                log::debug!("Loaded bug with seed {}", seed);
+                Ok(plan)
+            }
+            Some(Bug::Loaded { plan, .. }) => {
+                log::warn!(
+                    "Bug with seed {} is already loaded, returning the existing plan",
+                    seed
+                );
+                Ok(plan.clone())
+            }
+        }
+    }
+
+    pub(crate) fn remove_bug(&mut self, seed: u64) -> Result<(), String> {
+        self.bugs.remove(&seed);
+        std::fs::remove_dir_all(self.path.join(seed.to_string()))
+            .or(Err("should be able to remove bug directory".to_string()))?;
+
+        log::debug!("Removed bug with seed {}", seed);
+        Ok(())
+    }
+}
+
+impl BugBase {
+    /// Get the path to the bug base directory.
+    pub(crate) fn path(&self) -> &PathBuf {
+        &self.path
+    }
+
+    /// Get the path to the database file for a given seed.
+    pub(crate) fn db_path(&self, seed: u64) -> PathBuf {
+        self.path.join(format!("{}/test.db", seed))
+    }
+
+    /// Get paths to all the files for a given seed.
+    pub(crate) fn paths(&self, seed: u64) -> Paths {
+        let base = self.path.join(format!("{}/", seed));
+        Paths::new(&base)
+    }
+}
+
+impl BugBase {
+    pub(crate) fn get_limbo_project_dir() -> Result<PathBuf, String> {
+        Ok(PathBuf::from(
+            String::from_utf8(
+                Command::new("git")
+                    .args(["rev-parse", "--git-dir"])
+                    .output()
+                    .or(Err("should be able to get the git path".to_string()))?
+                    .stdout,
+            )
+            .or(Err("commit hash should be valid utf8".to_string()))?
+            .trim()
+            .strip_suffix(".git")
+            .ok_or("should be able to strip .git suffix".to_string())?,
+        ))
+    }
+}

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -6,8 +6,6 @@ use clap::{command, Parser};
 pub struct SimulatorCLI {
     #[clap(short, long, help = "set seed for reproducible runs", default_value = None)]
     pub seed: Option<u64>,
-    #[clap(short, long, help = "set custom output directory for produced files", default_value = None)]
-    pub output_dir: Option<String>,
     #[clap(
         short,
         long,
@@ -35,13 +33,7 @@ pub struct SimulatorCLI {
         default_value_t = 60 * 60 // default to 1 hour
     )]
     pub maximum_time: usize,
-    #[clap(
-        short = 'm',
-        long,
-        help = "minimize(shrink) the failing counterexample"
-    )]
-    pub shrink: bool,
-    #[clap(short = 'l', long, help = "load plan from a file")]
+    #[clap(short = 'l', long, help = "load plan from the bug base")]
     pub load: Option<String>,
     #[clap(
         short = 'w',
@@ -66,14 +58,8 @@ impl SimulatorCLI {
             return Err("Minimum size cannot be greater than maximum size".to_string());
         }
 
-        // Make sure incompatible options are not set
-        if self.shrink && self.doublecheck {
-            return Err("Cannot use shrink and doublecheck at the same time".to_string());
-        }
-
-        if let Some(plan_path) = &self.load {
-            std::fs::File::open(plan_path)
-                .map_err(|_| format!("Plan file '{}' could not be opened", plan_path))?;
+        if self.seed.is_some() && self.load.is_some() {
+            return Err("Cannot set seed and load plan at the same time".to_string());
         }
 
         Ok(())

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -85,6 +85,7 @@ impl SimulatorEnv {
         // Remove existing database file if it exists
         if db_path.exists() {
             std::fs::remove_file(db_path).unwrap();
+            std::fs::remove_file(db_path.with_extension("db-wal")).unwrap();
         }
 
         let db = match Database::open_file(io.clone(), db_path.to_str().unwrap(), false) {

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -68,7 +68,12 @@ pub(crate) fn execute_plans(
         // Pick the connection to interact with
         let connection_index = pick_index(env.connections.len(), &mut env.rng);
         let state = &mut states[connection_index];
-
+        std::thread::sleep(std::time::Duration::from_millis(
+            std::env::var("TICK_SLEEP")
+                .unwrap_or("0".into())
+                .parse()
+                .unwrap_or(0),
+        ));
         history.history.push(Execution::new(
             connection_index,
             state.interaction_pointer,
@@ -121,6 +126,7 @@ fn execute_plan(
     } else {
         match execute_interaction(env, connection_index, interaction, &mut state.stack) {
             Ok(next_execution) => {
+                interaction.shadow(env);
                 log::debug!("connection {} processed", connection_index);
                 // Move to the next interaction or property
                 match next_execution {

--- a/simulator/runner/mod.rs
+++ b/simulator/runner/mod.rs
@@ -1,3 +1,4 @@
+pub mod bugbase;
 pub mod cli;
 pub mod differential;
 pub mod env;


### PR DESCRIPTION
Previously, simulator used `tempfile` for storing the resulting interaction plans, database file, seeds, and all relevant information. This posed the problem that this information became ephemeral, and we were not able to properly use the results of previous runs for optimizing future runs. This PR removes the CLI option `output_dir`, bases the storage infrastructure on top of `BugBase` interface.