### PR TITLE
btree: remove IterationState

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -1228,6 +1228,7 @@ pub enum CursorResult<T> {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+/// The match condition of a table/index seek.
 pub enum SeekOp {
     EQ,
     GE,
@@ -1237,6 +1238,15 @@ pub enum SeekOp {
 }
 
 impl SeekOp {
+    /// A given seek op implies an iteration direction.
+    ///
+    /// For example, a seek with SeekOp::GT implies:
+    /// Find the first table/index key that compares greater than the seek key
+    /// -> used in forwards iteration.
+    ///
+    /// A seek with SeekOp::LE implies:
+    /// Find the last table/index key that compares less than or equal to the seek key
+    /// -> used in backwards iteration.
     pub fn iteration_direction(&self) -> IterationDirection {
         match self {
             SeekOp::EQ | SeekOp::GE | SeekOp::GT => IterationDirection::Forwards,

--- a/core/types.rs
+++ b/core/types.rs
@@ -5,6 +5,7 @@ use crate::ext::{ExtValue, ExtValueType};
 use crate::pseudo::PseudoCursor;
 use crate::storage::btree::BTreeCursor;
 use crate::storage::sqlite3_ondisk::write_varint;
+use crate::translate::plan::IterationDirection;
 use crate::vdbe::sorter::Sorter;
 use crate::vdbe::{Register, VTabOpaqueCursor};
 use crate::Result;
@@ -1233,6 +1234,15 @@ pub enum SeekOp {
     GT,
     LE,
     LT,
+}
+
+impl SeekOp {
+    pub fn iteration_direction(&self) -> IterationDirection {
+        match self {
+            SeekOp::EQ | SeekOp::GE | SeekOp::GT => IterationDirection::Forwards,
+            SeekOp::LE | SeekOp::LT => IterationDirection::Backwards,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]


### PR DESCRIPTION
iteration direction must be known when seeking, and transitively when using move_to() since seek() uses it, but otherwise IterationState just brings way too much noise to the code -- it was meant to encode invariants about how a cursor can be iterated, but it's not worth it.

iteration direction for seek()/move_to() can be inferred from the SeekOp:

GE/GT/EQ: forward
LT/LE: backward

and get_next_record()/get_prev_record() already have different logic for their respective iteration directions.