### PR TITLE
Setup tracing to allow output during test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ dist/
 # testing
 testing/limbo_output.txt
 **/limbo_output.txt
+testing/test.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1687,7 @@ dependencies = [
  "shlex",
  "syntect",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -3470,6 +3480,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,6 +39,7 @@ rustyline = { version = "15.0.0", default-features = true, features = [
 shlex = "1.3.0"
 syntect = "5.2.0"
 tracing = "0.1.41"
+tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 

--- a/cli/input.rs
+++ b/cli/input.rs
@@ -81,28 +81,30 @@ pub struct Settings {
     pub echo: bool,
     pub is_stdout: bool,
     pub io: Io,
+    pub tracing_output: Option<String>,
 }
 
-impl From<&Opts> for Settings {
-    fn from(opts: &Opts) -> Self {
+impl From<Opts> for Settings {
+    fn from(opts: Opts) -> Self {
         Self {
             null_value: String::new(),
             output_mode: opts.output_mode,
             echo: false,
             is_stdout: opts.output.is_empty(),
-            output_filename: opts.output.clone(),
+            output_filename: opts.output,
             db_file: opts
                 .database
                 .as_ref()
                 .map_or(":memory:".to_string(), |p| p.to_string_lossy().to_string()),
             io: match opts.vfs.as_ref().unwrap_or(&String::new()).as_str() {
-                "memory" => Io::Memory,
+                "memory" | ":memory:" => Io::Memory,
                 "syscall" => Io::Syscall,
                 #[cfg(all(target_os = "linux", feature = "io_uring"))]
                 "io_uring" => Io::IoUring,
                 "" => Io::default(),
                 vfs => Io::External(vfs.to_string()),
             },
+            tracing_output: opts.tracing_output,
         }
     }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -7,7 +7,6 @@ mod opcodes_dictionary;
 
 use rustyline::{error::ReadlineError, Config, Editor};
 use std::sync::atomic::Ordering;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 fn rustyline_config() -> Config {
     Config::builder()
@@ -17,15 +16,8 @@ fn rustyline_config() -> Config {
 
 fn main() -> anyhow::Result<()> {
     let mut rl = Editor::with_config(rustyline_config())?;
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_line_number(true)
-                .with_thread_ids(true),
-        )
-        .with(EnvFilter::from_default_env())
-        .init();
     let mut app = app::Limbo::new(&mut rl)?;
+    let _guard = app.init_tracing()?;
     let home = dirs::home_dir().expect("Could not determine home directory");
     let history_file = home.join(".limbo_history");
     if history_file.exists() {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,85 @@
+# Testing in Limbo
+
+Limbo supports a comprehensive testing system to ensure correctness, performance, and compatibility with SQLite.
+
+## 1. Compatibility Tests
+
+The `make test` target is the main entry point.
+
+Most compatibility tests live in the testing/ directory and are written in SQLite’s TCL test format. These tests ensure that Limbo matches SQLite’s behavior exactly. The database used during these tests is located at testing/testing.db, which includes the following schema:
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    first_name TEXT,
+    last_name TEXT,
+    email TEXT,
+    phone_number TEXT,
+    address TEXT,
+    city TEXT,
+    state TEXT,
+    zipcode TEXT,
+    age INTEGER
+);
+CREATE TABLE products (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    price REAL
+);
+CREATE INDEX age_idx ON users (age);
+```
+
+You can freely write queries against these tables during compatibility testing.
+
+### Shell and Python-based Tests
+
+For cases where output or behavior differs intentionally from SQLite (e.g. due to new features or limitations), tests should be placed in the testing/cli_tests/ directory and written in Python.
+
+These tests use the TestLimboShell class:
+
+```python
+from cli_tests.common import TestLimboShell
+
+def test_uuid():
+    limbo = TestLimboShell()
+    limbo.run_test_fn("SELECT uuid4_str();", lambda res: len(res) == 36)
+    limbo.quit()
+```
+
+You can use run_test, run_test_fn, or debug_print to interact with the shell and validate results. 
+The constructor takes an optional argument with the `sql` you want to initiate the tests with.  You can also enable blob testing or override the executable and flags.
+
+Use these Python-based tests for validating:
+
+  - Output formatting
+
+  - Shell commands and .dot interactions
+
+  - Limbo-specific extensions in `testing/cli_tests/extensions.py`
+
+  - Any known divergence from SQLite behavior
+
+
+> Logging and Tracing
+If you wish to trace internal events during test execution, you can set the RUST_LOG environment variable before running the test. For example:
+
+```bash
+RUST_LOG=none,limbo_core=trace make test
+```
+
+This will enable trace-level logs for the limbo_core crate and disable logs elsewhere. Logging all internal traces to the `testing/test.log` file. 
+
+**Note:** trace logs can be very verbose—it's not uncommon for a single test run to generate megabytes of logs.
+
+
+## Deterministic Simulation Testing (DST):
+
+TODO!
+
+
+## Fuzzing
+
+TODO!
+
+
+

--- a/scripts/limbo-sqlite3
+++ b/scripts/limbo-sqlite3
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-target/debug/limbo -m list "$@"
+# if RUST_LOG is non-empty, enable tracing output
+if [ -n "$RUST_LOG" ]; then
+   target/debug/limbo -m list -t testing/test.log "$@"
+else
+   target/debug/limbo -m list "$@"
+fi

--- a/testing/cli_tests/test_limbo_cli.py
+++ b/testing/cli_tests/test_limbo_cli.py
@@ -11,7 +11,7 @@ PIPE_BUF = 4096
 
 
 class ShellConfig:
-    def __init__(self, exe_name, flags: str = "-q"):
+    def __init__(self, exe_name, flags: str = "-q -t testing/trace.log"):
         self.sqlite_exec: str = exe_name
         self.sqlite_flags: List[str] = flags.split()
         self.cwd = os.getcwd()

--- a/testing/cli_tests/test_limbo_cli.py
+++ b/testing/cli_tests/test_limbo_cli.py
@@ -11,7 +11,7 @@ PIPE_BUF = 4096
 
 
 class ShellConfig:
-    def __init__(self, exe_name, flags: str = "-q -t testing/trace.log"):
+    def __init__(self, exe_name, flags: str = "-q"):
         self.sqlite_exec: str = exe_name
         self.sqlite_flags: List[str] = flags.split()
         self.cwd = os.getcwd()


### PR DESCRIPTION
## The problem:

Sometimes you want to run the tests _and_ look at logs, and previously that wasn't possible because all the tests relied on stdout/stderr.

## The solution:

Setup `tracing-appender` to automatically log to a designated `testing/test.log` when `RUST_LOG` is set.


This PR also starts a `testing.md` file describing testing in limbo. My hope is that people who know stuff about DST and the fuzzing setup will fill in the TODOs :)  