### PR TITLE
Feat: add support for descending indexes

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12,6 +12,7 @@ use crate::{
         },
         printf::exec_printf,
     },
+    types::compare_immutable,
 };
 use std::{borrow::BorrowMut, rc::Rc, sync::Arc};
 
@@ -2053,9 +2054,11 @@ pub fn op_idx_ge(
         let record_from_regs = make_record(&state.registers, start_reg, num_regs);
         let pc = if let Some(ref idx_record) = *cursor.record() {
             // Compare against the same number of values
-            let ord = idx_record.get_values()[..record_from_regs.len()]
-                .partial_cmp(&record_from_regs.get_values()[..])
-                .unwrap();
+            let idx_values = idx_record.get_values();
+            let idx_values = &idx_values[..record_from_regs.len()];
+            let record_values = record_from_regs.get_values();
+            let record_values = &record_values[..idx_values.len()];
+            let ord = compare_immutable(&idx_values, &record_values, cursor.index_key_sort_order);
             if ord.is_ge() {
                 target_pc.to_offset_int()
             } else {
@@ -2111,9 +2114,10 @@ pub fn op_idx_le(
         let record_from_regs = make_record(&state.registers, start_reg, num_regs);
         let pc = if let Some(ref idx_record) = *cursor.record() {
             // Compare against the same number of values
-            let ord = idx_record.get_values()[..record_from_regs.len()]
-                .partial_cmp(&record_from_regs.get_values()[..])
-                .unwrap();
+            let idx_values = idx_record.get_values();
+            let idx_values = &idx_values[..record_from_regs.len()];
+            let record_values = record_from_regs.get_values();
+            let ord = compare_immutable(&idx_values, &record_values, cursor.index_key_sort_order);
             if ord.is_le() {
                 target_pc.to_offset_int()
             } else {
@@ -2151,9 +2155,10 @@ pub fn op_idx_gt(
         let record_from_regs = make_record(&state.registers, start_reg, num_regs);
         let pc = if let Some(ref idx_record) = *cursor.record() {
             // Compare against the same number of values
-            let ord = idx_record.get_values()[..record_from_regs.len()]
-                .partial_cmp(&record_from_regs.get_values()[..])
-                .unwrap();
+            let idx_values = idx_record.get_values();
+            let idx_values = &idx_values[..record_from_regs.len()];
+            let record_values = record_from_regs.get_values();
+            let ord = compare_immutable(&idx_values, &record_values, cursor.index_key_sort_order);
             if ord.is_gt() {
                 target_pc.to_offset_int()
             } else {
@@ -2191,9 +2196,10 @@ pub fn op_idx_lt(
         let record_from_regs = make_record(&state.registers, start_reg, num_regs);
         let pc = if let Some(ref idx_record) = *cursor.record() {
             // Compare against the same number of values
-            let ord = idx_record.get_values()[..record_from_regs.len()]
-                .partial_cmp(&record_from_regs.get_values()[..])
-                .unwrap();
+            let idx_values = idx_record.get_values();
+            let idx_values = &idx_values[..record_from_regs.len()];
+            let record_values = record_from_regs.get_values();
+            let ord = compare_immutable(&idx_values, &record_values, cursor.index_key_sort_order);
             if ord.is_lt() {
                 target_pc.to_offset_int()
             } else {


### PR DESCRIPTION
### Feat:

- Adds support for descending indexes

### Testing:

- Augments existing compound key index seek fuzz test to test for various combinations of ascending and descending indexed columns. To illustrate, the test runs 10000 queries like this on 8 different tables with all different asc/desc permutations of a three-column primary key index:

```sql
query: SELECT * FROM t WHERE x = 2826  LIMIT 5
query: SELECT * FROM t WHERE x = 671 AND y >= 2447 ORDER BY x ASC, y DESC LIMIT 5
query: SELECT * FROM t WHERE x = 2412 AND y = 589 AND z >= 894 ORDER BY x DESC LIMIT 5
query: SELECT * FROM t WHERE x = 1217 AND y = 1437 AND z <= 265 ORDER BY x ASC, y ASC, z DESC LIMIT 5
query: SELECT * FROM t WHERE x < 138 ORDER BY x DESC LIMIT 5
query: SELECT * FROM t WHERE x = 1312 AND y = 2757 AND z > 39 ORDER BY x DESC, y ASC, z ASC LIMIT 5
query: SELECT * FROM t WHERE x = 1829 AND y >= 1629 ORDER BY x ASC, y ASC LIMIT 5
query: SELECT * FROM t WHERE x = 2047 ORDER BY x DESC LIMIT 5
query: SELECT * FROM t WHERE x = 893 AND y > 432 ORDER BY y DESC LIMIT 5
query: SELECT * FROM t WHERE x = 1865 AND y = 784 AND z <= 785 ORDER BY x DESC, y DESC, z DESC LIMIT 5
query: SELECT * FROM t WHERE x = 213 AND y = 1475 AND z <= 2870 ORDER BY x ASC, y ASC, z ASC LIMIT 5
query: SELECT * FROM t WHERE x >= 1780 ORDER BY x ASC LIMIT 5
query: SELECT * FROM t WHERE x = 1983 AND y = 602 AND z = 485 ORDER BY y ASC, z ASC LIMIT 5
query: SELECT * FROM t WHERE x = 2311 AND y >= 31 ORDER BY y DESC LIMIT 5
query: SELECT * FROM t WHERE x = 81 AND y >= 1037 ORDER BY x ASC, y DESC LIMIT 5
query: SELECT * FROM t WHERE x < 2698 ORDER BY x ASC LIMIT 5
query: SELECT * FROM t WHERE x = 1503 AND y = 554 AND z >= 185 ORDER BY x DESC, y DESC, z DESC LIMIT 5
query: SELECT * FROM t WHERE x = 619 AND y > 1414 ORDER BY x DESC, y ASC LIMIT 5
query: SELECT * FROM t WHERE x >= 865 ORDER BY x DESC LIMIT 5
query: SELECT * FROM t WHERE x = 1596 AND y = 622 AND z = 62 ORDER BY x DESC, z ASC LIMIT 5
query: SELECT * FROM t WHERE x = 1555 AND y = 1257 AND z < 1929 ORDER BY x ASC, y ASC, z ASC LIMIT 5
query: SELECT * FROM t WHERE x > 2598  LIMIT 5
query: SELECT * FROM t WHERE x = 302 AND y = 2476 AND z < 2302 ORDER BY z DESC LIMIT 5
query: SELECT * FROM t WHERE x = 2197 AND y = 2195 AND z > 2089 ORDER BY y ASC, z DESC LIMIT 5
query: SELECT * FROM t WHERE x = 1030 AND y = 1717 AND z < 987  LIMIT 5
query: SELECT * FROM t WHERE x = 2899 AND y >= 382 ORDER BY y DESC LIMIT 5
query: SELECT * FROM t WHERE x = 62 AND y = 2980 AND z < 1109 ORDER BY x DESC, y DESC, z DESC LIMIT 5
query: SELECT * FROM t WHERE x = 550 AND y > 221 ORDER BY y DESC LIMIT 5
query: SELECT * FROM t WHERE x = 376 AND y = 1874 AND z < 206 ORDER BY y DESC, z ASC LIMIT 5
query: SELECT * FROM t WHERE x = 859 AND y = 2157 ORDER BY x DESC LIMIT 5
query: SELECT * FROM t WHERE x = 2166 AND y = 2079 AND z < 301 ORDER BY x DESC, y ASC LIMIT 5
```

the queries are run against both sqlite and limbo.