### PR TITLE
Fix bug: we cant remove order by terms from the head of the list

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -3,7 +3,7 @@ use super::plan::{select_star, Operation, Search, SelectQueryType};
 use super::planner::Scope;
 use crate::function::{AggFunc, ExtFunc, Func};
 use crate::translate::optimizer::optimize_plan;
-use crate::translate::plan::{Aggregate, Direction, GroupBy, Plan, ResultSetColumn, SelectPlan};
+use crate::translate::plan::{Aggregate, GroupBy, Plan, ResultSetColumn, SelectPlan};
 use crate::translate::planner::{
     bind_column_references, break_predicate_at_and_boundaries, parse_from, parse_limit,
     parse_where, resolve_aggregates,
@@ -368,13 +368,7 @@ pub fn prepare_select_plan<'a>(
                     )?;
                     resolve_aggregates(&o.expr, &mut plan.aggregates);
 
-                    key.push((
-                        o.expr,
-                        o.order.map_or(Direction::Ascending, |o| match o {
-                            ast::SortOrder::Asc => Direction::Ascending,
-                            ast::SortOrder::Desc => Direction::Descending,
-                        }),
-                    ));
+                    key.push((o.expr, o.order.unwrap_or(ast::SortOrder::Asc)));
                 }
                 plan.order_by = Some(key);
             }

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -11,8 +11,7 @@ use limbo_sqlite3_parser::ast::{self, Expr, ResultColumn, SortOrder, Update};
 use super::emitter::emit_program;
 use super::optimizer::optimize_plan;
 use super::plan::{
-    ColumnUsedMask, Direction, IterationDirection, Plan, ResultSetColumn, TableReference,
-    UpdatePlan,
+    ColumnUsedMask, IterationDirection, Plan, ResultSetColumn, TableReference, UpdatePlan,
 };
 use super::planner::bind_column_references;
 use super::planner::{parse_limit, parse_where};
@@ -155,17 +154,7 @@ pub fn prepare_update_plan(schema: &Schema, body: &mut Update) -> crate::Result<
     let order_by = body.order_by.as_ref().map(|order| {
         order
             .iter()
-            .map(|o| {
-                (
-                    o.expr.clone(),
-                    o.order
-                        .map(|s| match s {
-                            SortOrder::Asc => Direction::Ascending,
-                            SortOrder::Desc => Direction::Descending,
-                        })
-                        .unwrap_or(Direction::Ascending),
-                )
-            })
+            .map(|o| (o.expr.clone(), o.order.unwrap_or(SortOrder::Asc)))
             .collect()
     });
     // Parse the WHERE clause

--- a/core/types.rs
+++ b/core/types.rs
@@ -1069,10 +1069,10 @@ impl IndexKeySortOrder {
         IndexKeySortOrder(spec)
     }
 
