### PR TITLE
Fix bug: left join null flag not being cleared

### DIFF
--- a/testing/join.test
+++ b/testing/join.test
@@ -273,3 +273,13 @@ do_execsql_test natural-join-and-using-join {
 } {"1|1|1
 1|1204|1
 1|1261|1"}
+
+# regression test for a backwards iteration left join case,
+# where the null flag of the right table was not cleared after a previous unmatched row.
+do_execsql_test left-join-backwards-iteration {
+    select users.id, users.first_name as user_name, products.name as product_name 
+    from users left join products on users.id = products.id 
+    where users.id < 13 order by users.id desc limit 3;
+} {12|Alan|
+11|Travis|accessories
+10|Daniel|coat}


### PR DESCRIPTION
In left joins, even if the join condition is not matched, the system must emit a row for every row of the outer table:

```
-- this must return t1.count() rows, with NULLs for all columns of t2
SELECT * FROM t1 LEFT JOIN t2 ON FALSE;
```

To achieve this, we set a "null flag" on the right table cursor which tells our VDBE to emit NULLs for any columns of that cursor until the flag is cleared.

Our logic for clearing the null flag was to do it in Next/Prev. However, this is problematic for a few reasons:

- If the inner table of the left join is using SeekRowid, then Next/Prev is never called on its cursor, so the null flag doesn't get cleared.
- If the inner table of the left join is using a non-covering index seek, i.e. it iterates its rows using an index, but seeks to the main table to fetch data, then Next/Prev is never called on the main table, and the main table's null flag doesn't get cleared.

What this results in is NULL values incorrectly being emitted for the inner table after the first correct NULL row, since the null flag is correctly set to true, but never cleared.

This PR fixes the issue by clearing the null flag whenever seek() is invoked on the cursor. Hence, the null flag is now cleared on:

- next()
- prev()
- seek()