### PR TITLE
core: Fix syscall VFS on Linux

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -191,6 +191,7 @@ cfg_block! {
         mod unix;
         #[cfg(feature = "fs")]
         pub use unix::UnixIO;
+        pub use unix::UnixIO as SyscallIO;
         pub use io_uring::UringIO as PlatformIO;
     }
 
@@ -199,16 +200,19 @@ cfg_block! {
         #[cfg(feature = "fs")]
         pub use unix::UnixIO;
         pub use unix::UnixIO as PlatformIO;
+        pub use PlatformIO as SyscallIO;
     }
 
     #[cfg(target_os = "windows")] {
         mod windows;
         pub use windows::WindowsIO as PlatformIO;
+        pub use PlatformIO as SyscallIO;
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))] {
         mod generic;
         pub use generic::GenericIO as PlatformIO;
+        pub use PlatformIO as SyscallIO;
     }
 }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -31,7 +31,9 @@ use fallible_iterator::FallibleIterator;
 pub use io::UnixIO;
 #[cfg(all(feature = "fs", target_os = "linux", feature = "io_uring"))]
 pub use io::UringIO;
-pub use io::{Buffer, Completion, File, MemoryIO, OpenFlags, PlatformIO, WriteCompletion, IO};
+pub use io::{
+    Buffer, Completion, File, MemoryIO, OpenFlags, PlatformIO, SyscallIO, WriteCompletion, IO,
+};
 use limbo_ext::{ResultCode, VTabKind, VTabModuleImpl};
 use limbo_sqlite3_parser::{ast, ast::Cmd, lexer::sql::Parser};
 use parking_lot::RwLock;
@@ -209,7 +211,7 @@ impl Database {
             Some(vfs) => vfs,
             None => match vfs.trim() {
                 "memory" => Arc::new(MemoryIO::new()),
-                "syscall" => Arc::new(PlatformIO::new()?),
+                "syscall" => Arc::new(SyscallIO::new()?),
                 #[cfg(all(target_os = "linux", feature = "io_uring"))]
                 "io_uring" => Arc::new(UringIO::new()?),
                 other => {


### PR DESCRIPTION
Fix the syscall VFS on Linux not to use `PlatformIO`, which is just an alias for `io_uring`.