### PR TITLE
Fix: comment out incorrect assert in fuzz

### DIFF
--- a/fuzz/fuzz_targets/expression.rs
+++ b/fuzz/fuzz_targets/expression.rs
@@ -195,7 +195,7 @@ fn do_fuzz(expr: Expr) -> Result<Corpus, Box<dyn Error>> {
                 StepResult::IO => io.run_once()?,
                 StepResult::Row => {
                     let row = stmt.row().unwrap();
-                    assert_eq!(row.count(), 1, "expr: {:?}", expr);
+                    assert_eq!(row.len(), 1, "expr: {:?}", expr);
                     break 'value row.get_value(0).clone();
                 }
                 _ => unreachable!(),


### PR DESCRIPTION
Currently, to run the fuzz test you need to remove an assert statement.

EDIT: @diegoreis42 pointed it out to me that the method had just changed actually. Made the change to use `row.len()` instead

# Problem

```
cargo +nightly fuzz run --target=aarch64-apple-darwin expression
   Compiling limbo_core v0.0.19-pre.4 (/Users/pedro/Projects/limbo/core)
   Compiling limbo-fuzz v0.0.0 (/Users/pedro/Projects/limbo/fuzz)
error[E0599]: `&limbo_core::vdbe::Row` is not an iterator
   --> fuzz_targets/expression.rs:198:36
    |
198 |                     assert_eq!(row.count(), 1, "expr: {:?}", expr);
    |                                    ^^^^^
    |                                    |
    |                                    `&limbo_core::vdbe::Row` is not an iterator
    |                                    private field, not a method
    |
   ::: /Users/pedro/Projects/limbo/core/vdbe/mod.rs:221:1
    |
221 | pub struct Row {
    | -------------- doesn't satisfy `limbo_core::vdbe::Row: std::iter::Iterator`
    |
    = note: the following trait bounds were not satisfied:
            `&limbo_core::vdbe::Row: std::iter::Iterator`
            which is required by `&mut &limbo_core::vdbe::Row: std::iter::Iterator`
            `limbo_core::vdbe::Row: std::iter::Iterator`
            which is required by `&mut limbo_core::vdbe::Row: std::iter::Iterator`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `limbo-fuzz` (bin "expression") due to 1 previous error
Error: failed to build fuzz script: ASAN_OPTIONS="detect_odr_violation=0" RUSTFLAGS="-Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-pc-table -Cllvm-args=-sanitizer-coverage-trace-compares --cfg fuzzing -Clink-dead-code -Zsanitizer=address -Cdebug-assertions -C codegen-units=1" "cargo" "build" "--manifest-path" "/Users/pedro/Projects/limbo/fuzz/Cargo.toml" "--target" "aarch64-apple-darwin" "--release" "--config" "profile.release.debug=true" "--bin" "expression"
```