### PR TITLE
Add `.timer` command to print SQL execution statistics

### DIFF
--- a/cli/commands/args.rs
+++ b/cli/commands/args.rs
@@ -106,3 +106,15 @@ pub struct LoadExtensionArgs {
     #[arg(add = ArgValueCompleter::new(PathCompleter::file()))]
     pub path: String,
 }
+
+#[derive(Debug, ValueEnum, Clone)]
+pub enum TimerMode {
+    On,
+    Off,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct TimerArgs {
+    #[arg(value_enum)]
+    pub mode: TimerMode,
+}

--- a/cli/commands/mod.rs
+++ b/cli/commands/mod.rs
@@ -3,7 +3,7 @@ pub mod import;
 
 use args::{
     CwdArgs, EchoArgs, ExitArgs, LoadExtensionArgs, NullValueArgs, OpcodesArgs, OpenArgs,
-    OutputModeArgs, SchemaArgs, SetOutputArgs, TablesArgs,
+    OutputModeArgs, SchemaArgs, SetOutputArgs, TablesArgs, TimerArgs,
 };
 use clap::Parser;
 use import::ImportArgs;
@@ -72,6 +72,8 @@ pub enum Command {
     /// List vfs modules available
     #[command(name = "vfslist", display_name = ".vfslist")]
     ListVfs,
+    #[command(name = "timer", display_name = ".timer")]
+    Timer(TimerArgs),
 }
 
 const _HELP_TEMPLATE: &str = "{before-help}{name}

--- a/cli/input.rs
+++ b/cli/input.rs
@@ -82,6 +82,7 @@ pub struct Settings {
     pub is_stdout: bool,
     pub io: Io,
     pub tracing_output: Option<String>,
+    pub timer: bool,
 }
 
 impl From<Opts> for Settings {
@@ -105,6 +106,7 @@ impl From<Opts> for Settings {
                 vfs => Io::External(vfs.to_string()),
             },
             tracing_output: opts.tracing_output,
+            timer: false,
         }
     }
 }


### PR DESCRIPTION
```
Limbo v0.0.19-pre.4
Enter ".help" for usage hints.
limbo> .timer on
limbo> select count(1) from users;
┌───────────┐
│ count (1) │
├───────────┤
│     10000 │
└───────────┘
Command stats:
----------------------------
total: 35 ms (this includes parsing/coloring of cli app)

query execution stats:
----------------------------
Execution: avg=16 us, total=33 us
I/O: avg=123 ns, total=3 us
limbo> select 1;
┌───┐
│ 1 │
├───┤
│ 1 │
└───┘
Command stats:
----------------------------
total: 282 us (this includes parsing/coloring of cli app)

query execution stats:
----------------------------
Execution: avg=2 us, total=4 us
I/O: No samples available
```