### PR TITLE
Add support to load log file with stress test

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 pub struct Plan {
     pub ddl_statements: Vec<String>,
@@ -349,13 +349,13 @@ fn read_plan_from_log_file(opts: &Opts) -> Result<Plan, Box<dyn std::error::Erro
         plan.ddl_statements
             .push(lines.next().expect("expected ddl statement").to_string());
     }
-    for i in 0..plan.nr_threads {
+    for _ in 0..plan.nr_threads {
         let mut queries = vec![];
         for _ in 0..plan.nr_iterations {
             queries.push(
                 lines
                     .next()
-                    .expect(format!("missing query for thread {}", i).as_str())
+                    .expect("missing query for thread {}")
                     .to_string(),
             );
         }

--- a/stress/opts.rs
+++ b/stress/opts.rs
@@ -26,6 +26,15 @@ pub struct Opts {
     )]
     pub log_file: String,
 
+    /// Load log file instead of creating a new one
+    #[clap(
+        short = 'L',
+        long = "load-log",
+        help = "load log file instead of creating a new one",
+        default_value_t = false
+    )]
+    pub load_log: bool,
+
     /// Database file
     #[clap(
         short = 'd',


### PR DESCRIPTION
run with: `RUST_BACKTRACE=1 cargo run -p limbo_stress -- -t 1 -l`
and then if you want to repeat same plan: `RUST_BACKTRACE=1 cargo run -p limbo_stress -- -t 1 -L`