### PR TITLE
refactor: fold Async/Await insns into a single instruction

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -460,9 +460,7 @@ Modifiers:
 | HaltIfNull     | No     |         |
 | IdxDelete      | No     |         |
 | IdxGE          | Yes    |         |
-| IdxInsert      | No     |         |
-| IdxInsertAsync | Yes    |         |
-| IdxInsertAwait | Yes    |         |
+| IdxInsert      | Yes     |         |
 | IdxLE          | Yes    |         |
 | IdxLT          | Yes    |         |
 | IdxRowid       | No     |         |
@@ -474,9 +472,7 @@ Modifiers:
 | IncrVacuum     | No     |         |
 | Init           | Yes    |         |
 | InitCoroutine  | Yes    |         |
-| Insert         | No     |         |
-| InsertAsync    | Yes    |         |
-| InsertAwait    | Yes    |         |
+| Insert         | Yes     |         |
 | InsertInt      | No     |         |
 | Int64          | No     |         |
 | Integer        | Yes    |         |
@@ -497,9 +493,7 @@ Modifiers:
 | MustBeInt      | Yes    |         |
 | Ne             | Yes    |         |
 | NewRowid       | Yes    |         |
-| Next           | No     |         |
-| NextAsync      | Yes    |         |
-| NextAwait      | Yes    |         |
+| Next           | Yes     |         |
 | Noop           | Yes     |         |
 | Not            | Yes    |         |
 | NotExists      | Yes    |         |
@@ -512,18 +506,13 @@ Modifiers:
 | OpenEphemeral  | No     |         |
 | OpenPseudo     | Yes    |         |
 | OpenRead       | Yes    |         |
-| OpenReadAsync  | Yes    |         |
-| OpenWrite      | No     |         |
-| OpenWriteAsync | Yes    |         |
-| OpenWriteAwait | Yes    |         |
+| OpenWrite      | Yes     |         |
 | Or             | Yes    |         |
 | Pagecount      | Partial| no temp databases |
 | Param          | No     |         |
 | ParseSchema    | No     |         |
 | Permutation    | No     |         |
-| Prev           | No     |         |
-| PrevAsync      | Yes    |         |
-| PrevAwait      | Yes    |         |
+| Prev           | Yes     |         |
 | Program        | No     |         |
 | ReadCookie     | Partial| no temp databases, only user_version supported |
 | Real           | Yes    |         |
@@ -533,8 +522,6 @@ Modifiers:
 | ResultRow      | Yes    |         |
 | Return         | Yes    |         |
 | Rewind         | Yes    |         |
-| RewindAsync    | Yes    |         |
-| RewindAwait    | Yes    |         |
 | RowData        | No     |         |
 | RowId          | Yes    |         |
 | RowKey         | No     |         |
@@ -580,7 +567,7 @@ Modifiers:
 | VDestroy       | No     |         |
 | VFilter        | Yes    |         |
 | VNext          | Yes    |         |
-| VOpen          | Yes    |VOpenAsync|
+| VOpen          | Yes    |         |
 | VRename        | No     |         |
 | VUpdate        | Yes    |         |
 | Vacuum         | No     |         |

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2972,11 +2972,6 @@ impl BTreeCursor {
         }
     }
 
-    pub fn wait_for_completion(&mut self) -> Result<()> {
-        // TODO: Wait for pager I/O to complete
-        Ok(())
-    }
-
     pub fn rowid(&self) -> Result<Option<u64>> {
         if let Some(mv_cursor) = &self.mv_cursor {
             let mv_cursor = mv_cursor.borrow();

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -431,8 +431,7 @@ fn emit_delete_insns(
             conflict_action,
         });
     } else {
-        program.emit_insn(Insn::DeleteAsync { cursor_id });
-        program.emit_insn(Insn::DeleteAwait { cursor_id });
+        program.emit_insn(Insn::Delete { cursor_id });
     }
     if let Some(limit) = limit {
         let limit_reg = program.alloc_register();
@@ -683,13 +682,12 @@ fn emit_update_insns(
             count: table_ref.columns().len(),
             dest_reg: record_reg,
         });
