### PR TITLE
core/ondisk: Poison page contents buffer

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4893,14 +4893,13 @@ mod tests {
         let page = Arc::new(Page::new(id));
 
         let drop_fn = Rc::new(|_| {});
-        let inner = PageContent {
-            offset: 0,
-            buffer: Arc::new(RefCell::new(Buffer::new(
+        let inner = PageContent::new(
+            0,
+            Arc::new(RefCell::new(Buffer::new(
                 BufferData::new(vec![0; 4096]),
                 drop_fn,
             ))),
-            overflow_cells: Vec::new(),
-        };
+        );
         page.get().contents.replace(inner);
 
         btree_init_page(&page, PageType::TableLeaf, 0, 4096);

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -637,11 +637,7 @@ pub fn allocate_page(page_id: usize, buffer_pool: &Rc<BufferPool>, offset: usize
         });
         let buffer = Arc::new(RefCell::new(Buffer::new(buffer, drop_fn)));
         page.set_loaded();
-        page.get().contents = Some(PageContent {
-            offset,
-            buffer,
-            overflow_cells: Vec::new(),
-        });
+        page.get().contents = Some(PageContent::new(offset, buffer));
     }
     page
 }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -698,11 +698,10 @@ impl WalFile {
             let drop_fn = Rc::new(move |buf| {
                 buffer_pool.put(buf);
             });
-            checkpoint_page.get().contents = Some(PageContent {
-                offset: 0,
-                buffer: Arc::new(RefCell::new(Buffer::new(buffer, drop_fn))),
-                overflow_cells: Vec::new(),
-            });
+            checkpoint_page.get().contents = Some(PageContent::new(
+                0,
+                Arc::new(RefCell::new(Buffer::new(buffer, drop_fn))),
+            ));
         }
         Self {
             io,


### PR DESCRIPTION
This makes it easier to catch accesses to uninitialized page contents.