### PR TITLE
Fix overwrite cell with size less than cell size

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3887,8 +3887,6 @@ impl BTreeCursor {
         new_payload: &[u8],
     ) -> Result<CursorResult<()>> {
         return_if_locked!(page_ref);
-        page_ref.set_dirty();
-        self.pager.add_dirty(page_ref.get().id);
         let buf = page_ref.get().contents.as_mut().unwrap().as_ptr();
         buf[dest_offset..dest_offset + new_payload.len()].copy_from_slice(&new_payload);
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4117,7 +4117,7 @@ fn find_free_cell(page_ref: &PageContent, usable_space: u16, amount: usize) -> R
                     return Ok(0);
                 }
                 // Delete the slot from freelist and update the page's fragment count.
-                page_ref.write_u16(prev_pc, next);
+                page_ref.write_u16_no_offset(prev_pc, next);
                 let frag = page_ref.num_frag_free_bytes() + new_size as u8;
                 page_ref.write_u8(offset::BTREE_FRAGMENTED_BYTES_COUNT, frag);
                 return Ok(pc);
@@ -4126,7 +4126,7 @@ fn find_free_cell(page_ref: &PageContent, usable_space: u16, amount: usize) -> R
             } else {
                 // Requested amount fits inside the current free slot so we reduce its size
                 // to account for newly allocated space.
-                page_ref.write_u16(pc + 2, new_size as u16);
+                page_ref.write_u16_no_offset(pc + 2, new_size as u16);
                 return Ok(pc + new_size);
             }
         }


### PR DESCRIPTION
We cannot simply paste a new payload into a cell with a payload with less size because we need to track fragmentation + free blocks. Let's keep it simple by only overwriting if size is the same.

Btw I feel like update is not re-entrant.