### PR TITLE
Create an automatic ephemeral index when a nested table scan would otherwise be selected

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -692,6 +692,7 @@ pub struct Index {
     pub root_page: usize,
     pub columns: Vec<IndexColumn>,
     pub unique: bool,
+    pub ephemeral: bool,
 }
 
 #[allow(dead_code)]
@@ -741,6 +742,7 @@ impl Index {
                     root_page,
                     columns: index_columns,
                     unique,
+                    ephemeral: false,
                 })
             }
             _ => todo!("Expected create index statement"),
@@ -783,6 +785,7 @@ impl Index {
             root_page,
             columns: index_columns,
             unique: true, // Primary key indexes are always unique
+            ephemeral: false,
         })
     }
 

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -62,6 +62,7 @@ pub fn translate_create_index(
             })
             .collect(),
         unique: unique_if_not_exists.0,
+        ephemeral: false,
     });
 
     // Allocate the necessary cursors:

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -355,15 +355,18 @@ fn use_indexes(
                         // but we just don't do that yet.
                         continue;
                     }
+                    let placeholder = vec![];
+                    let mut usable_indexes_ref = &placeholder;
                     if let Some(indexes) = available_indexes.get(table_name) {
-                        if let Some(search) = try_extract_index_search_from_where_clause(
-                            where_clause,
-                            table_index,
-                            table_reference,
-                            indexes,
-                        )? {
-                            table_reference.op = Operation::Search(search);
-                        }
+                        usable_indexes_ref = indexes;
+                    }
+                    if let Some(search) = try_extract_index_search_from_where_clause(
+                        where_clause,
+                        table_index,
+                        table_reference,
+                        usable_indexes_ref,
+                    )? {
+                        table_reference.op = Operation::Search(search);
                     }
                 }
             }
@@ -728,10 +731,6 @@ pub fn try_extract_index_search_from_where_clause(
 ) -> Result<Option<Search>> {
     // If there are no WHERE terms, we can't extract a search
     if where_clause.is_empty() {
-        return Ok(None);
-    }
-    // If there are no indexes, we can't extract a search
-    if table_indexes.is_empty() {
         return Ok(None);
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -590,6 +590,10 @@ impl TableReference {
         };
         self.index_is_covering(index.as_ref())
     }
+
+    pub fn column_is_used(&self, index: usize) -> bool {
+        self.col_used_mask.get(index)
+    }
 }
 
 /// A definition of a rowid/index search.

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -509,7 +509,10 @@ impl TableReference {
         match &self.table {
             Table::BTree(btree) => {
                 let use_covering_index = self.utilizes_covering_index();
-                let table_cursor_id = if use_covering_index && mode == OperationMode::SELECT {
+                let index_is_ephemeral = index.map_or(false, |index| index.ephemeral);
+                let table_not_required =
+                    OperationMode::SELECT == mode && use_covering_index && !index_is_ephemeral;
+                let table_cursor_id = if table_not_required {
                     None
                 } else {
                     Some(program.alloc_cursor_id(

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -363,6 +363,12 @@ impl ProgramBuilder {
                 Insn::Next { pc_if_next, .. } => {
                     resolve(pc_if_next, "Next");
                 }
+                Insn::Once {
+                    target_pc_when_reentered,
+                    ..
+                } => {
+                    resolve(target_pc_when_reentered, "Once");
+                }
                 Insn::Prev { pc_if_prev, .. } => {
                     resolve(pc_if_prev, "Prev");
                 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3766,7 +3766,6 @@ pub fn op_idx_insert(
     pager: &Rc<Pager>,
     mv_store: Option<&Rc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
-    dbg!("op_idx_insert_");
     if let Insn::IdxInsert {
         cursor_id,
         record_reg,
@@ -3807,7 +3806,6 @@ pub fn op_idx_insert(
                 }
             };
 
-            dbg!(moved_before);
             // Start insertion of row. This might trigger a balance procedure which will take care of moving to different pages,
             // therefore, we don't want to seek again if that happens, meaning we don't want to return on io without moving to the following opcode
             // because it could trigger a movement to child page after a balance root which will leave the current page as the root page.


### PR DESCRIPTION
Closes #747 

- Creates an automatic ephemeral (in-memory) index on the right-side table of a join if otherwise a nested table scan would be selected.
- This behavior is not hardcoded; instead this PR introduces a (quite dumb) cost estimator that naturally deincentivizes building ephemeral indexes where they don't make sense (e.g. the outermost table). I will probably build this estimator to be smarter in the future when working on join reordering optimizations

### Example bytecode plans and runtimes (note that this is debug mode)

Example query with no persistent indexes to choose from. Without ephemeral index it's a nested scan:

```sql
limbo> explain select * from t1 natural join t2;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     13    0                    0   Start at 13
1     OpenRead           0     2     0                    0   table=t1, root=2
2     OpenRead           1     3     0                    0   table=t2, root=3
3     Rewind             0     12    0                    0   Rewind t1
4       Rewind           1     11    0                    0   Rewind t2
5         Column         0     0     2                    0   r[2]=t1.a
6         Column         1     0     3                    0   r[3]=t2.a
7         Ne             2     3     10                   0   if r[2]!=r[3] goto 10
8         Column         0     0     1                    0   r[1]=t1.a
9         ResultRow      1     1     0                    0   output=r[1]
10      Next             1     5     0                    0   
11    Next               0     4     0                    0   
12    Halt               0     0     0                    0   
13    Transaction        0     0     0                    0   write=false
14    Goto               0     1     0                    0   

limbo> .timer on
limbo> select * from t1 natural join t2;
┌───┐
│ a │
├───┤
└───┘
Command stats:
----------------------------
total: 953 ms (this includes parsing/coloring of cli app)
```

Same query with autoindexing enabled:

```sql
limbo> explain select * from t1 natural join t2;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     22    0                    0   Start at 22
1     OpenRead           0     2     0                    0   table=t1, root=2
2     OpenRead           1     3     0                    0   table=t2, root=3
3     Rewind             0     21    0                    0   Rewind t1
4       Once             12    0     0                    0   goto 12 # execute block 5-11 only once, on subsequent iters jump straight to 12
5       OpenAutoindex    3     0     0                    0   cursor=3
6       Rewind           1     12    0                    0   Rewind t2 # open source table for ephemeral index
7         Column         1     0     2                    0   r[2]=t2.a
8         RowId          1     3     0                    0   r[3]=t2.rowid
9         MakeRecord     2     2     4                    0   r[4]=mkrec(r[2..3])
10        IdxInsert      3     4     2                    0   key=r[4] # insert stuff to ephemeral index
11      Next             1     7     0                    0   
12      Column           0     0     5                    0   r[5]=t1.a
13      IsNull           5     20    0                    0   if (r[5]==NULL) goto 20
14      SeekGE           3     20    5                    0   key=[5..5] # perform seek on ephemeral index
15        IdxGT          3     20    5                    0   key=[5..5]
16        DeferredSeek   3     1     0                    0   
17        Column         0     0     1                    0   r[1]=t1.a
18        ResultRow      1     1     0                    0   output=r[1]
19      Next             2     15    0                    0   
20    Next               0     4     0                    0   
21    Halt               0     0     0                    0   
22    Transaction        0     0     0                    0   write=false
23    Goto               0     1     0                    0   

limbo> .timer on
limbo> select * from t1 natural join t2;
┌───┐
│ a │
├───┤
└───┘
Command stats:
----------------------------
total: 220 ms (this includes parsing/coloring of cli app)
```