### PR TITLE
btree: use binary search in seek/move_to for table btrees

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1463,8 +1463,10 @@ impl BTreeCursor {
         //    This cell contains the actual data we are looking for.
         // 6. If we find the cell, we return the record. Otherwise, we return an empty result.
         self.move_to_root();
-
         let iter_dir = cmp.iteration_direction();
+        if let SeekKey::TableRowId(rowid_key) = key {
+            return self.tablebtree_move_to_binsearch(rowid_key, cmp, iter_dir);
+        }
 
         loop {
             let page = self.stack.top();


### PR DESCRIPTION
Implements binary search to find the correct cell within a page, specialized for table btrees only due to lack of energy at 8:30 PM

---

I used a [1GB TPC-H database](https://github.com/lovasoa/TPCH-sqlite/releases/download/v1.0/TPC-H.db) for benchmarking and ran this query which does a lot of seeks:

before
```sql
limbo> .timer on
limbo> select
        l_orderkey,
        3 as revenue,
        o_orderdate,
        o_shippriority
from
        lineitem,
        orders,
        customer
where
        c_mktsegment = 'FURNITURE'
        and c_custkey = o_custkey
        and l_orderkey = o_orderkey
        and o_orderdate < cast('1995-03-29' as datetime)
        and l_shipdate > cast('1995-03-29' as datetime);
┌────────────┬─────────┬─────────────┬────────────────┐
│ l_orderkey │ revenue │ o_orderdate │ o_shippriority │
├────────────┼─────────┼─────────────┼────────────────┤
└────────────┴─────────┴─────────────┴────────────────┘
Command stats:
----------------------------
total: 16.267797375 s (this includes parsing/coloring of cli app)
```

after
```sql
limbo> .timer on
limbo> select
        l_orderkey,
        3 as revenue,
        o_orderdate,
        o_shippriority
from
        lineitem,
        orders,
        customer
where
        c_mktsegment = 'FURNITURE'
        and c_custkey = o_custkey
        and l_orderkey = o_orderkey
        and o_orderdate < cast('1995-03-29' as datetime)
        and l_shipdate > cast('1995-03-29' as datetime);
┌────────────┬─────────┬─────────────┬────────────────┐
│ l_orderkey │ revenue │ o_orderdate │ o_shippriority │
├────────────┼─────────┼─────────────┼────────────────┤
└────────────┴─────────┴─────────────┴────────────────┘
Command stats:
----------------------------
total: 5.20604125 s (this includes parsing/coloring of cli app)
```

BTW sqlite completes this in 600 milliseconds so there's still a lot of fuckiness somewhere.

---

UPDATE: refactored table btree seek (on leaf pages) to use binary search too. I also updated the above numbers so that I ran each a few times and took the lowest time i got for each. This is after binsearch on leaf pages too: 

```sql
limbo> select l_orderkey, 3 as revenue, o_orderdate, o_shippriority from lineitem, orders, customer where c_mktsegment = 'FURNITURE' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < cast('1995-03-29' as datetime) and l_shipdate > cast('1995-03-29' as datetime);
┌────────────┬─────────┬─────────────┬────────────────┐
│ l_orderkey │ revenue │ o_orderdate │ o_shippriority │
├────────────┼─────────┼─────────────┼────────────────┤
└────────────┴─────────┴─────────────┴────────────────┘
Command stats:
----------------------------
total: 4.529645958 s (this includes parsing/coloring of cli app)
```