### PR TITLE
xConnect for virtual tables to query core db connection

### DIFF
--- a/core/ext/dynamic.rs
+++ b/core/ext/dynamic.rs
@@ -100,9 +100,11 @@ pub fn add_builtin_vfs_extensions(
     let mut api = match api {
         None => ExtensionApi {
             ctx: std::ptr::null_mut(),
+            conn: std::ptr::null_mut(),
             register_scalar_function,
             register_aggregate_function,
             register_vtab_module,
+            connect: super::vtab_connect::connect,
             vfs_interface: VfsInterface {
                 register_vfs,
                 builtin_vfs: vfslist.as_mut_ptr(),

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "fs")]
 mod dynamic;
+mod vtab_connect;
 #[cfg(all(target_os = "linux", feature = "io_uring"))]
 use crate::UringIO;
 use crate::{function::ExternalFunc, Connection, Database, LimboError, IO};
@@ -155,9 +156,11 @@ impl Connection {
     pub fn build_limbo_ext(&self) -> ExtensionApi {
         ExtensionApi {
             ctx: self as *const _ as *mut c_void,
+            conn: std::ptr::null_mut(),
             register_scalar_function,
             register_aggregate_function,
             register_vtab_module,
+            connect: vtab_connect::connect,
             #[cfg(feature = "fs")]
             vfs_interface: limbo_ext::VfsInterface {
                 register_vfs: dynamic::register_vfs,

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -153,9 +153,10 @@ impl Connection {
         ResultCode::OK
     }
 
-    pub fn build_limbo_ext(&self) -> ExtensionApi {
+    pub fn build_limbo_ext(self: &Rc<Connection>) -> ExtensionApi {
+        let cloned = self.clone();
         ExtensionApi {
-            ctx: self as *const _ as *mut c_void,
+            ctx: Rc::into_raw(cloned) as *const _ as *mut c_void,
             conn: std::ptr::null_mut(),
             register_scalar_function,
             register_aggregate_function,
@@ -170,7 +171,7 @@ impl Connection {
         }
     }
 
-    pub fn register_builtins(&self) -> Result<(), String> {
+    pub fn register_builtins(self: &Rc<Connection>) -> Result<(), String> {
         #[allow(unused_variables)]
         let mut ext_api = self.build_limbo_ext();
         #[cfg(feature = "uuid")]

--- a/core/ext/vtab_connect.rs
+++ b/core/ext/vtab_connect.rs
@@ -5,21 +5,28 @@ use std::{
     ffi::{c_char, c_void, CStr, CString},
     num::NonZeroUsize,
     ptr,
-    rc::Rc,
+    rc::{Rc, Weak},
 };
 
 pub unsafe extern "C" fn connect(ctx: *mut c_void) -> *mut ExtConn {
     if ctx.is_null() {
         return ptr::null_mut();
     }
-    Rc::increment_strong_count(ctx as *const Connection);
-    let ext_conn = ExtConn::new(ctx, prepare_stmt, close);
-    Box::into_raw(Box::new(ext_conn))
+    let rc_conn = Rc::from_raw(ctx as *const Connection); // temporarily own
+    let weak_box = Box::new(Rc::downgrade(&rc_conn)); // get weak reference
+    let weak_ptr = Box::into_raw(weak_box) as *mut c_void;
+    let _ = Rc::into_raw(rc_conn); // restore original count / return ownership
+    Box::into_raw(Box::new(ExtConn::new(weak_ptr, prepare_stmt, close)))
 }
 
 pub unsafe extern "C" fn close(ctx: *mut c_void) {
-    let conn = Rc::from_raw(ctx as *const Connection);
-    let _ = conn.close();
+    if ctx.is_null() {
+        return;
+    }
+    let weak_box: Box<Weak<Connection>> = Box::from_raw(ctx as *mut Weak<Connection>);
+    if let Some(conn) = weak_box.upgrade() {
+        let _ = conn.close();
+    }
 }
 
 pub unsafe extern "C" fn prepare_stmt(ctx: *mut ExtConn, sql: *const c_char) -> *const Stmt {
@@ -34,14 +41,17 @@ pub unsafe extern "C" fn prepare_stmt(ctx: *mut ExtConn, sql: *const c_char) -> 
     let Ok(extcon) = ExtConn::from_ptr(ctx) else {
         return ptr::null_mut();
     };
-    Rc::increment_strong_count(extcon._ctx as *const Connection);
-    let conn: Rc<Connection> = Rc::from_raw(extcon._ctx as *const Connection);
+    let weak_ptr = extcon._ctx as *const Weak<Connection>;
+    let weak = &*weak_ptr;
+    let Some(conn) = weak.upgrade() else {
+        return ptr::null_mut();
+    };
     match conn.prepare(&sql_str) {
         Ok(stmt) => {
-            let stmt = Box::new(stmt);
+            let raw_stmt = Box::into_raw(Box::new(stmt)) as *mut c_void;
             Box::into_raw(Box::new(Stmt::new(
-                Rc::into_raw(conn.clone()) as *mut c_void,
-                Box::into_raw(stmt) as *mut c_void,
+                extcon._ctx,
+                raw_stmt,
                 stmt_bind_args_fn,
                 stmt_step,
                 stmt_get_row,
@@ -82,21 +92,19 @@ pub unsafe extern "C" fn stmt_step(stmt: *mut Stmt) -> ResultCode {
     }
     let conn: &Connection = unsafe { &*(stmt._conn as *const Connection) };
     let stmt_ctx: &mut Statement = unsafe { &mut *(stmt._ctx as *mut Statement) };
-    loop {
-        match stmt_ctx.step() {
-            Ok(StepResult::Row) => return ResultCode::Row,
-            Ok(StepResult::Done) => return ResultCode::EOF,
-            Ok(StepResult::IO) => {
+    while let Ok(res) = stmt_ctx.step() {
+        match res {
+            StepResult::Row => return ResultCode::Row,
+            StepResult::Done => return ResultCode::EOF,
+            StepResult::IO => {
                 let _ = conn.pager.io.run_once();
                 continue;
             }
-            Ok(StepResult::Interrupt) => return ResultCode::Interrupt,
-            Ok(StepResult::Busy) => return ResultCode::Busy,
-            _ => {
-                return ResultCode::Error;
-            }
+            StepResult::Interrupt => return ResultCode::Interrupt,
+            StepResult::Busy => return ResultCode::Busy,
         }
     }
+    ResultCode::Error
 }
 
 pub unsafe extern "C" fn stmt_get_row(ctx: *mut Stmt) {
@@ -169,6 +177,9 @@ pub unsafe extern "C" fn stmt_close(ctx: *mut Stmt) {
         stmt.free_current_row();
     }
     // take ownership of internal statement
-    let mut stmt: Box<Statement> = Box::from_raw(stmt._ctx as *mut Statement);
-    stmt.reset()
+    let wrapper = Box::from_raw(stmt as *mut Stmt);
+    if !wrapper._ctx.is_null() {
+        let mut _stmt: Box<Statement> = Box::from_raw(wrapper._ctx as *mut Statement);
+        _stmt.reset()
+    }
 }

--- a/core/ext/vtab_connect.rs
+++ b/core/ext/vtab_connect.rs
@@ -109,12 +109,12 @@ pub unsafe extern "C" fn stmt_get_row(ctx: *mut Stmt) {
     let stmt_ctx: &mut Statement = unsafe { &mut *(stmt._ctx as *mut Statement) };
     if let Some(row) = stmt_ctx.row() {
         let values = row.get_values();
-        let mut owned_values = Vec::with_capacity(values.len());
+        let mut owned_values = Vec::with_capacity(row.len());
         for value in values {
             owned_values.push(OwnedValue::to_ffi(value));
         }
         stmt.current_row = Box::into_raw(owned_values.into_boxed_slice()) as *mut Value;
-        stmt.current_row_len = values.len() as i32;
+        stmt.current_row_len = row.len() as i32;
     } else {
         stmt.current_row_len = 0;
     }

--- a/core/ext/vtab_connect.rs
+++ b/core/ext/vtab_connect.rs
@@ -1,0 +1,174 @@
+use crate::{types::OwnedValue, Connection, Statement, StepResult};
+use limbo_ext::{Conn as ExtConn, ResultCode, Stmt, Value};
+use std::{
+    boxed::Box,
+    ffi::{c_char, c_void, CStr, CString},
+    num::NonZeroUsize,
+    ptr,
+    rc::Rc,
+};
+
+pub unsafe extern "C" fn connect(ctx: *mut c_void) -> *mut ExtConn {
+    if ctx.is_null() {
+        return ptr::null_mut();
+    }
+    Rc::increment_strong_count(ctx as *const Connection);
+    let ext_conn = ExtConn::new(ctx, prepare_stmt, close);
+    Box::into_raw(Box::new(ext_conn))
+}
+
+pub unsafe extern "C" fn close(ctx: *mut c_void) {
+    let conn = Rc::from_raw(ctx as *const Connection);
+    let _ = conn.close();
+}
+
+pub unsafe extern "C" fn prepare_stmt(ctx: *mut ExtConn, sql: *const c_char) -> *const Stmt {
+    let c_str = unsafe { CStr::from_ptr(sql as *mut c_char) };
+    let sql_str = match c_str.to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return ptr::null_mut(),
+    };
+    if ctx.is_null() {
+        return ptr::null_mut();
+    }
+    let Ok(extcon) = ExtConn::from_ptr(ctx) else {
+        return ptr::null_mut();
+    };
+    Rc::increment_strong_count(extcon._ctx as *const Connection);
+    let conn: Rc<Connection> = Rc::from_raw(extcon._ctx as *const Connection);
+    match conn.prepare(&sql_str) {
+        Ok(stmt) => {
+            let stmt = Box::new(stmt);
+            Box::into_raw(Box::new(Stmt::new(
+                Rc::into_raw(conn.clone()) as *mut c_void,
+                Box::into_raw(stmt) as *mut c_void,
+                stmt_bind_args_fn,
+                stmt_step,
+                stmt_get_row,
+                stmt_get_column_names,
+                stmt_free_current_row,
+                stmt_close,
+            ))) as *const Stmt
+        }
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+pub unsafe extern "C" fn stmt_bind_args_fn(
+    ctx: *mut Stmt,
+    idx: i32,
+    arg: *const Value,
+) -> ResultCode {
+    let Ok(stmt) = Stmt::from_ptr(ctx) else {
+        return ResultCode::Error;
+    };
+    let stmt_ctx: &mut Statement = unsafe { &mut *(stmt._ctx as *mut Statement) };
+    let Ok(owned_val) = OwnedValue::from_ffi_ptr(arg) else {
+        return ResultCode::Error;
+    };
+    let Some(idx) = NonZeroUsize::new(idx as usize) else {
+        return ResultCode::Error;
+    };
+    stmt_ctx.bind_at(idx, owned_val);
+    ResultCode::OK
+}
+
+pub unsafe extern "C" fn stmt_step(stmt: *mut Stmt) -> ResultCode {
+    let Ok(stmt) = Stmt::from_ptr(stmt) else {
+        return ResultCode::Error;
+    };
+    if stmt._conn.is_null() || stmt._ctx.is_null() {
+        return ResultCode::Error;
+    }
+    let conn: &Connection = unsafe { &*(stmt._conn as *const Connection) };
+    let stmt_ctx: &mut Statement = unsafe { &mut *(stmt._ctx as *mut Statement) };
+    loop {
+        match stmt_ctx.step() {
+            Ok(StepResult::Row) => return ResultCode::Row,
+            Ok(StepResult::Done) => return ResultCode::EOF,
+            Ok(StepResult::IO) => {
+                let _ = conn.pager.io.run_once();
+                continue;
+            }
+            Ok(StepResult::Interrupt) => return ResultCode::Interrupt,
+            Ok(StepResult::Busy) => return ResultCode::Busy,
+            _ => {
+                return ResultCode::Error;
+            }
+        }
+    }
+}
+
+pub unsafe extern "C" fn stmt_get_row(ctx: *mut Stmt) {
+    let Ok(stmt) = Stmt::from_ptr(ctx) else {
+        return;
+    };
+    if !stmt.current_row.is_null() {
+        stmt.free_current_row();
+    }
+    let stmt_ctx: &mut Statement = unsafe { &mut *(stmt._ctx as *mut Statement) };
+    if let Some(row) = stmt_ctx.row() {
+        let values = row.get_values();
+        let mut owned_values = Vec::with_capacity(values.len());
+        for value in values {
+            owned_values.push(OwnedValue::to_ffi(value));
+        }
+        stmt.current_row = Box::into_raw(owned_values.into_boxed_slice()) as *mut Value;
+        stmt.current_row_len = values.len() as i32;
+    } else {
+        stmt.current_row_len = 0;
+    }
+}
+
+pub unsafe extern "C" fn stmt_free_current_row(ctx: *mut Stmt) {
+    let Ok(stmt) = Stmt::from_ptr(ctx) else {
+        return;
+    };
+    if !stmt.current_row.is_null() {
+        let values: &mut [Value] =
+            std::slice::from_raw_parts_mut(stmt.current_row, stmt.current_row_len as usize);
+        for value in values.iter_mut() {
+            let owned_value = std::mem::take(value);
+            owned_value.__free_internal_type();
+        }
+        let _ = Box::from_raw(stmt.current_row);
+    }
+}
+
+pub unsafe extern "C" fn stmt_get_column_names(
+    ctx: *mut Stmt,
+    count: *mut i32,
+) -> *mut *mut c_char {
+    let Ok(stmt) = Stmt::from_ptr(ctx) else {
+        *count = 0;
+        return ptr::null_mut();
+    };
+    let stmt_ctx: &mut Statement = unsafe { &mut *(stmt._ctx as *mut Statement) };
+    let num_cols = stmt_ctx.num_columns();
+    if num_cols == 0 {
+        *count = 0;
+        return ptr::null_mut();
+    }
+    let mut c_names: Vec<*mut c_char> = Vec::with_capacity(num_cols);
+    for i in 0..num_cols {
+        let name = stmt_ctx.get_column_name(i);
+        let c_str = CString::new(name.as_bytes()).unwrap();
+        c_names.push(c_str.into_raw());
+    }
+
+    *count = c_names.len() as i32;
+    let names_array = c_names.into_boxed_slice();
+    Box::into_raw(names_array) as *mut *mut c_char
+}
+
+pub unsafe extern "C" fn stmt_close(ctx: *mut Stmt) {
+    let Ok(stmt) = Stmt::from_ptr(ctx) else {
+        return;
+    };
+    if !stmt.current_row.is_null() {
+        stmt.free_current_row();
+    }
+    // take ownership of internal statement
+    let mut stmt: Box<Statement> = Box::from_raw(stmt._ctx as *mut Statement);
+    stmt.reset()
+}

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -701,7 +701,14 @@ impl VirtualTable {
     }
 
     pub fn open(&self) -> crate::Result<VTabOpaqueCursor> {
-        let cursor = unsafe { (self.implementation.open)(self.implementation.ctx) };
+        let cursor = unsafe {
+            (self.implementation.open)(self.implementation.ctx, self.implementation.conn)
+        };
+        if cursor.is_null() {
+            return Err(LimboError::ExtensionError(
+                "Failed to open virtual table cursor".to_string(),
+            ));
+        }
         VTabOpaqueCursor::new(cursor)
     }
 

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -319,6 +319,9 @@ pub fn open_loop(
                         // For each constraint used by best_index, translate the opposite side.
                         for (i, usage) in index_info.constraint_usages.iter().enumerate() {
                             if let Some(argv_index) = usage.argv_index {
+                                if argv_index == 0 {
+                                    continue;
+                                }
                                 if let Some(cinfo) = converted_constraints.get(i) {
                                     let (pred_idx, is_rhs) = cinfo.unpack_plan_info();
                                     if let ast::Expr::Binary(lhs, _, rhs) =

--- a/core/types.rs
+++ b/core/types.rs
@@ -385,6 +385,56 @@ impl OwnedValue {
         unsafe { v.__free_internal_type() };
         res
     }
+
+    /// creates a new OwnedValue without owning the underlying ffi value
+    /// # Safety
+    /// This derefs a raw ptr after a null check, the caller still owns the ffi value
+    pub unsafe fn from_ffi_ptr(v: *const ExtValue) -> Result<Self> {
+        if v.is_null() {
+            return Err(LimboError::ExtensionError("Value is null".into()));
+        }
+        let v = unsafe { &*v };
+        match v.value_type() {
+            ExtValueType::Null => Ok(OwnedValue::Null),
+            ExtValueType::Integer => {
+                let Some(int) = v.to_integer() else {
+                    return Ok(OwnedValue::Null);
+                };
+                Ok(OwnedValue::Integer(int))
+            }
+            ExtValueType::Float => {
+                let Some(float) = v.to_float() else {
+                    return Ok(OwnedValue::Null);
+                };
+                Ok(OwnedValue::Float(float))
+            }
+            ExtValueType::Text => {
+                let Some(text) = v.to_text() else {
+                    return Ok(OwnedValue::Null);
+                };
+                if v.is_json() {
+                    Ok(OwnedValue::Text(Text::json(text.to_string())))
+                } else {
+                    Ok(OwnedValue::build_text(text))
+                }
+            }
+            ExtValueType::Blob => {
+                let Some(blob) = v.to_blob() else {
+                    return Ok(OwnedValue::Null);
+                };
+                Ok(OwnedValue::Blob(blob))
+            }
+            ExtValueType::Error => {
+                let Some(err) = v.to_error_details() else {
+                    return Ok(OwnedValue::Null);
+                };
+                match err {
+                    (_, Some(msg)) => Err(LimboError::ExtensionError(msg)),
+                    (code, None) => Err(LimboError::ExtensionError(code.to_string())),
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/extensions/completion/src/lib.rs
+++ b/extensions/completion/src/lib.rs
@@ -3,8 +3,12 @@
 
 mod keywords;
 
+use std::rc::Rc;
+
 use keywords::KEYWORDS;
-use limbo_ext::{register_extension, ResultCode, VTabCursor, VTabModule, VTabModuleDerive, Value};
+use limbo_ext::{
+    register_extension, Connection, ResultCode, VTabCursor, VTabModule, VTabModuleDerive, Value,
+};
 
 register_extension! {
     vtabs: { CompletionVTab }
@@ -75,7 +79,7 @@ impl VTabModule for CompletionVTab {
         .to_string()
     }
 
-    fn open(&self) -> Result<Self::VCursor, Self::Error> {
+    fn open(&self, _conn: Option<Rc<Connection>>) -> Result<Self::VCursor, Self::Error> {
         Ok(CompletionCursor::default())
     }
 

--- a/extensions/core/README.md
+++ b/extensions/core/README.md
@@ -190,8 +190,9 @@ impl VTabModule for CsvVTable {
         )"
     }
 
-    /// Open to return a new cursor: In this simple example, the CSV file is read completely into memory on connect.
-    fn open(&self) -> Result<Self::VCursor, Self::Error> {
+    /// You have the option of storing a connection to the database that opened the module, and you can query
+    /// tables accessible by the underlying connection.
+    fn open(&self, conn: Option<Rc<Connection>>) -> Result<Self::VCursor, Self::Error> {
         // Read CSV file contents from "data.csv"
         let csv_content = fs::read_to_string("data.csv").unwrap_or_default();
         // For simplicity, we'll ignore the header row.
@@ -204,11 +205,21 @@ impl VTabModule for CsvVTable {
                     .collect()
             })
             .collect();
-        Ok(CsvCursor { rows, index: 0 })
+        Ok(CsvCursor { rows, index: 0, conn })
     }
 
     /// Filter through result columns. (not used in this simple example)
-    fn filter(_cursor: &mut Self::VCursor, _args: &[Value]) -> ResultCode {
+    fn filter(cursor: &mut Self::VCursor, _args: &[Value]) -> ResultCode {
+        /// Prepare statement:
+        let stmt = cursor.conn.prepare("SELECT a, b, c from some_table;");
+
+        /// Iterate over rows:
+        while let StepResult::Row = stmt.step() {
+            let row = stmt.get_row();
+            if let Some(a) = row.first() {
+                // do something with column 'a'
+            }
+        }
         ResultCode::OK
     }
 
@@ -254,6 +265,7 @@ impl VTabModule for CsvVTable {
 struct CsvCursor {
     rows: Vec<Vec<String>>,
     index: usize,
+    conn: Rc<Connection>,
 }
 
 /// Implement the VTabCursor trait for your cursor type

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -11,7 +11,7 @@ use functions::{RegisterAggFn, RegisterScalarFn};
 pub use limbo_macros::VfsDerive;
 pub use limbo_macros::{register_extension, scalar, AggregateDerive, VTabModuleDerive};
 use std::os::raw::c_void;
-pub use types::{ResultCode, Value, ValueType};
+pub use types::{ResultCode, StepResult, Value, ValueType};
 #[cfg(feature = "vfs")]
 pub use vfs_modules::{RegisterVfsFn, VfsExtension, VfsFile, VfsFileImpl, VfsImpl, VfsInterface};
 pub use vtabs::{

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -14,11 +14,11 @@ use std::os::raw::c_void;
 pub use types::{ResultCode, Value, ValueType};
 #[cfg(feature = "vfs")]
 pub use vfs_modules::{RegisterVfsFn, VfsExtension, VfsFile, VfsFileImpl, VfsImpl, VfsInterface};
-use vtabs::RegisterModuleFn;
 pub use vtabs::{
-    ConstraintInfo, ConstraintOp, ConstraintUsage, ExtIndexInfo, IndexInfo, OrderByInfo,
-    VTabCursor, VTabKind, VTabModule, VTabModuleImpl,
+    Conn, Connection, ConstraintInfo, ConstraintOp, ConstraintUsage, ExtIndexInfo, IndexInfo,
+    OrderByInfo, Stmt, VTabCursor, VTabKind, VTabModule, VTabModuleImpl,
 };
+use vtabs::{ConnectFn, RegisterModuleFn};
 
 pub type ExtResult<T> = std::result::Result<T, ResultCode>;
 
@@ -27,9 +27,11 @@ pub type ExtensionEntryPoint = unsafe extern "C" fn(api: *const ExtensionApi) ->
 #[repr(C)]
 pub struct ExtensionApi {
     pub ctx: *mut c_void,
+    pub conn: *mut Conn,
     pub register_scalar_function: RegisterScalarFn,
     pub register_aggregate_function: RegisterAggFn,
     pub register_vtab_module: RegisterModuleFn,
+    pub connect: ConnectFn,
     #[cfg(feature = "vfs")]
     pub vfs_interface: VfsInterface,
 }

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -16,7 +16,7 @@ pub use types::{ResultCode, StepResult, Value, ValueType};
 pub use vfs_modules::{RegisterVfsFn, VfsExtension, VfsFile, VfsFileImpl, VfsImpl, VfsInterface};
 pub use vtabs::{
     Conn, Connection, ConstraintInfo, ConstraintOp, ConstraintUsage, ExtIndexInfo, IndexInfo,
-    OrderByInfo, Stmt, VTabCursor, VTabKind, VTabModule, VTabModuleImpl,
+    OrderByInfo, Statement, Stmt, VTabCursor, VTabKind, VTabModule, VTabModuleImpl,
 };
 use vtabs::{ConnectFn, RegisterModuleFn};
 

--- a/extensions/core/src/types.rs
+++ b/extensions/core/src/types.rs
@@ -23,6 +23,10 @@ pub enum ResultCode {
     EOF = 15,
     ReadOnly = 16,
     RowID = 17,
+    Interrupt = 18,
+    Busy = 19,
+    IO = 20,
+    Row = 21,
 }
 
 impl ResultCode {
@@ -60,6 +64,32 @@ impl Display for ResultCode {
             ResultCode::EOF => write!(f, "EOF"),
             ResultCode::ReadOnly => write!(f, "Read Only"),
             ResultCode::RowID => write!(f, "RowID"),
+            ResultCode::Interrupt => write!(f, "Interrupt"),
+            ResultCode::Busy => write!(f, "Busy"),
+            ResultCode::IO => write!(f, "IO"),
+            ResultCode::Row => write!(f, "Row"),
+        }
+    }
+}
+
+#[derive(Copy, Debug, Clone, PartialEq)]
+pub enum StepResult {
+    Error,
+    Row,
+    Done,
+    Interrupt,
+    Busy,
+}
+
+impl From<ResultCode> for StepResult {
+    fn from(code: ResultCode) -> Self {
+        match code {
+            ResultCode::Error => StepResult::Error,
+            ResultCode::Row => StepResult::Row,
+            ResultCode::EOF => StepResult::Done,
+            ResultCode::Interrupt => StepResult::Interrupt,
+            ResultCode::Busy => StepResult::Busy,
+            _ => StepResult::Error,
         }
     }
 }

--- a/extensions/core/src/types.rs
+++ b/extensions/core/src/types.rs
@@ -72,6 +72,12 @@ impl Display for ResultCode {
     }
 }
 
+impl Default for Value {
+    fn default() -> Self {
+        Self::null()
+    }
+}
+
 #[derive(Copy, Debug, Clone, PartialEq)]
 pub enum StepResult {
     Error,

--- a/extensions/core/src/vtabs.rs
+++ b/extensions/core/src/vtabs.rs
@@ -324,8 +324,9 @@ pub type CloseStmtFn = unsafe extern "C" fn(ctx: *mut Stmt);
 
 /// core database connection
 // public fields for core only
+#[repr(C)]
 pub struct Conn {
-    // Rc::into_raw from core::Connection
+    // Rc::Weak from core::Connection
     pub _ctx: *mut c_void,
     pub _prepare_stmt: PrepareStmtFn,
     pub _close: CloseConnectionFn,
@@ -352,7 +353,9 @@ impl Conn {
     }
 
     pub fn prepare_stmt(&self, sql: &str) -> *const Stmt {
-        let sql = CString::new(sql).unwrap();
+        let Ok(sql) = CString::new(sql) else {
+            return std::ptr::null();
+        };
         unsafe { (self._prepare_stmt)(self as *const Conn as *mut Conn, sql.as_ptr()) }
     }
 }
@@ -503,13 +506,7 @@ impl Stmt {
 
     /// Execute the statement to attempt to retrieve the next result row.
     fn step(&self) -> StepResult {
-        match unsafe { (self._step)(self.to_ptr() as *mut Stmt) } {
-            ResultCode::Row => StepResult::Row,
-            ResultCode::EOF => StepResult::Done,
-            ResultCode::Busy => StepResult::Busy,
-            ResultCode::Interrupt => StepResult::Interrupt,
-            _ => StepResult::Error,
-        }
+        unsafe { (self._step)(self.to_ptr() as *mut Stmt) }.into()
     }
 
     /// Free the memory for the values obtained from the `get_row` method.
@@ -517,10 +514,7 @@ impl Stmt {
     /// This fn is unsafe because it derefs a raw pointer after null and
     /// length checks. This fn should only be called with the pointer returned from get_row.
     pub unsafe fn free_current_row(&mut self) {
-        if self.current_row.is_null() {
-            return;
-        }
-        if self.current_row_len <= 0 {
+        if self.current_row.is_null() || self.current_row_len <= 0 {
             return;
         }
         // free from the core side so we don't have to expose `__free_internal_type`
@@ -533,10 +527,7 @@ impl Stmt {
     /// be called after the step() method returns `StepResult::Row`
     pub fn get_row(&self) -> &[Value] {
         unsafe { (self._get_row_values)(self.to_ptr() as *mut Stmt) };
-        if self.current_row.is_null() {
-            return &[];
-        }
-        if self.current_row_len < 1 {
+        if self.current_row.is_null() || self.current_row_len < 1 {
             return &[];
         }
         let col_count = self.current_row_len;

--- a/extensions/core/src/vtabs.rs
+++ b/extensions/core/src/vtabs.rs
@@ -1,5 +1,9 @@
-use crate::{ResultCode, Value};
-use std::ffi::{c_char, c_void};
+use crate::{types::StepResult, ExtResult, ResultCode, Value};
+use std::{
+    ffi::{c_char, c_void, CStr, CString},
+    num::NonZeroUsize,
+    rc::Rc,
+};
 
 pub type RegisterModuleFn = unsafe extern "C" fn(
     ctx: *mut c_void,
@@ -12,6 +16,7 @@ pub type RegisterModuleFn = unsafe extern "C" fn(
 #[derive(Clone, Debug)]
 pub struct VTabModuleImpl {
     pub ctx: *const c_void,
+    pub conn: *mut Conn,
     pub name: *const c_char,
     pub create_schema: VtabFnCreateSchema,
     pub open: VtabFnOpen,
@@ -42,7 +47,7 @@ impl VTabModuleImpl {
 
 pub type VtabFnCreateSchema = unsafe extern "C" fn(args: *const Value, argc: i32) -> *mut c_char;
 
-pub type VtabFnOpen = unsafe extern "C" fn(*const c_void) -> *const c_void;
+pub type VtabFnOpen = unsafe extern "C" fn(*const c_void, conn: *mut Conn) -> *const c_void;
 
 pub type VtabFnFilter = unsafe extern "C" fn(
     cursor: *const c_void,
@@ -89,7 +94,7 @@ pub trait VTabModule: 'static {
     type Error: std::fmt::Display;
 
     fn create_schema(args: &[Value]) -> String;
-    fn open(&self) -> Result<Self::VCursor, Self::Error>;
+    fn open(&self, conn: Option<Rc<Connection>>) -> Result<Self::VCursor, Self::Error>;
     fn filter(
         cursor: &mut Self::VCursor,
         args: &[Value],
@@ -303,4 +308,275 @@ impl ConstraintInfo {
     pub fn unpack_plan_info(&self) -> (usize, bool) {
         ((self.plan_info >> 1) as usize, (self.plan_info & 1) != 0)
     }
+}
+
+pub type ConnectFn = unsafe extern "C" fn(ctx: *mut c_void) -> *mut Conn;
+pub type PrepareStmtFn = unsafe extern "C" fn(api: *mut Conn, sql: *const c_char) -> *const Stmt;
+pub type GetColumnNamesFn =
+    unsafe extern "C" fn(ctx: *mut Stmt, count: *mut i32) -> *mut *mut c_char;
+pub type BindArgsFn =
+    unsafe extern "C" fn(ctx: *mut Stmt, idx: i32, arg: *const Value) -> ResultCode;
+pub type StmtStepFn = unsafe extern "C" fn(ctx: *mut Stmt) -> ResultCode;
+pub type StmtGetRowValuesFn = unsafe extern "C" fn(ctx: *mut Stmt);
+pub type FreeCurrentRowFn = unsafe extern "C" fn(ctx: *mut Stmt);
+pub type CloseConnectionFn = unsafe extern "C" fn(ctx: *mut c_void);
+pub type CloseStmtFn = unsafe extern "C" fn(ctx: *mut Stmt);
+
+/// core database connection
+// public fields for core only
+pub struct Conn {
+    // Rc::into_raw from core::Connection
+    pub _ctx: *mut c_void,
+    pub _prepare_stmt: PrepareStmtFn,
+    pub _close: CloseConnectionFn,
+}
+
+impl Conn {
+    pub fn new(ctx: *mut c_void, prepare_stmt: PrepareStmtFn, close: CloseConnectionFn) -> Self {
+        Conn {
+            _ctx: ctx,
+            _prepare_stmt: prepare_stmt,
+            _close: close,
+        }
+    }
+    /// # Safety
+    pub unsafe fn from_ptr(ptr: *mut Conn) -> crate::ExtResult<&'static mut Self> {
+        if ptr.is_null() {
+            return Err(ResultCode::Error);
+        }
+        Ok(unsafe { &mut *(ptr) })
+    }
+
+    pub fn close(&self) {
+        unsafe { (self._close)(self._ctx) };
+    }
+
+    pub fn prepare_stmt(&self, sql: &str) -> *const Stmt {
+        let sql = CString::new(sql).unwrap();
+        unsafe { (self._prepare_stmt)(self as *const Conn as *mut Conn, sql.as_ptr()) }
+    }
+}
+
+/// Prepared statement for querying a core database connection
+/// public API with wrapper methods for extensions
+#[derive(Debug)]
+pub struct Statement {
+    _ctx: *const Stmt,
+}
+
+/// The Database connection that opened the vtab:
+/// Public API to expose methods for extensions
+#[derive(Debug)]
+pub struct Connection {
+    _ctx: *const Conn,
+}
+
+impl Connection {
+    pub fn new(ctx: *const Conn) -> Self {
+        Connection { _ctx: ctx }
+    }
+
+    /// From the included SQL string, prepare a statement for execution.
+    pub fn prepare(self: &Rc<Self>, sql: &str) -> ExtResult<Statement> {
+        let stmt = unsafe { (*self._ctx).prepare_stmt(sql) };
+        if stmt.is_null() {
+            return Err(ResultCode::Error);
+        }
+        Ok(Statement { _ctx: stmt })
+    }
+
+    /// Close the connection to the database.
+    pub fn close(self) {
+        unsafe { ((*self._ctx)._close)(self._ctx as *mut c_void) };
+    }
+}
+
+impl Statement {
+    /// Bind a value to a parameter in the prepared statement
+    ///```ignore
+    /// let stmt = conn.prepare_stmt("select * from users where name = ?");
+    /// stmt.bind(1, Value::from_text("test".into()));
+    pub fn bind(&self, idx: NonZeroUsize, arg: &Value) {
+        let arg = arg as *const Value;
+        unsafe { (*self._ctx).bind_args(idx, arg) }
+    }
+
+    /// Execute the statement and return the next row
+    ///```ignore
+    /// while stmt.step() == StepResult::Row {
+    ///     let row = stmt.get_row();
+    ///     println!("row: {:?}", row);
+    /// }
+    /// ```
+    pub fn step(&self) -> StepResult {
+        unsafe { (*self._ctx).step() }
+    }
+
+    // Get the current row values
+    ///```ignore
+    /// while stmt.step() == StepResult::Row {
+    ///    let row = stmt.get_row();
+    ///    println!("row: {:?}", row);
+    ///```
+    pub fn get_row(&mut self) -> &[Value] {
+        unsafe { (*self._ctx).get_row() }
+    }
+
+    /// Get the result column names for the prepared statement
+    pub fn get_column_names(&self) -> Vec<String> {
+        unsafe { (*self._ctx).get_column_names() }
+    }
+
+    /// Close the statement
+    pub fn close(&self) {
+        unsafe { (*self._ctx).close() }
+    }
+}
+
+/// Internal/core use _only_
+/// Extensions should not import or use this type directly
+#[repr(C)]
+pub struct Stmt {
+    // Rc::into_raw from core::Connection
+    pub _conn: *mut c_void,
+    // Rc::into_raw from core::Statement
+    pub _ctx: *mut c_void,
+    pub _bind_args_fn: BindArgsFn,
+    pub _step: StmtStepFn,
+    pub _get_row_values: StmtGetRowValuesFn,
+    pub _get_column_names: GetColumnNamesFn,
+    pub _free_current_row: FreeCurrentRowFn,
+    pub _close: CloseStmtFn,
+    pub current_row: *mut Value,
+    pub current_row_len: i32,
+}
+
+impl Stmt {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        conn: *mut c_void,
+        ctx: *mut c_void,
+        bind: BindArgsFn,
+        step: StmtStepFn,
+        rows: StmtGetRowValuesFn,
+        names: GetColumnNamesFn,
+        free_row: FreeCurrentRowFn,
+        close: CloseStmtFn,
+    ) -> Self {
+        Stmt {
+            _conn: conn,
+            _ctx: ctx,
+            _bind_args_fn: bind,
+            _step: step,
+            _get_row_values: rows,
+            _get_column_names: names,
+            _free_current_row: free_row,
+            _close: close,
+            current_row: std::ptr::null_mut(),
+            current_row_len: -1,
+        }
+    }
+
+    /// Close the statement
+    pub fn close(&self) {
+        unsafe { (self._close)(self as *const Stmt as *mut Stmt) };
+    }
+
+    /// # Safety
+    /// Derefs a null ptr, does a null check first
+    pub unsafe fn from_ptr(ptr: *mut Stmt) -> ExtResult<&'static mut Self> {
+        if ptr.is_null() {
+            return Err(ResultCode::Error);
+        }
+        Ok(unsafe { &mut *(ptr) })
+    }
+
+    /// Returns the pointer to the statement.
+    pub fn to_ptr(&self) -> *const Stmt {
+        self
+    }
+
+    /// Bind a value to a parameter in the prepared statement
+    fn bind_args(&self, idx: NonZeroUsize, arg: *const Value) {
+        unsafe { (self._bind_args_fn)(self.to_ptr() as *mut Stmt, idx.get() as i32, arg) };
+    }
+
+    /// Execute the statement to attempt to retrieve the next result row.
+    fn step(&self) -> StepResult {
+        match unsafe { (self._step)(self.to_ptr() as *mut Stmt) } {
+            ResultCode::Row => StepResult::Row,
+            ResultCode::EOF => StepResult::Done,
+            ResultCode::Busy => StepResult::Busy,
+            ResultCode::Interrupt => StepResult::Interrupt,
+            _ => StepResult::Error,
+        }
+    }
+
+    /// Free the memory for the values obtained from the `get_row` method.
+    /// # Safety
+    /// This fn is unsafe because it derefs a raw pointer after null and
+    /// length checks. This fn should only be called with the pointer returned from get_row.
+    pub unsafe fn free_current_row(&mut self) {
+        if self.current_row.is_null() {
+            return;
+        }
+        if self.current_row_len <= 0 {
+            return;
+        }
+        // free from the core side so we don't have to expose `__free_internal_type`
+        (self._free_current_row)(self.to_ptr() as *mut Stmt);
+        self.current_row = std::ptr::null_mut();
+        self.current_row_len = -1;
+    }
+
+    /// Returns the values from the current row in the prepared statement, should
+    /// be called after the step() method returns `StepResult::Row`
+    pub fn get_row(&self) -> &[Value] {
+        unsafe { (self._get_row_values)(self.to_ptr() as *mut Stmt) };
+        if self.current_row.is_null() {
+            return &[];
+        }
+        if self.current_row_len < 1 {
+            return &[];
+        }
+        let col_count = self.current_row_len;
+        unsafe { std::slice::from_raw_parts(self.current_row, col_count as usize) }
+    }
+
+    /// Returns the names of the result columns for the prepared statement.
+    pub fn get_column_names(&self) -> Vec<String> {
+        let mut count_value: i32 = 0;
+        let count: *mut i32 = &mut count_value;
+        let col_names = unsafe { (self._get_column_names)(self.to_ptr() as *mut Stmt, count) };
+        if col_names.is_null() || count_value == 0 {
+            return Vec::new();
+        }
+        let mut names = Vec::new();
+        let slice = unsafe { std::slice::from_raw_parts(col_names, count_value as usize) };
+        for x in slice {
+            let name = unsafe { CStr::from_ptr(*x) };
+            names.push(name.to_str().unwrap().to_string());
+        }
+        unsafe { free_column_names(col_names, count_value) };
+        names
+    }
+}
+
+/// Free the column names returned from get_column_names
+/// # Safety
+/// This function is unsafe because it derefs a raw pointer, this fn
+/// should only be called with the pointer returned from get_column_names
+/// only when they will no longer be used.
+pub unsafe fn free_column_names(names: *mut *mut c_char, count: i32) {
+    if names.is_null() || count < 1 {
+        return;
+    }
+    let slice = std::slice::from_raw_parts_mut(names, count as usize);
+
+    for name in slice {
+        if !name.is_null() {
+            let _ = CString::from_raw(*name);
+        }
+    }
+    let _ = Box::from_raw(names);
 }

--- a/extensions/series/src/lib.rs
+++ b/extensions/series/src/lib.rs
@@ -1,5 +1,8 @@
+use std::rc::Rc;
+
 use limbo_ext::{
-    register_extension, ResultCode, VTabCursor, VTabKind, VTabModule, VTabModuleDerive, Value,
+    register_extension, Connection, ResultCode, VTabCursor, VTabKind, VTabModule, VTabModuleDerive,
+    Value,
 };
 
 register_extension! {
@@ -36,7 +39,7 @@ impl VTabModule for GenerateSeriesVTab {
         .into()
     }
 
-    fn open(&self) -> Result<Self::VCursor, Self::Error> {
+    fn open(&self, _con: Option<Rc<Connection>>) -> Result<Self::VCursor, Self::Error> {
         Ok(GenerateSeriesCursor {
             start: 0,
             stop: 0,

--- a/extensions/series/src/lib.rs
+++ b/extensions/series/src/lib.rs
@@ -233,7 +233,7 @@ mod tests {
     // Helper function to collect all values from a cursor, returns Result with error code
     fn collect_series(series: Series) -> Result<Vec<i64>, ResultCode> {
         let tbl = GenerateSeriesVTab;
-        let mut cursor = tbl.open()?;
+        let mut cursor = tbl.open(None)?;
 
         // Create args array for filter
         let args = vec![
@@ -550,7 +550,7 @@ mod tests {
         let stop = series.stop;
         let step = series.step;
         let tbl = GenerateSeriesVTab {};
-        let mut cursor = tbl.open().unwrap();
+        let mut cursor = tbl.open(None).unwrap();
 
         let args = vec![
             Value::from_integer(start),

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -1,13 +1,15 @@
 use lazy_static::lazy_static;
 use limbo_ext::{
-    register_extension, scalar, ConstraintInfo, ConstraintOp, ConstraintUsage, ExtResult,
-    IndexInfo, OrderByInfo, ResultCode, VTabCursor, VTabKind, VTabModule, VTabModuleDerive, Value,
+    register_extension, scalar, Connection, ConstraintInfo, ConstraintOp, ConstraintUsage,
+    ExtResult, IndexInfo, OrderByInfo, ResultCode, VTabCursor, VTabKind, VTabModule,
+    VTabModuleDerive, Value,
 };
 #[cfg(not(target_family = "wasm"))]
 use limbo_ext::{VfsDerive, VfsExtension, VfsFile};
 use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::rc::Rc;
 use std::sync::Mutex;
 
 register_extension! {
@@ -39,7 +41,7 @@ impl VTabModule for KVStoreVTab {
         "CREATE TABLE x (key TEXT PRIMARY KEY, value TEXT);".to_string()
     }
 
-    fn open(&self) -> Result<Self::VCursor, Self::Error> {
+    fn open(&self, _conn: Option<Rc<Connection>>) -> Result<Self::VCursor, Self::Error> {
         let _ = env_logger::try_init();
         Ok(KVStoreCursor {
             rows: Vec::new(),

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use limbo_ext::{
     register_extension, scalar, Connection, ConstraintInfo, ConstraintOp, ConstraintUsage,
-    ExtResult, IndexInfo, OrderByInfo, ResultCode, VTabCursor, VTabKind, VTabModule,
+    ExtResult, IndexInfo, OrderByInfo, ResultCode, StepResult, VTabCursor, VTabKind, VTabModule,
     VTabModuleDerive, Value,
 };
 #[cfg(not(target_family = "wasm"))]
@@ -13,7 +13,7 @@ use std::rc::Rc;
 use std::sync::Mutex;
 
 register_extension! {
-    vtabs: { KVStoreVTab },
+    vtabs: { KVStoreVTab, TableStats },
     scalars: { test_scalar },
     vfs: { TestFS },
 }
@@ -302,5 +302,121 @@ impl VfsFile for TestFile {
 
     fn size(&self) -> i64 {
         self.file.metadata().map(|m| m.len() as i64).unwrap_or(-1)
+    }
+}
+
+#[derive(VTabModuleDerive, Default)]
+pub struct TableStats;
+
+pub struct StatsCursor {
+    pos: usize,
+    rows: Vec<(String, i64)>,
+    conn: Option<Rc<Connection>>,
+}
+
+/// implement the module
+impl VTabModule for TableStats {
+    type VCursor = StatsCursor;
+    const VTAB_KIND: VTabKind = VTabKind::VirtualTable;
+    const NAME: &'static str = "tablestats";
+    type Error = String;
+
+    fn create_schema(_args: &[Value]) -> String {
+        // Two columns, no hidden columns; rowid provided implicitly.
+        "CREATE TABLE x(name TEXT, rows INT);".to_string()
+    }
+
+    fn open(&self, conn: Option<Rc<Connection>>) -> Result<Self::VCursor, Self::Error> {
+        Ok(StatsCursor {
+            pos: 0,
+            rows: Vec::new(),
+            conn,
+        })
+    }
+
+    fn filter(
+        cursor: &mut Self::VCursor,
+        _args: &[Value],
+        _idx_info: Option<(&str, i32)>,
+    ) -> ResultCode {
+        cursor.rows.clear();
+        cursor.pos = 0;
+
+        let Some(conn) = &cursor.conn else {
+            return ResultCode::Error;
+        };
+
+        // discover application tables
+        let mut master = conn
+            .prepare(
+                "SELECT name FROM sqlite_schema \
+                      WHERE type = 'table' AND name NOT LIKE 'sqlite_%';",
+            )
+            .map_err(|_| ResultCode::Error)
+            .unwrap();
+
+        while master.step() == StepResult::Row {
+            let tbl_name = master.get_row()[0]
+                .to_text()
+                .unwrap_or("<invalid>")
+                .to_string();
+
+            // count rows for each table; ignore errors to keep demo simple
+            if let Ok(mut count_stmt) =
+                conn.prepare(&format!("SELECT COUNT(*) FROM \"{}\";", tbl_name))
+            {
+                let count = match count_stmt.step() {
+                    StepResult::Row => count_stmt.get_row()[0].to_integer().unwrap_or(0),
+                    _ => 0,
+                };
+                cursor.rows.push((tbl_name, count));
+            }
+        }
+        ResultCode::OK
+    }
+
+    fn column(cursor: &Self::VCursor, idx: u32) -> Result<Value, Self::Error> {
+        cursor
+            .rows
+            .get(cursor.pos)
+            .ok_or("row out of range".to_string())
+            .and_then(|(name, cnt)| match idx {
+                0 => Ok(Value::from_text(name.clone())),
+                1 => Ok(Value::from_integer(*cnt)),
+                _ => Err("bad column".into()),
+            })
+    }
+
+    fn next(cursor: &mut Self::VCursor) -> ResultCode {
+        cursor.pos += 1;
+        if cursor.pos >= cursor.rows.len() {
+            ResultCode::EOF
+        } else {
+            ResultCode::OK
+        }
+    }
+
+    fn eof(cursor: &Self::VCursor) -> bool {
+        cursor.pos >= cursor.rows.len()
+    }
+}
+
+impl VTabCursor for StatsCursor {
+    type Error = String;
+
+    fn rowid(&self) -> i64 {
+        self.pos as i64
+    }
+
+    fn column(&self, idx: u32) -> Result<Value, Self::Error> {
+        <TableStats as VTabModule>::column(self, idx)
+    }
+
+    fn eof(&self) -> bool {
+        <TableStats as VTabModule>::eof(self)
+    }
+
+    fn next(&mut self) -> ResultCode {
+        <TableStats as VTabModule>::next(self)
     }
 }

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -322,7 +322,7 @@ impl VTabModule for TableStats {
     type Error = String;
 
     fn create_schema(_args: &[Value]) -> String {
-        // Two columns, no hidden columns; rowid provided implicitly.
+        // table name, total rows
         "CREATE TABLE x(name TEXT, rows INT);".to_string()
     }
 
@@ -349,27 +349,39 @@ impl VTabModule for TableStats {
         // discover application tables
         let mut master = conn
             .prepare(
-                "SELECT name FROM sqlite_schema \
-                      WHERE type = 'table' AND name NOT LIKE 'sqlite_%';",
+                "SELECT name, sql FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%';",
             )
             .map_err(|_| ResultCode::Error)
             .unwrap();
 
-        while master.step() == StepResult::Row {
-            let tbl_name = master.get_row()[0]
-                .to_text()
-                .unwrap_or("<invalid>")
-                .to_string();
-
-            // count rows for each table; ignore errors to keep demo simple
-            if let Ok(mut count_stmt) =
-                conn.prepare(&format!("SELECT COUNT(*) FROM \"{}\";", tbl_name))
-            {
+        let mut tables = Vec::new();
+        while let StepResult::Row = master.step() {
+            let row = master.get_row();
+            let tbl = if let Some(val) = row.first() {
+                val.to_text().unwrap_or("").to_string()
+            } else {
+                "".to_string()
+            };
+            if tbl.is_empty() {
+                continue;
+            };
+            if row.get(1).is_some_and(|v| {
+                v.to_text()
+                    .unwrap()
+                    .contains(&format!("USING {}", Self::NAME))
+            }) {
+                continue;
+            }
+            tables.push(tbl);
+        }
+        for tbl in tables {
+            // count rows for each table
+            if let Ok(mut count_stmt) = conn.prepare(&format!("SELECT COUNT(*) FROM {};", tbl)) {
                 let count = match count_stmt.step() {
                     StepResult::Row => count_stmt.get_row()[0].to_integer().unwrap_or(0),
                     _ => 0,
                 };
-                cursor.rows.push((tbl_name, count));
+                cursor.rows.push((tbl, count));
             }
         }
         ResultCode::OK

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -473,13 +473,13 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
             }
 
             #[no_mangle]
-            unsafe extern "C" fn #open_fn_name(ctx: *const ::std::ffi::c_void) -> *const ::std::ffi::c_void {
-                if ctx.is_null() {
+            unsafe extern "C" fn #open_fn_name(ctx: *const ::std::ffi::c_void, conn: *mut ::limbo_ext::Conn) -> *const ::std::ffi::c_void {
+                if ctx.is_null() || conn.is_null() {
                     return ::std::ptr::null();
                 }
-                let ctx  = ctx as *const #struct_name;
-                let ctx: &#struct_name = &*ctx;
-                if let Ok(cursor) = <#struct_name as ::limbo_ext::VTabModule>::open(ctx) {
+                let ctx: &#struct_name = unsafe {&*(ctx as *const #struct_name)};
+                let conn = ::std::rc::Rc::new(::limbo_ext::Connection::new(conn));
+                if let Ok(cursor) = <#struct_name as ::limbo_ext::VTabModule>::open(ctx, Some(conn)) {
                     return ::std::boxed::Box::into_raw(::std::boxed::Box::new(cursor)) as *const ::std::ffi::c_void;
                 } else {
                     return ::std::ptr::null();
@@ -635,17 +635,21 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
 
             #[no_mangle]
             pub unsafe extern "C" fn #register_fn_name(
-                api: *const ::limbo_ext::ExtensionApi
+                api: *mut ::limbo_ext::ExtensionApi
             ) -> ::limbo_ext::ResultCode {
                 if api.is_null() {
                     return ::limbo_ext::ResultCode::Error;
                 }
-                let api = &*api;
+                let api = &mut *api;
+                // establish connection on vtab module registration
+                let connection = unsafe { (api.connect)(api.ctx) };
+                api.conn = connection;
                 let name = <#struct_name as ::limbo_ext::VTabModule>::NAME;
                 let name_c = ::std::ffi::CString::new(name).unwrap().into_raw() as *const ::std::ffi::c_char;
                 let table_instance = ::std::boxed::Box::into_raw(::std::boxed::Box::new(#struct_name::default()));
                 let module = ::limbo_ext::VTabModuleImpl {
                     ctx: table_instance as *const ::std::ffi::c_void,
+                    conn: api.conn,
                     name: name_c,
                     create_schema: Self::#create_schema_fn_name,
                     open: Self::#open_fn_name,
@@ -1013,9 +1017,10 @@ pub fn register_extension(input: TokenStream) -> TokenStream {
 
                 #(#aggregate_calls)*
 
-                #(#vtab_calls)*
-
                 #(#vfs_calls)*
+
+                let api = unsafe { &*api as *const ::limbo_ext::ExtensionApi } as *mut ::limbo_ext::ExtensionApi;
+                #(#vtab_calls)*
 
                 ::limbo_ext::ResultCode::OK
             }

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -499,7 +499,7 @@ def test_ipaddr():
 
 
 def test_vfs():
-    limbo = TestLimboShell()
+    limbo = TestLimboShell("")
     ext_path = "target/debug/liblimbo_ext_tests"
     limbo.run_test_fn(".vfslist", lambda x: "testvfs" not in x, "testvfs not loaded")
     limbo.execute_dot(f".load {ext_path}")
@@ -552,6 +552,65 @@ def test_drop_virtual_table():
     limbo.quit()
 
 
+def test_tablestats():
+    ext_path = "target/debug/liblimbo_ext_tests"
+    limbo = TestLimboShell("")
+    limbo.execute_dot("CREATE TABLE people(id INTEGER PRIMARY KEY, name TEXT);")
+    limbo.execute_dot("INSERT INTO people(name) VALUES ('Ada'), ('Grace'), ('Linus');")
+
+    limbo.execute_dot("CREATE TABLE logs(ts INT, msg TEXT);")
+    limbo.execute_dot("INSERT INTO logs VALUES (1,'boot ok');")
+
+    # verify counts
+    limbo.run_test_fn(
+        "SELECT COUNT(*) FROM people;", lambda res: res == "3", "three people rows"
+    )
+    limbo.run_test_fn(
+        "SELECT COUNT(*) FROM logs;", lambda res: res == "1", "one logs row"
+    )
+    # load extension
+    limbo.execute_dot(f".load {ext_path}")
+    limbo.execute_dot("CREATE VIRTUAL TABLE stats USING tablestats;")
+
+    def _split(res):
+        return [ln.strip() for ln in res.splitlines() if ln.strip()]
+
+    limbo.run_test_fn(
+        "SELECT * FROM stats ORDER BY name;",
+        lambda res: sorted(_split(res)) == sorted(["logs|1", "people|3"]),
+        "stats shows correct initial counts (and skips itself)",
+    )
+
+    limbo.execute_dot("INSERT INTO logs VALUES (2,'panic'), (3,'recovery');")
+    limbo.execute_dot("DELETE FROM people WHERE name='Linus';")
+
+    limbo.run_test_fn(
+        "SELECT * FROM stats WHERE name='logs';",
+        lambda res: res == "logs|3",
+        "row‑count grows after INSERT",
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM stats WHERE name='people';",
+        lambda res: res == "people|2",
+        "row‑count shrinks after DELETE",
+    )
+
+    limbo.execute_dot("CREATE TABLE misc(x);")
+    limbo.run_test_fn(
+        "SELECT * FROM stats WHERE name='misc';",
+        lambda res: res == "misc|0",
+        "newly‑created table shows up with zero rows",
+    )
+
+    limbo.execute_dot("DROP TABLE logs;")
+    limbo.run_test_fn(
+        "SELECT name FROM stats WHERE name='logs';",
+        lambda res: res == "",
+        "dropped table disappears from stats",
+    )
+    limbo.quit()
+
+
 def test_sqlite_vfs_compat():
     sqlite = TestLimboShell(
         init_commands="",
@@ -600,6 +659,7 @@ def main():
         test_sqlite_vfs_compat()
         test_kv()
         test_drop_virtual_table()
+        test_tablestats()
     except Exception as e:
         console.error(f"Test FAILED: {e}")
         cleanup()


### PR DESCRIPTION
Re-Opening #1076 because it had bit-rotted to a point of no return.

However it has improved. Now with Weak references and no incrementing Rc strong counts.

This also includes a better test extension that returns info about the other tables in the schema.
![image](https://github.com/user-attachments/assets/4292dc9c-121e-4ba2-8a51-4533bbcf2afd)
(theme doesn't show rows column)