### PR TITLE
Fix incompatibility `AND` Operation

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5872,14 +5872,18 @@ pub fn exec_and(lhs: &OwnedValue, rhs: &OwnedValue) -> OwnedValue {
         | (OwnedValue::Integer(0), _)
         | (_, OwnedValue::Float(0.0))
         | (OwnedValue::Float(0.0), _) => OwnedValue::Integer(0),
-        (OwnedValue::Null, _) | (_, OwnedValue::Null) => OwnedValue::Null,
         (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => exec_and(
-            &cast_text_to_numeric(lhs.as_str()),
-            &cast_text_to_numeric(rhs.as_str()),
+            &cast_text_to_real(lhs.as_str()),
+            &cast_text_to_real(rhs.as_str()),
         ),
         (OwnedValue::Text(text), other) | (other, OwnedValue::Text(text)) => {
-            exec_and(&cast_text_to_numeric(text.as_str()), other)
+            exec_and(&cast_text_to_real(text.as_str()), other)
         }
+        (OwnedValue::Blob(blob), other) | (other, OwnedValue::Blob(blob)) => {
+            let text = String::from_utf8_lossy(blob);
+            exec_and(&cast_text_to_real(&text), other)
+        }
+        (OwnedValue::Null, _) | (_, OwnedValue::Null) => OwnedValue::Null,
         _ => OwnedValue::Integer(1),
     }
 }

--- a/testing/all.test
+++ b/testing/all.test
@@ -29,3 +29,4 @@ source $testdir/transactions.test
 source $testdir/update.test
 source $testdir/drop_table.test
 source $testdir/default_value.test
+source $testdir/boolean.test

--- a/testing/boolean.test
+++ b/testing/boolean.test
@@ -1,0 +1,56 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+foreach {testname lhs ans} {
+  int-1           1        0
+  int-2           2        0
+  int-3           0        1
+  float-1         1.0      0
+  float-2         2.0      0
+  float-3         0.0      1
+  text            'a'      1
+  text-int-1      '0'      1
+  text-int-2      '1'      0
+  text-float-1    '1.0'    0
+  text-float-2    '0.0'    1
+  text-float-edge '12-23.0' 0
+  null            NULL     {}
+  empty-blob	  x''	   1
+  cast-blob		  "CAST ('af' AS BLOB)" 	1
+  blob			  x'0000'  1
+  blob-2 		  x'0001'  1
+} {
+  do_execsql_test boolean-not-$testname "SELECT not $lhs" $::ans
+}
+
+foreach {testname lhs rhs ans} {
+  
+  blob-blob       x''      x''		0
+  1-blob          1        x''		0
+  0-blob          0        x''		0
+  0-1        	  0    	   1		0
+  1-1             1        1		1
+  int-int     	  20       1000		1
+  int-float       20       1.0		1
+  int-0.0    	  20       0.0		0
+  0.0-0.0    	  0.0      0.0		0
+  text            'a'      1		0
+  text-int-1      '0'      1		0
+  text-int-2      '1'      0		0
+  text-float-1    '1.0'    0		0
+  text-float-2    '0.0'    1		0
+  text-float-3    '1.0'    1		1
+  text-float-edge '12-23.0' 0		0
+  null-null		  NULL	   NULL		""
+  1-null		  1		   NULL		""
+  1.0-null		  1.0	   NULL		""
+  blob-null   	  x''      NULL		0
+  blob2-null	  x'0001'  NULL		0
+  0-null		  0		   NULL		0
+  0.0-null		  0.0	   NULL		0
+  '0.0'-null	  '0.0'	   NULL		0
+} {
+  do_execsql_test boolean-and-$testname "SELECT $lhs AND $rhs" $::ans
+}

--- a/testing/math.test
+++ b/testing/math.test
@@ -643,39 +643,6 @@ do_execsql_test bitwise-not-blob-2 {
 	SELECT ~ x'0001';
 } {-1}
 
-do_execsql_test boolean-not-empty-blob {
-	SELECT NOT x''
-} {1}
-
-do_execsql_test boolean-not-cast-blob {
-	SELECT NOT CAST ('af' AS BLOB);
-} {1}
-
-do_execsql_test boolean-not-blob {
-	SELECT NOT x'0000';
-} {1}
-
-do_execsql_test boolean-not-blob-2 {
-	SELECT NOT x'0001';
-} {1}
-
-foreach {testname lhs ans} {
-  int-1           1        0
-  int-2           2        0
-  int-3           0        1
-  float-1         1.0      0
-  float-2         2.0      0
-  float-3         0.0      1
-  text            'a'      1
-  text-int-1      '0'      1
-  text-int-2      '1'      0
-  text-float-1    '1.0'    0
-  text-float-2    '0.0'    1
-  text-float-edge '12-23.0' 0
-  null            NULL     {}
-} {
-  do_execsql_test boolean-not "SELECT not $lhs" $::ans
-}
 
 do_execsql_test pi {
   SELECT pi()


### PR DESCRIPTION
Sqlite reference implementation: https://github.com/sqlite/sqlite/blob/837dc09bce7de8971c7488b70cf5da93c60fbed0/src/vdbe.c#L2558

We did not support blobs before and our ordering of the match statements were incorrect when one of the arguments was NULL