### PR TITLE
Check that index seek key members are not null

### DIFF
--- a/testing/where.test
+++ b/testing/where.test
@@ -572,3 +572,7 @@ do_execsql_test where-constant-condition-no-tables {
 do_execsql_test where-constant-condition-no-tables-2 {
     select 1 where 1 IS NOT NULL;
 } {1}
+
+do_execsql_test where-null-comparison-index-seek-regression-test {
+    select age from users where age > NULL;
+} {}


### PR DESCRIPTION
Fixes bug where e.g. `SELECT age FROM users WHERE age > NULL` would return all rows, since NULL is lower than anything else in index keys, but in comparison expressions it returns NULL.

Solution: check whether index seek key members can be null, and if they are null, do not seek and instead exit the loop.

Example bytecode on a table with an index on (a,b,c):

```sql
sqlite> explain select * from t where a = 5 and b = 6 and c > NULL;
addr  opcode         p1    p2    p3    p4             p5  comment      
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     18    0                    0   Start at 18
1     OpenRead       0     2     0     5              0   root=2 iDb=0; t
2     OpenRead       1     3     0     k(4,,,,)       0   root=3 iDb=0; abc
3     Integer        5     1     0                    0   r[1]=5
4     Integer        6     2     0                    0   r[2]=6
5     Null           0     3     0                    0   r[3]=NULL
6     IsNull         3     17    0                    0   if r[3]==NULL goto 17
7     SeekGT         1     17    1     3              0   key=r[1..3]
8       IdxGT          1     17    1     2              0   key=r[1..2]
9       DeferredSeek   1     0     0                    0   Move 0 to 1.rowid if needed
10      Column         1     0     4                    0   r[4]= cursor 1 column 0
11      Column         1     1     5                    0   r[5]= cursor 1 column 1
12      Column         1     2     6                    0   r[6]= cursor 1 column 2
13      Column         0     3     7                    0   r[7]= cursor 0 column 3
14      Column         0     4     8                    0   r[8]= cursor 0 column 4
15      ResultRow      4     5     0                    0   output=r[4..8]
16    Next           1     8     0                    0   
17    Halt           0     0     0                    0   
18    Transaction    0     0     2     0              1   usesStmtJournal=0
19    Goto           0     1     0                    0   
sqlite> select * from t where a = 5 and b = 6 and c > NULL;

Limbo v0.0.19-pre.4
Enter ".help" for usage hints.
limbo> explain select * from t where a = 5 and b = 6 and c > NULL;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     21    0                    0   Start at 21
1     OpenReadAsync      0     2     0                    0   table=t, root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     3     0                    0   table=abc, root=3
4     OpenReadAwait      0     0     0                    0   
5     Integer            5     6     0                    0   r[6]=5
6     Integer            6     7     0                    0   r[7]=6
7     Null               0     8     0                    0   r[8]=NULL
8     IsNull             8     20    0                    0   if (r[8]==NULL) goto 20
9     SeekGT             1     20    6                    0   key=[6..8]
10      IdxGT            1     20    6                    0   key=[6..7]
11      DeferredSeek     1     0     0                    0   
12      Column           0     0     1                    0   r[1]=t.a
13      Column           0     1     2                    0   r[2]=t.b
14      Column           0     2     3                    0   r[3]=t.c
15      Column           0     3     4                    0   r[4]=t.d
16      Column           0     4     5                    0   r[5]=t.e
17      ResultRow        1     5     0                    0   output=r[1..5]
18    NextAsync          1     0     0                    0   
19    NextAwait          1     10    0                    0   
20    Halt               0     0     0                    0   
21    Transaction        0     0     0                    0   write=false
22    Goto               0     1     0                    0  
```