### PR TITLE
Return null when parameter is unbound

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -1,5 +1,3 @@
-use std::num::NonZero;
-
 use thiserror::Error;
 
 #[derive(Debug, Error, miette::Diagnostic)]
@@ -49,8 +47,6 @@ pub enum LimboError {
     Constraint(String),
     #[error("Extension error: {0}")]
     ExtensionError(String),
-    #[error("Unbound parameter at index {0}")]
-    Unbound(NonZero<usize>),
     #[error("Runtime error: integer overflow")]
     IntegerOverflow,
     #[error("Schema is locked for write")]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4395,12 +4395,7 @@ pub fn op_variable(
     let Insn::Variable { index, dest } = insn else {
         unreachable!("unexpected Insn {:?}", insn)
     };
-    state.registers[*dest] = Register::OwnedValue(
-        state
-            .get_parameter(*index)
-            .ok_or(LimboError::Unbound(*index))?
-            .clone(),
-    );
+    state.registers[*dest] = Register::OwnedValue(state.get_parameter(*index));
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -285,7 +285,10 @@ impl ProgramState {
     }
 
     pub fn get_parameter(&self, index: NonZero<usize>) -> OwnedValue {
-        self.parameters.get(&index).cloned().unwrap_or(OwnedValue::Null)
+        self.parameters
+            .get(&index)
+            .cloned()
+            .unwrap_or(OwnedValue::Null)
     }
 
     pub fn reset(&mut self) {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -284,8 +284,8 @@ impl ProgramState {
         self.parameters.insert(index, value);
     }
 
-    pub fn get_parameter(&self, index: NonZero<usize>) -> Option<&OwnedValue> {
-        self.parameters.get(&index)
+    pub fn get_parameter(&self, index: NonZero<usize>) -> OwnedValue {
+        self.parameters.get(&index).cloned().unwrap_or(OwnedValue::Null)
     }
 
     pub fn reset(&mut self) {


### PR DESCRIPTION
Fix #1323.