-        program.emit_insn(Insn::InsertAsync {
+        program.emit_insn(Insn::Insert {
             cursor: cursor_id,
             key_reg: beg,
             record_reg,
             flag: 0,
         });
-        program.emit_insn(Insn::InsertAwait { cursor_id });
     } else if let Some(vtab) = table_ref.virtual_table() {
         let arg_count = table_ref.columns().len() + 2;
         program.emit_insn(Insn::VUpdate {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -102,11 +102,10 @@ pub fn translate_create_table(
         Some(SQLITE_TABLEID.to_owned()),
         CursorType::BTreeTable(table.clone()),
     );
-    program.emit_insn(Insn::OpenWriteAsync {
+    program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
     });
-    program.emit_insn(Insn::OpenWriteAwait {});
 
     // Add the table entry to sqlite_schema
     emit_schema_entry(
@@ -220,14 +219,11 @@ pub fn emit_schema_entry(
         dest_reg: record_reg,
     });
 
-    program.emit_insn(Insn::InsertAsync {
+    program.emit_insn(Insn::Insert {
         cursor: sqlite_schema_cursor_id,
         key_reg: rowid_reg,
         record_reg,
         flag: 0,
-    });
-    program.emit_insn(Insn::InsertAwait {
-        cursor_id: sqlite_schema_cursor_id,
     });
 }
 
@@ -499,11 +495,10 @@ pub fn translate_create_virtual_table(
         Some(SQLITE_TABLEID.to_owned()),
         CursorType::BTreeTable(table.clone()),
     );
-    program.emit_insn(Insn::OpenWriteAsync {
+    program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
     });
-    program.emit_insn(Insn::OpenWriteAwait {});
 
     let sql = create_vtable_body_to_str(&vtab);
     emit_schema_entry(
@@ -578,19 +573,15 @@ pub fn translate_drop_table(
         Some(table_name.to_string()),
         CursorType::BTreeTable(schema_table.clone()),
     );
-    program.emit_insn(Insn::OpenWriteAsync {
+    program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
     });
-    program.emit_insn(Insn::OpenWriteAwait {});
 
     //  1. Remove all entries from the schema table related to the table we are dropping, except for triggers
     //  loop to beginning of schema table
-    program.emit_insn(Insn::RewindAsync {
-        cursor_id: sqlite_schema_cursor_id,
-    });
     let end_metadata_label = program.allocate_label();
-    program.emit_insn(Insn::RewindAwait {
+    program.emit_insn(Insn::Rewind {
         cursor_id: sqlite_schema_cursor_id,
         pc_if_empty: end_metadata_label,
     });
@@ -625,18 +616,12 @@ pub fn translate_drop_table(
         cursor_id: sqlite_schema_cursor_id,
         dest: row_id_reg,
     });
-    program.emit_insn(Insn::DeleteAsync {
-        cursor_id: sqlite_schema_cursor_id,
-    });
-    program.emit_insn(Insn::DeleteAwait {
+    program.emit_insn(Insn::Delete {
         cursor_id: sqlite_schema_cursor_id,
     });
 
     program.resolve_label(next_label, program.offset());
-    program.emit_insn(Insn::NextAsync {
-        cursor_id: sqlite_schema_cursor_id,
-    });
-    program.emit_insn(Insn::NextAwait {
+    program.emit_insn(Insn::Next {
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: metadata_loop,
     });

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -327,17 +327,11 @@ impl ProgramBuilder {
                 } => {
                     resolve(target_pc, "IfNot");
                 }
-                Insn::RewindAwait {
-                    cursor_id: _cursor_id,
-                    pc_if_empty,
-                } => {
-                    resolve(pc_if_empty, "RewindAwait");
+                Insn::Rewind { pc_if_empty, .. } => {
+                    resolve(pc_if_empty, "Rewind");
                 }
-                Insn::LastAwait {
-                    cursor_id: _cursor_id,
-                    pc_if_empty,
-                } => {
-                    resolve(pc_if_empty, "LastAwait");
+                Insn::Last { pc_if_empty, .. } => {
+                    resolve(pc_if_empty, "Last");
                 }
                 Insn::Goto { target_pc } => {
                     resolve(target_pc, "Goto");
@@ -366,11 +360,11 @@ impl ProgramBuilder {
                 Insn::IfPos { target_pc, .. } => {
                     resolve(target_pc, "IfPos");
                 }
-                Insn::NextAwait { pc_if_next, .. } => {
-                    resolve(pc_if_next, "NextAwait");
+                Insn::Next { pc_if_next, .. } => {
+                    resolve(pc_if_next, "Next");
                 }
-                Insn::PrevAwait { pc_if_next, .. } => {
-                    resolve(pc_if_next, "PrevAwait");
+                Insn::Prev { pc_if_prev, .. } => {
+                    resolve(pc_if_prev, "Prev");
                 }
                 Insn::InitCoroutine {
                     yield_reg: _,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -336,11 +336,11 @@ pub fn insn_to_str(
                 0,
                 format!("if !r[{}] goto {}", reg, target_pc.to_debug_int()),
             ),
-            Insn::OpenReadAsync {
+            Insn::OpenRead {
                 cursor_id,
                 root_page,
             } => (
-                "OpenReadAsync",
+                "OpenRead",
                 *cursor_id as i32,
                 *root_page as i32,
                 0,
@@ -355,27 +355,9 @@ pub fn insn_to_str(
                     root_page
                 ),
             ),
-            Insn::OpenReadAwait => (
-                "OpenReadAwait",
-                0,
-                0,
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
-            ),
-            Insn::VOpenAsync { cursor_id } => (
-                "VOpenAsync",
+            Insn::VOpen { cursor_id } => (
+                "VOpen",
                 *cursor_id as i32,
-                0,
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
-            ),
-            Insn::VOpenAwait => (
-                "VOpenAwait",
-                0,
                 0,
                 0,
                 OwnedValue::build_text(""),
@@ -462,27 +444,18 @@ pub fn insn_to_str(
                 0,
                 format!("{} columns in r[{}]", num_fields, content_reg),
             ),
-            Insn::RewindAsync { cursor_id } => (
-                "RewindAsync",
-                *cursor_id as i32,
-                0,
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
-            ),
-            Insn::RewindAwait {
+            Insn::Rewind {
                 cursor_id,
                 pc_if_empty,
             } => (
-                "RewindAwait",
+                "Rewind",
                 *cursor_id as i32,
                 pc_if_empty.to_debug_int(),
                 0,
                 OwnedValue::build_text(""),
                 0,
                 format!(
-                    "Rewind table {}",
+                    "Rewind {}",
                     program.cursor_ref[*cursor_id]
                         .0
                         .as_ref()
@@ -573,20 +546,11 @@ pub fn insn_to_str(
                     format!("output=r[{}..{}]", start_reg, start_reg + count - 1)
                 },
             ),
-            Insn::NextAsync { cursor_id } => (
-                "NextAsync",
-                *cursor_id as i32,
-                0,
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
-            ),
-            Insn::NextAwait {
+            Insn::Next {
                 cursor_id,
                 pc_if_next,
             } => (
-                "NextAwait",
+                "Next",
                 *cursor_id as i32,
                 pc_if_next.to_debug_int(),
                 0,
@@ -795,29 +759,20 @@ pub fn insn_to_str(
                 0,
                 "".to_string(),
             ),
-            Insn::IdxInsertAsync {
+            Insn::IdxInsert {
                 cursor_id,
                 record_reg,
                 unpacked_start,
                 flags,
                 ..
             } => (
-                "IdxInsertAsync",
+                "IdxInsert",
                 *cursor_id as i32,
                 *record_reg as i32,
                 unpacked_start.unwrap_or(0) as i32,
                 OwnedValue::build_text(""),
                 flags.0 as u16,
                 format!("key=r[{}]", record_reg),
-            ),
-            Insn::IdxInsertAwait { cursor_id } => (
-                "IdxInsertAwait",
-                *cursor_id as i32,
-                0,
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
             ),
             Insn::IdxGT {
                 cursor_id,
@@ -1034,13 +989,13 @@ pub fn insn_to_str(
                 0,
                 "".to_string(),
             ),
-            Insn::InsertAsync {
+            Insn::Insert {
                 cursor,
                 key_reg,
                 record_reg,
                 flag,
             } => (
-                "InsertAsync",
+                "Insert",
                 *cursor as i32,
                 *record_reg as i32,
                 *key_reg as i32,
@@ -1048,26 +1003,8 @@ pub fn insn_to_str(
                 *flag as u16,
                 "".to_string(),
             ),
-            Insn::InsertAwait { cursor_id } => (
-                "InsertAwait",
-                *cursor_id as i32,
-                0,
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
-            ),
-            Insn::DeleteAsync { cursor_id } => (
-                "DeleteAsync",
-                *cursor_id as i32,
-                0,
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
-            ),
-            Insn::DeleteAwait { cursor_id } => (
-                "DeleteAwait",
+            Insn::Delete { cursor_id } => (
+                "Delete",
                 *cursor_id as i32,
                 0,
                 0,
@@ -1135,26 +1072,17 @@ pub fn insn_to_str(
                     limit_reg, combined_reg, limit_reg, offset_reg, combined_reg
                 ),
             ),
-            Insn::OpenWriteAsync {
+            Insn::OpenWrite {
                 cursor_id,
                 root_page,
                 ..
             } => (
-                "OpenWriteAsync",
+                "OpenWrite",
                 *cursor_id as i32,
                 match root_page {
                     RegisterOrLiteral::Literal(i) => *i as _,
                     RegisterOrLiteral::Register(i) => *i as _,
                 },
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
-            ),
-            Insn::OpenWriteAwait {} => (
-                "OpenWriteAwait",
-                0,
-                0,
                 0,
                 OwnedValue::build_text(""),
                 0,
@@ -1221,10 +1149,13 @@ pub fn insn_to_str(
                 0,
                 "".to_string(),
             ),
-            Insn::LastAsync { cursor_id } => (
-                "LastAsync",
+            Insn::Last {
+                cursor_id,
+                pc_if_empty,
+            } => (
+                "Last",
                 *cursor_id as i32,
-                0,
+                pc_if_empty.to_debug_int(),
                 0,
                 OwnedValue::build_text(""),
                 0,
@@ -1248,28 +1179,13 @@ pub fn insn_to_str(
                 0,
                 where_clause.clone(),
             ),
-            Insn::LastAwait { cursor_id, .. } => (
-                "LastAwait",
+            Insn::Prev {
+                cursor_id,
+                pc_if_prev,
+            } => (
+                "Prev",
                 *cursor_id as i32,
-                0,
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
-            ),
-            Insn::PrevAsync { cursor_id } => (
-                "PrevAsync",
-                *cursor_id as i32,
-                0,
-                0,
-                OwnedValue::build_text(""),
-                0,
-                "".to_string(),
-            ),
-            Insn::PrevAwait { cursor_id, .. } => (
-                "PrevAwait",
-                *cursor_id as i32,
-                0,
+                pc_if_prev.to_debug_int(),
                 0,
                 OwnedValue::build_text(""),
                 0,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -563,8 +563,8 @@ fn print_insn(program: &Program, addr: InsnReference, insn: &Insn, indent: Strin
 fn get_indent_count(indent_count: usize, curr_insn: &Insn, prev_insn: Option<&Insn>) -> usize {
     let indent_count = if let Some(insn) = prev_insn {
         match insn {
-            Insn::RewindAwait { .. }
-            | Insn::LastAwait { .. }
+            Insn::Rewind { .. }
+            | Insn::Last { .. }
             | Insn::SorterSort { .. }
             | Insn::SeekGE { .. }
             | Insn::SeekGT { .. }
@@ -578,9 +578,7 @@ fn get_indent_count(indent_count: usize, curr_insn: &Insn, prev_insn: Option<&In
     };
 
     match curr_insn {
-        Insn::NextAsync { .. } | Insn::SorterNext { .. } | Insn::PrevAsync { .. } => {
-            indent_count - 1
-        }
+        Insn::Next { .. } | Insn::SorterNext { .. } | Insn::Prev { .. } => indent_count - 1,
         _ => indent_count,
     }
 }


### PR DESCRIPTION
Seems to me like these are not needed -- we wait for completions in `io.run_once()` as soon as anything returns a `StepResult::IO`, and practically all of the `*Await` opcodes either explicitly do nothing or call `cursor.wait_for_completion()` which does nothing