### PR TITLE
Feat: Covering indexes

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -95,7 +95,7 @@ pub struct TranslateCtx<'a> {
 
 /// Used to distinguish database operations
 #[allow(clippy::upper_case_acronyms, dead_code)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OperationMode {
     SELECT,
     INSERT,

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -167,32 +167,34 @@ fn eliminate_orderby_like_groupby(plan: &mut SelectPlan) -> Result<()> {
     Ok(())
 }
 
+/// Eliminate unnecessary ORDER BY clauses.
+/// Returns true if the ORDER BY clause was eliminated.
 fn eliminate_unnecessary_orderby(
     table_references: &mut [TableReference],
     available_indexes: &HashMap<String, Vec<Arc<Index>>>,
     order_by: &mut Option<Vec<(ast::Expr, Direction)>>,
     group_by: &Option<GroupBy>,
-) -> Result<()> {
+) -> Result<bool> {
     let Some(order) = order_by else {
-        return Ok(());
+        return Ok(false);
     };
     let Some(first_table_reference) = table_references.first_mut() else {
-        return Ok(());
+        return Ok(false);
     };
     let Some(btree_table) = first_table_reference.btree() else {
-        return Ok(());
+        return Ok(false);
     };
     // If GROUP BY clause is present, we can't rely on already ordered columns because GROUP BY reorders the data
     // This early return prevents the elimination of ORDER BY when GROUP BY exists, as sorting must be applied after grouping
     // And if ORDER BY clause duplicates GROUP BY we handle it later in fn eliminate_orderby_like_groupby
     if group_by.is_some() {
-        return Ok(());
+        return Ok(false);
     }
     let Operation::Scan {
         index, iter_dir, ..
     } = &mut first_table_reference.op
     else {
-        return Ok(());
+        return Ok(false);
     };
 
     assert!(
@@ -207,7 +209,7 @@ fn eliminate_unnecessary_orderby(
             Direction::Descending => IterationDirection::Backwards,
         };
         *order_by = None;
-        return Ok(());
+        return Ok(true);
     }
 
     // Find the best matching index for the ORDER BY columns
@@ -235,7 +237,7 @@ fn eliminate_unnecessary_orderby(
     }
 
     let Some(matching_index) = best_index.0 else {
-        return Ok(());
+        return Ok(false);
     };
     let match_count = best_index.1;
 
@@ -280,7 +282,7 @@ fn eliminate_unnecessary_orderby(
         }
     }
 
-    Ok(())
+    Ok(order_by.is_none())
 }
 
 /**
@@ -300,7 +302,8 @@ fn use_indexes(
     group_by: &Option<GroupBy>,
 ) -> Result<()> {
     // Try to use indexes for eliminating ORDER BY clauses
-    eliminate_unnecessary_orderby(table_references, available_indexes, order_by, group_by)?;
+    let did_eliminate_orderby =
+        eliminate_unnecessary_orderby(table_references, available_indexes, order_by, group_by)?;
 
     // Try to use indexes for WHERE conditions
     for (table_index, table_reference) in table_references.iter_mut().enumerate() {
@@ -345,6 +348,12 @@ fn use_indexes(
                         } else {
                             i += 1;
                         }
+                    }
+                    if did_eliminate_orderby && table_index == 0 {
+                        // If we already made the decision to remove ORDER BY based on the Rowid (e.g. ORDER BY id), then skip this.
+                        // It would be possible to analyze the index and see if the covering index would retain the ordering guarantee,
+                        // but we just don't do that yet.
+                        continue;
                     }
                     if let Some(indexes) = available_indexes.get(table_name) {
                         if let Some(search) = try_extract_index_search_from_where_clause(

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -368,6 +368,22 @@ fn use_indexes(
                 }
             }
         }
+
+        // Finally, if there's no other reason to use an index, if an index covers the columns used in the query, let's use it.
+        if let Some(indexes) = available_indexes.get(table_reference.table.get_name()) {
+            for index_candidate in indexes.iter() {
+                let is_covering = table_reference.index_is_covering(index_candidate);
+                if let Operation::Scan { index, .. } = &mut table_reference.op {
+                    if index.is_some() {
+                        continue;
+                    }
+                    if is_covering {
+                        *index = Some(index_candidate.clone());
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     Ok(())

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -539,6 +539,17 @@ impl TableReference {
         }
     }
 
+    /// Resolve the already opened cursors for this table reference.
+    pub fn resolve_cursors(
+        &self,
+        program: &mut ProgramBuilder,
+    ) -> Result<(Option<CursorID>, Option<CursorID>)> {
+        let index = self.op.index();
+        let table_cursor_id = program.resolve_cursor_id_safe(&self.identifier);
+        let index_cursor_id = index.map(|index| program.resolve_cursor_id(&index.name));
+        Ok((table_cursor_id, index_cursor_id))
+    }
+
     /// Returns true if a given index is a covering index for this [TableReference].
     pub fn index_is_covering(&self, index: &Index) -> bool {
         let Table::BTree(btree) = &self.table else {


### PR DESCRIPTION
Closes #364 

Covering indexes mean being able to read all the necessary data from an index instead of using the underlying table at all. This PR adds that functionality.

This PR can be reviewed commit-by-commit as the first commits are enablers for the actual covering index usage functionality

Example of a scan where covering index can be used:

```sql
limbo> .schema
CREATE TABLE t(a,b,c,d,e);
CREATE INDEX abc ON t (a,b,c);
limbo> explain select b+1,concat(a, c) from t;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     12    0                    0   Start at 12
1     OpenRead           0     3     0                    0   table=abc, root=3
2     Rewind             0     11    0                    0   Rewind abc
3       Column           0     1     3                    0   r[3]=abc.b
4       Integer          1     4     0                    0   r[4]=1
5       Add              3     4     1                    0   r[1]=r[3]+r[4]
6       Column           0     0     5                    0   r[5]=abc.a
7       Column           0     2     6                    0   r[6]=abc.c
8       Function         0     5     2     concat         0   r[2]=func(r[5..6])
9       ResultRow        1     2     0                    0   output=r[1..2]
10    Next               0     3     0                    0   
11    Halt               0     0     0                    0   
12    Transaction        0     0     0                    0   write=false
13    Goto               0     1     0                    0  
```

Example of a scan where it can't be used:
```sql
limbo> .schema
CREATE TABLE t(a,b,c,d,e);
CREATE INDEX abc ON t (a,b,c);
limbo> explain select a,b,c,d from t limit 5;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     11    0                    0   Start at 11
1     OpenRead           0     2     0                    0   table=t, root=2
2     Rewind             0     10    0                    0   Rewind t
3       Column           0     0     4                    0   r[4]=t.a
4       Column           0     1     5                    0   r[5]=t.b
5       Column           0     2     6                    0   r[6]=t.c
6       Column           0     3     7                    0   r[7]=t.d
7       ResultRow        4     4     0                    0   output=r[4..7]
8       DecrJumpZero     1     10    0                    0   if (--r[1]==0) goto 10
9     Next               0     3     0                    0   
10    Halt               0     0     0                    0   
11    Transaction        0     0     0                    0   write=false
12    Integer            5     1     0                    0   r[1]=5
13    Integer            0     2     0                    0   r[2]=0
14    OffsetLimit        1     3     2                    0   if r[1]>0 then r[3]=r[1]+max(0,r[2]) else r[3]=(-1)
15    Goto               0     1     0                    0 
```
