### PR TITLE
simulator: provide high level commands on top of a single runner

### DIFF
--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -48,7 +48,7 @@ impl Paths {
 
 fn main() -> Result<(), String> {
     init_logger();
-    let cli_opts = SimulatorCLI::parse();
+    let mut cli_opts = SimulatorCLI::parse();
     cli_opts.validate()?;
 
     match cli_opts.subcommand {

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -19,14 +19,14 @@ pub struct SimulatorCLI {
         help = "change the maximum size of the randomly generated sequence of interactions",
         default_value_t = 5000
     )]
-    pub maximum_size: usize,
+    pub maximum_tests: usize,
     #[clap(
         short = 'k',
         long,
         help = "change the minimum size of the randomly generated sequence of interactions",
         default_value_t = 1000
     )]
-    pub minimum_size: usize,
+    pub minimum_tests: usize,
     #[clap(
         short = 't',
         long,
@@ -81,16 +81,22 @@ pub enum SimulatorCommand {
 }
 
 impl SimulatorCLI {
-    pub fn validate(&self) -> Result<(), String> {
-        if self.minimum_size < 1 {
+    pub fn validate(&mut self) -> Result<(), String> {
+        if self.minimum_tests < 1 {
             return Err("minimum size must be at least 1".to_string());
         }
-        if self.maximum_size < 1 {
+        if self.maximum_tests < 1 {
             return Err("maximum size must be at least 1".to_string());
         }
-        // todo: fix an issue here where if minimum size is not defined, it prevents setting low maximum sizes.
-        if self.minimum_size > self.maximum_size {
-            return Err("Minimum size cannot be greater than maximum size".to_string());
+
+        if self.minimum_tests > self.maximum_tests {
+            log::warn!(
+                "minimum size '{}' is greater than '{}' maximum size, setting both to '{}'",
+                self.minimum_tests,
+                self.maximum_tests,
+                self.maximum_tests
+            );
+            self.minimum_tests = self.maximum_tests - 1;
         }
 
         if self.seed.is_some() && self.load.is_some() {

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -1,7 +1,7 @@
 use clap::{command, Parser};
 use serde::{Deserialize, Serialize};
 
-#[derive(Parser, Clone, Serialize, Deserialize)]
+#[derive(Parser, Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]
 #[command(name = "limbo-simulator")]
 #[command(author, version, about, long_about = None)]
 pub struct SimulatorCLI {
@@ -44,6 +44,40 @@ pub struct SimulatorCLI {
     pub watch: bool,
     #[clap(long, help = "run differential testing between sqlite and Limbo")]
     pub differential: bool,
+    #[clap(subcommand)]
+    pub subcommand: Option<SimulatorCommand>,
+}
+
+#[derive(Parser, Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]
+pub enum SimulatorCommand {
+    #[clap(about = "run the simulator in a loop")]
+    Loop {
+        #[clap(
+            short = 'n',
+            long,
+            help = "number of iterations to run the simulator",
+            default_value_t = 5
+        )]
+        n: usize,
+        #[clap(
+            short = 's',
+            long,
+            help = "short circuit the simulator, stop on the first failure",
+            default_value_t = false
+        )]
+        short_circuit: bool,
+    },
+    #[clap(about = "list all the bugs in the base")]
+    List,
+    #[clap(about = "run the simulator against a specific bug")]
+    Test {
+        #[clap(
+            short = 'b',
+            long,
+            help = "run the simulator with previous buggy runs for the specific filter"
+        )]
+        filter: String,
+    },
 }
 
 impl SimulatorCLI {

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -67,7 +67,7 @@ impl SimulatorEnv {
         };
 
         let opts = SimulatorOpts {
-            ticks: rng.gen_range(cli_opts.minimum_size..=cli_opts.maximum_size),
+            ticks: rng.gen_range(cli_opts.minimum_tests..=cli_opts.maximum_tests),
             max_connections: 1, // TODO: for now let's use one connection as we didn't implement
             // correct transactions processing
             max_tables: rng.gen_range(0..128),
@@ -77,7 +77,7 @@ impl SimulatorEnv {
             delete_percent,
             drop_percent,
             page_size: 4096, // TODO: randomize this too
-            max_interactions: rng.gen_range(cli_opts.minimum_size..=cli_opts.maximum_size),
+            max_interactions: rng.gen_range(cli_opts.minimum_tests..=cli_opts.maximum_tests),
             max_time_simulation: cli_opts.maximum_time,
         };
 


### PR DESCRIPTION
Previously, the simulator only generated and ran a single run with the given configurations, and anyone was free to implement retrial or looping on top, which is still possible.

I still wanted to start adding some higher level commands on top, especially now that we have access to bug base, so this PR adds the following options;

- loop: run the simulator in a loop `n` times, with the option to short circuit if any run fails.
- list: list all the bugs in the bug base.
- test: run the simulator against a specific bug by providing a `filter`, this is useful when debugging a certain issue so you can first run a bunch of tests in a `loop`, and rerun them using `test` when you think you have a fix.