### PR TITLE
page_cache: evict non-dirty pages

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -62,6 +62,8 @@ impl DumbLruPageCache {
     pub fn insert(&mut self, key: PageCacheKey, value: PageRef) {
         self._delete(key.clone(), false);
         trace!("cache_insert(key={:?})", key);
+        // TODO: fail to insert if couldn't make room for page
+        let _ = self.evict();
         let entry = Box::new(PageCacheEntry {
             key: key.clone(),
             next: None,
@@ -73,9 +75,6 @@ impl DumbLruPageCache {
         self.touch(ptr);
 
         self.map.borrow_mut().insert(key, ptr);
-        if self.len() > self.capacity {
-            self.pop_if_not_dirty_or_locked();
-        }
     }
 
     pub fn delete(&mut self, key: PageCacheKey) {
@@ -177,20 +176,47 @@ impl DumbLruPageCache {
         self.head.borrow_mut().replace(entry);
     }
 
-    fn pop_if_not_dirty_or_locked(&mut self) {
-        let tail = *self.tail.borrow();
-        if tail.is_none() {
-            return;
+    // Tries to evict pages until there's capacity for one more page
+    #[must_use]
+    fn evict(&mut self) -> bool {
+        if self.len() < self.capacity {
+            return true;
         }
-        let mut tail = tail.unwrap();
-        let tail_entry = unsafe { tail.as_mut() };
-        if tail_entry.page.is_dirty() || tail_entry.page.is_locked() {
-            // TODO: drop another clean and unlocked entry
-            return;
+
+        let mut current = match *self.tail.borrow() {
+            Some(tail) => tail,
+            None => {
+                debug!("evict() nothing at tail");
+                return false;
+            }
+        };
+
+        while self.len() >= self.capacity {
+            let current_entry = unsafe { current.as_mut() };
+
+            if current_entry.page.is_dirty() || current_entry.page.is_locked() {
+                match current_entry.prev {
+                    Some(prev) => current = prev,
+                    None => {
+                        debug!("evict() not enough clean and unlocked pages to evict");
+                        return false;
+                    }
+                }
+                continue;
+            }
+
+            debug!("evict(key={:?})", current_entry.key);
+
+            let prev = current_entry.prev;
+            let key_to_remove = current_entry.key.clone();
+            self.detach(current, true);
+            assert!(self.map.borrow_mut().remove(&key_to_remove).is_some());
+            if prev.is_none() {
+                break;
+            }
+            current = prev.unwrap();
         }
-        tracing::debug!("pop_if_not_dirty(key={:?})", tail_entry.key);
-        self.detach(tail, true);
-        assert!(self.map.borrow_mut().remove(&tail_entry.key).is_some());
+        true
     }
 
     pub fn clear(&mut self) {
@@ -224,11 +250,47 @@ mod tests {
 
     use super::PageCacheKey;
 
+    #[derive(Clone, Copy)]
+    pub enum DirtyState {
+        Clean,
+        Dirty,
+    }
+
+    #[derive(Clone, Copy)]
+    pub enum LockState {
+        Unlocked,
+        Locked,
+    }
+
+    #[must_use]
+    fn insert_page(
+        cache: &mut DumbLruPageCache,
+        id: usize,
+        dirty: DirtyState,
+        lock: LockState,
+    ) -> PageCacheKey {
+        let key = PageCacheKey::new(id, None);
+        #[allow(clippy::arc_with_non_send_sync)]
+        let page = Arc::new(Page::new(id));
+
+        match dirty {
+            DirtyState::Dirty => page.set_dirty(),
+            DirtyState::Clean => (),
+        }
+
+        match lock {
+            LockState::Locked => page.set_locked(),
+            LockState::Unlocked => (),
+        }
+        cache.insert(key.clone(), page.clone());
+        key
+    }
+
     #[test]
     fn test_page_cache_evict() {
         let mut cache = DumbLruPageCache::new(1);
-        let key1 = insert_page(&mut cache, 1);
-        let key2 = insert_page(&mut cache, 2);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Clean, LockState::Unlocked);
+        let key2 = insert_page(&mut cache, 2, DirtyState::Clean, LockState::Unlocked);
         assert_eq!(cache.get(&key2).unwrap().get().id, 2);
         assert!(cache.get(&key1).is_none());
     }
@@ -292,8 +354,8 @@ mod tests {
     #[test]
     fn test_page_cache_insert_and_get() {
         let mut cache = DumbLruPageCache::new(2);
-        let key1 = insert_page(&mut cache, 1);
-        let key2 = insert_page(&mut cache, 2);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Clean, LockState::Unlocked);
+        let key2 = insert_page(&mut cache, 2, DirtyState::Clean, LockState::Unlocked);
         assert_eq!(cache.get(&key1).unwrap().get().id, 1);
         assert_eq!(cache.get(&key2).unwrap().get().id, 2);
     }
@@ -301,9 +363,9 @@ mod tests {
     #[test]
     fn test_page_cache_over_capacity() {
         let mut cache = DumbLruPageCache::new(2);
-        let key1 = insert_page(&mut cache, 1);
-        let key2 = insert_page(&mut cache, 2);
-        let key3 = insert_page(&mut cache, 3);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Clean, LockState::Unlocked);
+        let key2 = insert_page(&mut cache, 2, DirtyState::Clean, LockState::Unlocked);
+        let key3 = insert_page(&mut cache, 3, DirtyState::Clean, LockState::Unlocked);
         assert!(cache.get(&key1).is_none());
         assert_eq!(cache.get(&key2).unwrap().get().id, 2);
         assert_eq!(cache.get(&key3).unwrap().get().id, 3);
@@ -312,7 +374,7 @@ mod tests {
     #[test]
     fn test_page_cache_delete() {
         let mut cache = DumbLruPageCache::new(2);
-        let key1 = insert_page(&mut cache, 1);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Clean, LockState::Unlocked);
         cache.delete(key1.clone());
         assert!(cache.get(&key1).is_none());
     }
@@ -320,27 +382,83 @@ mod tests {
     #[test]
     fn test_page_cache_clear() {
         let mut cache = DumbLruPageCache::new(2);
-        let key1 = insert_page(&mut cache, 1);
-        let key2 = insert_page(&mut cache, 2);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Clean, LockState::Unlocked);
+        let key2 = insert_page(&mut cache, 2, DirtyState::Clean, LockState::Unlocked);
         cache.clear();
         assert!(cache.get(&key1).is_none());
         assert!(cache.get(&key2).is_none());
-    }
-
-    fn insert_page(cache: &mut DumbLruPageCache, id: usize) -> PageCacheKey {
-        let key = PageCacheKey::new(id, None);
-        #[allow(clippy::arc_with_non_send_sync)]
-        let page = Arc::new(Page::new(id));
-        cache.insert(key.clone(), page.clone());
-        key
     }
 
     #[test]
     fn test_page_cache_insert_sequential() {
         let mut cache = DumbLruPageCache::new(2);
         for i in 0..10000 {
-            let key = insert_page(&mut cache, i);
+            let key = insert_page(&mut cache, i, DirtyState::Clean, LockState::Unlocked);
             assert_eq!(cache.peek(&key, false).unwrap().get().id, i);
         }
+    }
+
+    #[test]
+    fn test_page_cache_evict_one() {
+        let mut cache = DumbLruPageCache::new(1);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Clean, LockState::Unlocked);
+        let _ = insert_page(&mut cache, 2, DirtyState::Clean, LockState::Unlocked);
+        assert!(cache.get(&key1).is_none());
+    }
+
+    #[test]
+    fn test_page_cache_no_evict_dirty() {
+        let mut cache = DumbLruPageCache::new(1);
+        let _ = insert_page(&mut cache, 1, DirtyState::Dirty, LockState::Unlocked);
+        assert!(cache.evict() == false);
+        assert!(cache.len() == 1);
+    }
+
+    #[test]
+    fn test_page_cache_no_evict_locked() {
+        let mut cache = DumbLruPageCache::new(1);
+        let _ = insert_page(&mut cache, 1, DirtyState::Clean, LockState::Locked);
+        assert!(cache.evict() == false);
+        assert!(cache.len() == 1);
+    }
+
+    #[test]
+    fn test_page_cache_no_evict_one_dirty() {
+        let mut cache = DumbLruPageCache::new(1);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Dirty, LockState::Unlocked);
+        let _ = insert_page(&mut cache, 2, DirtyState::Clean, LockState::Unlocked); // fails to evict 1
+        assert!(cache.get(&key1).is_some());
+    }
+
+    #[test]
+    fn test_page_cache_no_evict_one_locked() {
+        let mut cache = DumbLruPageCache::new(1);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Clean, LockState::Locked);
+        let _ = insert_page(&mut cache, 2, DirtyState::Clean, LockState::Unlocked); // fails to evict 1
+        assert!(cache.get(&key1).is_some());
+    }
+
+    #[test]
+    fn test_page_cache_evict_one_after_cleaned() {
+        let mut cache = DumbLruPageCache::new(1);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Dirty, LockState::Unlocked);
+        let _ = insert_page(&mut cache, 2, DirtyState::Clean, LockState::Unlocked);
+        let entry1 = cache.get(&key1);
+        assert!(entry1.is_some());
+        entry1.unwrap().clear_dirty();
+        let _ = insert_page(&mut cache, 3, DirtyState::Clean, LockState::Unlocked);
+        assert!(cache.get(&key1).is_none());
+    }
+
+    #[test]
+    fn test_page_cache_evict_one_after_unlocked() {
+        let mut cache = DumbLruPageCache::new(1);
+        let key1 = insert_page(&mut cache, 1, DirtyState::Clean, LockState::Locked);
+        let _ = insert_page(&mut cache, 2, DirtyState::Clean, LockState::Unlocked);
+        let entry1 = cache.get(&key1);
+        assert!(entry1.is_some());
+        entry1.unwrap().clear_locked();
+        let _ = insert_page(&mut cache, 3, DirtyState::Clean, LockState::Unlocked);
+        assert!(cache.get(&key1).is_none());
     }
 }


### PR DESCRIPTION
If tail is dirty, keep looking backwards to evict.
While there, evict as many pages as necessary until cache is at capacity since a previous pass could have failed to evict pages.