### PR TITLE
Fix two issues with indexes

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -570,7 +570,7 @@ pub fn parse_where(
   For expressions not referencing any tables (e.g. constants), this is before the main loop is
   opened, because they do not need any table data.
 */
-fn determine_where_to_eval_expr<'a>(predicate: &'a ast::Expr) -> Result<EvalAt> {
+pub fn determine_where_to_eval_expr<'a>(predicate: &'a ast::Expr) -> Result<EvalAt> {
     let mut eval_at: EvalAt = EvalAt::BeforeLoop;
     match predicate {
         ast::Expr::Binary(e1, _, e2) => {

--- a/testing/where.test
+++ b/testing/where.test
@@ -573,6 +573,12 @@ do_execsql_test where-constant-condition-no-tables-2 {
     select 1 where 1 IS NOT NULL;
 } {1}
 
+# We had a bug where NULL was incorrectly used as a seek key, returning all rows (because NULL < everything in index keys)
 do_execsql_test where-null-comparison-index-seek-regression-test {
     select age from users where age > NULL;
 } {}
+
+# We had a bug where Limbo tried to use an index when there was a WHERE term like 't.x = t.x'
+do_execsql_test where-self-referential-regression {
+  select count(1) from users where id = id;
+} {10000}


### PR DESCRIPTION
Fixes #1298

- Fixes Limbo trying to use an index using a WHERE clause constraint that refers to the same table on both sides, e.g. `WHERE t.x = t.x`
- Fixes not using indexes when the relevant expression is paren wrapped, e.g.
    - `SELECT * FROM t WHERE (indexcol) > 5`
    - `SELECT * FROM t WHERE (indexcol > 5)`
- Changes existing table logical expr fuzz test to have primary keys (which helped me find both issues above)