### PR TITLE
Bump julian_day_converter to 0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "julian_day_converter"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa5652b85ab018289638c6b924db618da9edd2ddfff7fa0ec38a8b51a9192d3"
+checksum = "f2987f71b89b85c812c8484cbf0c5d7912589e77bfdc66fd3e52f760e7859f16"
 dependencies = [
  "chrono",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,7 +53,7 @@ regex-syntax = { version = "0.8.5", default-features = false, features = [
     "unicode",
 ] }
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
-julian_day_converter = "0.4.4"
+julian_day_converter = "0.4.5"
 rand = "0.8.5"
 libm = "0.2"
 limbo_macros = { workspace = true }

--- a/testing/scalar-functions-datetime.test
+++ b/testing/scalar-functions-datetime.test
@@ -597,6 +597,10 @@ foreach i $FMT {
   do_execsql_test strftime-invalid-$i "SELECT strftime('$i','2025-01-23T13:14:30.567');" {}
 }
 
+do_execsql_test strftime-julianday {
+  SELECT strftime('%Y-%m-%d %H:%M:%fZ', 2459717.08070103);
+} {"2022-05-17 13:56:12.569Z"}
+
 
 # Tests for the TIMEDIFF function
 


### PR DESCRIPTION
The previous version of `julian_day-converter` had precision issues, potentially causing loss of precision when converting between `julianday` and `datetime`

![image](https://github.com/user-attachments/assets/84042ca3-28cc-4020-a248-714df6298791)