-    pub fn from_bool_vec(order: Vec<bool>) -> Self {
+    pub fn from_list(order: &[SortOrder]) -> Self {
         let mut spec = 0;
-        for (i, &is_asc) in order.iter().enumerate() {
-            spec |= (!is_asc as u64) << i;
+        for (i, order) in order.iter().enumerate() {
+            spec |= ((*order == SortOrder::Desc) as u64) << i;
         }
         IndexKeySortOrder(spec)
     }

--- a/core/types.rs
+++ b/core/types.rs
@@ -1069,6 +1069,14 @@ impl IndexKeySortOrder {
         IndexKeySortOrder(spec)
     }
 
+    pub fn from_bool_vec(order: Vec<bool>) -> Self {
+        let mut spec = 0;
+        for (i, &is_asc) in order.iter().enumerate() {
+            spec |= (!is_asc as u64) << i;
+        }
+        IndexKeySortOrder(spec)
+    }
+
     pub fn default() -> Self {
         Self(0)
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2693,14 +2693,6 @@ pub fn op_sorter_open(
     else {
         unreachable!("unexpected Insn {:?}", insn)
     };
-    let order = order
-        .get_values()
-        .iter()
-        .map(|v| match v {
-            OwnedValue::Integer(i) => *i == 0,
-            _ => unreachable!(),
-        })
-        .collect();
     let cursor = Sorter::new(order);
     let mut cursors = state.cursors.borrow_mut();
     cursors

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1,3 +1,5 @@
+use limbo_sqlite3_parser::ast::SortOrder;
+
 use crate::vdbe::{builder::CursorType, insn::RegisterOrLiteral};
 
 use super::{Insn, InsnReference, OwnedValue, Program};
@@ -876,17 +878,10 @@ pub fn insn_to_str(
             } => {
                 let _p4 = String::new();
                 let to_print: Vec<String> = order
-                    .get_values()
                     .iter()
                     .map(|v| match v {
-                        OwnedValue::Integer(i) => {
-                            if *i == 0 {
-                                "B".to_string()
-                            } else {
-                                "-B".to_string()
-                            }
-                        }
-                        _ => unreachable!(),
+                        SortOrder::Asc => "B".to_string(),
+                        SortOrder::Desc => "-B".to_string(),
                     })
                     .collect();
                 (

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -7,9 +7,9 @@ use super::{execute, AggFunc, BranchOffset, CursorID, FuncCtx, InsnFunction, Pag
 use crate::{
     schema::BTreeTable,
     storage::{pager::CreateBTreeFlags, wal::CheckpointMode},
-    types::Record,
 };
 use limbo_macros::Description;
+use limbo_sqlite3_parser::ast::SortOrder;
 
 /// Flags provided to comparison instructions (e.g. Eq, Ne) which determine behavior related to NULL values.
 #[derive(Clone, Copy, Debug, Default)]
@@ -586,9 +586,9 @@ pub enum Insn {
 
     /// Open a sorter.
     SorterOpen {
-        cursor_id: CursorID, // P1
-        columns: usize,      // P2
-        order: Record,       // P4. 0 if ASC and 1 if DESC
+        cursor_id: CursorID,   // P1
+        columns: usize,        // P2
+        order: Vec<SortOrder>, // P4.
     },
 
     /// Insert a row into the sorter.

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1,10 +1,10 @@
-use crate::types::ImmutableRecord;
-use std::cmp::Ordering;
+use crate::types::{compare_immutable, ImmutableRecord, IndexKeySortOrder};
 
 pub struct Sorter {
     records: Vec<ImmutableRecord>,
     current: Option<ImmutableRecord>,
-    order: Vec<bool>,
+    order: IndexKeySortOrder,
+    key_len: usize,
 }
 
 impl Sorter {
@@ -12,7 +12,8 @@ impl Sorter {
         Self {
             records: Vec::new(),
             current: None,
-            order,
+            key_len: order.len(),
+            order: IndexKeySortOrder::from_bool_vec(order),
         }
     }
     pub fn is_empty(&self) -> bool {
@@ -26,24 +27,11 @@ impl Sorter {
     // We do the sorting here since this is what is called by the SorterSort instruction
     pub fn sort(&mut self) {
         self.records.sort_by(|a, b| {
-            let cmp_by_idx = |idx: usize, ascending: bool| {
-                let a = &a.get_value(idx);
-                let b = &b.get_value(idx);
-                if ascending {
-                    a.cmp(b)
-                } else {
-                    b.cmp(a)
-                }
-            };
-
-            let mut cmp_ret = Ordering::Equal;
-            for (idx, &is_asc) in self.order.iter().enumerate() {
-                cmp_ret = cmp_by_idx(idx, is_asc);
-                if cmp_ret != Ordering::Equal {
-                    break;
-                }
-            }
-            cmp_ret
+            compare_immutable(
+                &a.values[..self.key_len],
+                &b.values[..self.key_len],
+                self.order,
+            )
         });
         self.records.reverse();
         self.next()

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1,3 +1,5 @@
+use limbo_sqlite3_parser::ast::SortOrder;
+
 use crate::types::{compare_immutable, ImmutableRecord, IndexKeySortOrder};
 
 pub struct Sorter {
@@ -8,12 +10,12 @@ pub struct Sorter {
 }
 
 impl Sorter {
-    pub fn new(order: Vec<bool>) -> Self {
+    pub fn new(order: &[SortOrder]) -> Self {
         Self {
             records: Vec::new(),
             current: None,
             key_len: order.len(),
-            order: IndexKeySortOrder::from_bool_vec(order),
+            order: IndexKeySortOrder::from_list(order),
         }
     }
     pub fn is_empty(&self) -> bool {

--- a/testing/groupby.test
+++ b/testing/groupby.test
@@ -185,3 +185,10 @@ William|111}
 do_execsql_test group_by_column_number {
   select u.first_name, count(1) from users u group by 1 limit 1;
 } {Aaron|41}
+
+# There was a regression where we incorrectly removed SOME order by terms and left others in place, which is invalid and results in wrong rows being returned.
+do_execsql_test groupby_orderby_removal_regression_test {
+  select id, last_name, count(1) from users GROUP BY 1,2 order by id, last_name desc limit 3;
+} {1|Foster|1
+2|Salazar|1
+3|Perry|1}


### PR DESCRIPTION
we had an incorrect optimization in `eliminate_orderby_like_groupby()` where it could remove e.g. the first term of the ORDER BY if it matched the first GROUP BY term and the result set was naturally ordered by that term. this is invalid. see e.g.:

```sql
main branch - BAD: removes the `ORDER BY id` term because the results are naturally ordered by id.
However, this results in sorting the entire thing by last name only!

limbo> select id, last_name, count(1) from users GROUP BY 1,2 order by id, last_name desc limit 3;
┌──────┬───────────┬───────────┐
│ id   │ last_name │ count (1) │
├──────┼───────────┼───────────┤
│ 6235 │ Zuniga    │         1 │
├──────┼───────────┼───────────┤
│ 8043 │ Zuniga    │         1 │
├──────┼───────────┼───────────┤
│  944 │ Zimmerman │         1 │
└──────┴───────────┴───────────┘

after fix - GOOD:

limbo> select id, last_name, count(1) from users GROUP BY 1,2 order by id, last_name desc limit 3;
┌────┬───────────┬───────────┐
│ id │ last_name │ count (1) │
├────┼───────────┼───────────┤
│  1 │ Foster    │         1 │
├────┼───────────┼───────────┤
│  2 │ Salazar   │         1 │
├────┼───────────┼───────────┤
│  3 │ Perry     │         1 │
└────┴───────────┴───────────┘


I also refactored sorters to always use the ast `SortOrder` instead of boolean vectors, and use the `compare_immutable()` utility we use inside btrees too.
