### PR TITLE
Feature: Collate

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -193,7 +193,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | ... OVER (...)            | No      | Is incorrectly ignored                   |
 | (expr)                    | Yes     |                                          |
 | CAST (expr AS type)       | Yes     |                                          |
-| COLLATE                   | No      |                                          |
+| COLLATE                   | Partial | Custom Collations not supported          |
 | (NOT) LIKE                | Yes     |                                          |
 | (NOT) GLOB                | Yes     |                                          |
 | (NOT) REGEXP              | No      |                                          |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,10 +1841,12 @@ dependencies = [
  "ryu",
  "sorted-vec",
  "strum",
+ "strum_macros",
  "tempfile",
  "test-log",
  "thiserror 1.0.69",
  "tracing",
+ "uncased",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ limbo_series = { path = "extensions/series", version = "0.0.20" }
 limbo_sqlite3_parser = { path = "vendored/sqlite3-parser", version = "0.0.20" }
 limbo_time = { path = "extensions/time", version = "0.0.20" }
 limbo_uuid = { path = "extensions/uuid", version = "0.0.20" }
+strum = { version = "0.26", features = ["derive"] }
+strum_macros = "0.26"
 
 [profile.release]
 debug = "line-tables-only"

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ uv-sync:
 	uv sync --all-packages
 .PHONE: uv-sync
 
-test: limbo uv-sync test-compat test-vector test-sqlite3 test-shell test-extensions test-memory test-write test-update test-constraint
+test: limbo uv-sync test-compat test-vector test-sqlite3 test-shell test-extensions test-memory test-write test-update test-constraint test-collate
 .PHONY: test
 
 test-extensions: limbo uv-sync
@@ -99,6 +99,10 @@ test-write: limbo uv-sync
 test-update: limbo uv-sync
 	SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-update
 .PHONY: test-update
+
+test-collate: limbo uv-sync
+	SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-collate
+.PHONY: test-collate
 
 test-constraint: limbo uv-sync
 	SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-constraint

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -69,11 +69,13 @@ limbo_ipaddr = { workspace = true, optional = true, features = ["static"] }
 limbo_completion = { workspace = true, optional = true, features = ["static"] }
 limbo_ext_tests = { workspace = true, optional = true, features = ["static"] }
 miette = "7.6.0"
-strum = "0.26"
+strum = { workspace = true }
 parking_lot = "0.12.3"
 crossbeam-skiplist = "0.1.3"
 tracing = "0.1.41"
 ryu = "1.0.19"
+uncased = "0.9.10"
+strum_macros = {workspace = true }
 bitflags = "2.9.0"
 
 [build-dependencies]

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -236,6 +236,10 @@ impl BTreeTable {
         sql.push_str(");\n");
         sql
     }
+
+    pub fn column_collations(&self) -> Vec<Option<CollationSeq>> {
+        self.columns.iter().map(|column| column.collation).collect()
+    }
 }
 
 #[derive(Debug, Default)]

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,3 +1,4 @@
+use crate::translate::collate::CollationSeq;
 use crate::{util::normalize_ident, Result};
 use crate::{LimboError, VirtualTable};
 use core::fmt;
@@ -261,6 +262,7 @@ impl PseudoTable {
             notnull: false,
             default: None,
             unique: false,
+            collation: None,
         });
     }
     pub fn get_column(&self, name: &str) -> Option<(usize, &Column)> {
@@ -418,6 +420,7 @@ fn create_table(
                 let mut notnull = false;
                 let mut order = SortOrder::Asc;
                 let mut unique = false;
+                let mut collation = None;
                 for c_def in &col_def.constraints {
                     match &c_def.constraint {
                         limbo_sqlite3_parser::ast::ColumnConstraint::PrimaryKey {
@@ -442,6 +445,10 @@ fn create_table(
                             }
                             unique = true;
                         }
+                        limbo_sqlite3_parser::ast::ColumnConstraint::Collate { collation_name } => {
+                            collation = Some(CollationSeq::new(collation_name.0.as_str())?);
+                        }
+                        // Collate
                         _ => {}
                     }
                 }
@@ -464,6 +471,7 @@ fn create_table(
                     notnull,
                     default,
                     unique,
+                    collation,
                 });
             }
             if options.contains(TableOptions::WITHOUT_ROWID) {
@@ -534,6 +542,7 @@ pub struct Column {
     pub notnull: bool,
     pub default: Option<Expr>,
     pub unique: bool,
+    pub collation: Option<CollationSeq>,
 }
 
 impl Column {
@@ -737,6 +746,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 notnull: false,
                 default: None,
                 unique: false,
+                collation: None,
             },
             Column {
                 name: Some("name".to_string()),
@@ -747,6 +757,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 notnull: false,
                 default: None,
                 unique: false,
+                collation: None,
             },
             Column {
                 name: Some("tbl_name".to_string()),
@@ -757,6 +768,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 notnull: false,
                 default: None,
                 unique: false,
+                collation: None,
             },
             Column {
                 name: Some("rootpage".to_string()),
@@ -767,6 +779,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 notnull: false,
                 default: None,
                 unique: false,
+                collation: None,
             },
             Column {
                 name: Some("sql".to_string()),
@@ -777,6 +790,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 notnull: false,
                 default: None,
                 unique: false,
+                collation: None,
             },
         ],
         unique_sets: None,
@@ -1406,6 +1420,7 @@ mod tests {
                 notnull: false,
                 default: None,
                 unique: false,
+                collation: None,
             }],
             unique_sets: None,
         };

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -625,7 +625,7 @@ impl BTreeCursor {
                             record_slice_same_num_cols,
                             index_key.get_values(),
                             self.index_key_sort_order,
-                            CollationSeq::Binary,
+                            &self.collations,
                         );
                         order
                     };
@@ -684,7 +684,7 @@ impl BTreeCursor {
                             record_slice_same_num_cols,
                             index_key.get_values(),
                             self.index_key_sort_order,
-                            CollationSeq::Binary,
+                            &self.collations,
                         );
                         order
                     };
@@ -1265,7 +1265,7 @@ impl BTreeCursor {
                             record_slice_same_num_cols,
                             index_key.get_values(),
                             self.index_key_sort_order,
-                            CollationSeq::Binary,
+                            &self.collations,
                         );
                         order
                     };
@@ -1326,7 +1326,7 @@ impl BTreeCursor {
                             record_slice_same_num_cols,
                             index_key.get_values(),
                             self.index_key_sort_order,
-                            CollationSeq::Binary,
+                            &self.collations,
                         );
                         order
                     };
@@ -1607,7 +1607,7 @@ impl BTreeCursor {
                     record_slice_equal_number_of_cols,
                     index_key.get_values(),
                     self.index_key_sort_order,
-                    CollationSeq::Binary,
+                    &self.collations,
                 );
                 // in sqlite btrees left child pages have <= keys.
                 // in general, in forwards iteration we want to find the first key that matches the seek condition.
@@ -1932,7 +1932,7 @@ impl BTreeCursor {
                 record_slice_equal_number_of_cols,
                 key.get_values(),
                 self.index_key_sort_order,
-                CollationSeq::Binary,
+                &self.collations,
             );
             let found = match seek_op {
                 SeekOp::GT => cmp.is_gt(),
@@ -2100,7 +2100,7 @@ impl BTreeCursor {
                                     .unwrap()
                                     .get_values(),
                         self.index_key_sort_order,
-                        CollationSeq::Binary,
+                        &self.collations,
                         ) == Ordering::Equal {
 
                         tracing::debug!("insert_into_page: found exact match with cell_idx={cell_idx}, overwriting");
@@ -3747,7 +3747,7 @@ impl BTreeCursor {
                         key.to_index_key_values(),
                         self.get_immutable_record().as_ref().unwrap().get_values(),
                         self.index_key_sort_order,
-                        CollationSeq::Binary,
+                        &self.collations,
                     );
                     match order {
                         Ordering::Less | Ordering::Equal => {
@@ -4777,6 +4777,10 @@ impl BTreeCursor {
                 Ok(CursorResult::IO)
             }
         }
+    }
+
+    pub fn collations(&self) -> &[CollationSeq] {
+        &self.collations
     }
 }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7,7 +7,7 @@ use crate::{
             TableLeafCell,
         },
     },
-    translate::plan::IterationDirection,
+    translate::{collate::CollationSeq, plan::IterationDirection},
     types::IndexKeySortOrder,
     MvCursor,
 };
@@ -610,6 +610,7 @@ impl BTreeCursor {
                             record_slice_same_num_cols,
                             index_key.get_values(),
                             self.index_key_sort_order,
+                            CollationSeq::Binary,
                         );
                         order
                     };
@@ -668,6 +669,7 @@ impl BTreeCursor {
                             record_slice_same_num_cols,
                             index_key.get_values(),
                             self.index_key_sort_order,
+                            CollationSeq::Binary,
                         );
                         order
                     };
@@ -1248,6 +1250,7 @@ impl BTreeCursor {
                             record_slice_same_num_cols,
                             index_key.get_values(),
                             self.index_key_sort_order,
+                            CollationSeq::Binary,
                         );
                         order
                     };
@@ -1308,6 +1311,7 @@ impl BTreeCursor {
                             record_slice_same_num_cols,
                             index_key.get_values(),
                             self.index_key_sort_order,
+                            CollationSeq::Binary,
                         );
                         order
                     };
@@ -1588,6 +1592,7 @@ impl BTreeCursor {
                     record_slice_equal_number_of_cols,
                     index_key.get_values(),
                     self.index_key_sort_order,
+                    CollationSeq::Binary,
                 );
                 // in sqlite btrees left child pages have <= keys.
                 // in general, in forwards iteration we want to find the first key that matches the seek condition.
@@ -1912,6 +1917,7 @@ impl BTreeCursor {
                 record_slice_equal_number_of_cols,
                 key.get_values(),
                 self.index_key_sort_order,
+                CollationSeq::Binary,
             );
             let found = match seek_op {
                 SeekOp::GT => cmp.is_gt(),
@@ -2079,6 +2085,7 @@ impl BTreeCursor {
                                     .unwrap()
                                     .get_values(),
                         self.index_key_sort_order,
+                        CollationSeq::Binary,
                         ) == Ordering::Equal {
 
                         tracing::debug!("insert_into_page: found exact match with cell_idx={cell_idx}, overwriting");
@@ -3725,6 +3732,7 @@ impl BTreeCursor {
                         key.to_index_key_values(),
                         self.get_immutable_record().as_ref().unwrap().get_values(),
                         self.index_key_sort_order,
+                        CollationSeq::Binary,
                     );
                     match order {
                         Ordering::Less | Ordering::Equal => {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7592,7 +7592,7 @@ mod tests {
     #[test]
     pub fn test_read_write_payload_with_offset() {
         let (pager, root_page) = empty_btree();
-        let mut cursor = BTreeCursor::new(None, pager.clone(), root_page);
+        let mut cursor = BTreeCursor::new(None, pager.clone(), root_page, vec![]);
         let offset = 2; // blobs data starts at offset 2
         let initial_text = "hello world";
         let initial_blob = initial_text.as_bytes().to_vec();
@@ -7668,7 +7668,7 @@ mod tests {
     #[test]
     pub fn test_read_write_payload_with_overflow_page() {
         let (pager, root_page) = empty_btree();
-        let mut cursor = BTreeCursor::new(None, pager.clone(), root_page);
+        let mut cursor = BTreeCursor::new(None, pager.clone(), root_page, vec![]);
         let mut large_blob = vec![b'A'; 40960 - 11]; // insert large blob. 40960 = 10 page long.
         let hello_world = b"hello world";
         large_blob.extend_from_slice(hello_world);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -408,7 +408,7 @@ pub struct BTreeCursor {
     /// Store whether the Cursor is in a valid state. Meaning if it is pointing to a valid cell index or not
     valid_state: CursorValidState,
     /// Colations for Index Btree constraint checks
-    /// Contains the Collation Seq for the whole Table
+    /// Contains the Collation Seq for the whole Index
     /// This Vec should be empty for Table Btree
     collations: Vec<CollationSeq>,
 }

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, str::FromStr as _};
 
 use tracing::Level;
 
@@ -22,6 +22,12 @@ pub enum CollationSeq {
 }
 
 impl CollationSeq {
+    pub fn new(collation: &str) -> crate::Result<Self> {
+        CollationSeq::from_str(collation).map_err(|_| {
+            crate::LimboError::ParseError(format!("no such collation sequence: {}", collation))
+        })
+    }
+
     pub fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
         tracing::event!(Level::DEBUG, collate = %self, lhs, rhs);
         match self {

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -4,7 +4,9 @@ use tracing::Level;
 
 // TODO: in the future allow user to define collation sequences
 // Will have to meddle with ffi for this
-#[derive(Debug, Eq, PartialEq, strum_macros::Display, Default)]
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, strum_macros::Display, strum_macros::EnumString, Default,
+)]
 #[strum(ascii_case_insensitive)]
 /// **Pre defined collation sequences**\
 /// Collating functions only matter when comparing string values.

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 
+use tracing::Level;
+
 // TODO: in the future allow user to define collation sequences
 // Will have to meddle with ffi for this
 #[derive(Debug, Eq, PartialEq, strum_macros::Display, Default)]
@@ -18,7 +20,8 @@ pub enum CollationSeq {
 }
 
 impl CollationSeq {
-    fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
+    pub fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
+        tracing::event!(Level::DEBUG, collate = %self, lhs, rhs);
         match self {
             CollationSeq::Binary => Self::binary_cmp(lhs, rhs),
             CollationSeq::NoCase => Self::nocase_cmp(lhs, rhs),

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -48,6 +48,6 @@ impl CollationSeq {
     }
 
     fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
-        lhs.trim().cmp(rhs.trim())
+        lhs.trim_end().cmp(rhs.trim_end())
     }
 }

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -1,0 +1,42 @@
+use std::cmp::Ordering;
+
+// TODO: in the future allow user to define collation sequences
+// Will have to meddle with ffi for this
+#[derive(Debug, Eq, PartialEq, strum_macros::Display, Default)]
+#[strum(ascii_case_insensitive)]
+/// **Pre defined collation sequences**\
+/// Collating functions only matter when comparing string values.
+/// Numeric values are always compared numerically, and BLOBs are always compared byte-by-byte using memcmp().
+pub enum CollationSeq {
+    /// Standard String compare
+    #[default]
+    Binary,
+    /// Ascii case insensitive
+    NoCase,
+    /// Same as Binary but with trimmed whitespace
+    Rtrim,
+}
+
+impl CollationSeq {
+    fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
+        match self {
+            CollationSeq::Binary => Self::binary_cmp(lhs, rhs),
+            CollationSeq::NoCase => Self::nocase_cmp(lhs, rhs),
+            CollationSeq::Rtrim => Self::rtrim_cmp(lhs, rhs),
+        }
+    }
+
+    fn binary_cmp(lhs: &str, rhs: &str) -> Ordering {
+        lhs.cmp(rhs)
+    }
+
+    fn nocase_cmp(lhs: &str, rhs: &str) -> Ordering {
+        let nocase_lhs = uncased::UncasedStr::new(lhs);
+        let nocase_rhs = uncased::UncasedStr::new(rhs);
+        nocase_lhs.cmp(nocase_rhs)
+    }
+
+    fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
+        lhs.trim().cmp(rhs.trim())
+    }
+}

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -914,6 +914,7 @@ fn emit_update_insns(
             rhs: idx_rowid_reg,
             target_pc: constraint_check,
             flags: CmpInsFlags::default(), // TODO: not sure what type of comparison flag is needed
+            collation: program.curr_collation(),
         });
 
         program.emit_insn(Insn::Halt {
@@ -943,6 +944,7 @@ fn emit_update_insns(
                 rhs: beg,
                 target_pc: record_label,
                 flags: CmpInsFlags::default(),
+                collation: program.curr_collation(),
             });
 
             program.emit_insn(Insn::NotExists {

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -275,7 +275,7 @@ pub fn emit_query<'a>(
 
     // Initialize cursors and other resources needed for query execution
     if let Some(ref mut order_by) = plan.order_by {
-        init_order_by(program, t_ctx, order_by)?;
+        init_order_by(program, t_ctx, order_by, &plan.table_references)?;
     }
 
     if let Some(ref group_by) = plan.group_by {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -466,41 +466,42 @@ pub fn translate_expr(
                 let e2_reg = e1_reg + 1;
 
                 translate_expr(program, referenced_tables, e1, e1_reg, resolver)?;
-                let left_collation = program.curr_collation_ctx();
+                let left_collation_ctx = program.curr_collation_ctx();
                 program.reset_collation();
 
                 translate_expr(program, referenced_tables, e2, e2_reg, resolver)?;
-                let right_collation = program.curr_collation_ctx();
+                let right_collation_ctx = program.curr_collation_ctx();
                 program.reset_collation();
 
-                /*
-                 * The rules for determining which collating function to use for a binary comparison
-                 * operator (=, <, >, <=, >=, !=, IS, and IS NOT) are as follows:
-                 *
-                 * 1. If either operand has an explicit collating function assignment using the postfix COLLATE operator,
-                 * then the explicit collating function is used for comparison,
-                 * with precedence to the collating function of the left operand.
-                 *
-                 * 2. If either operand is a column, then the collating function of that column is used
-                 * with precedence to the left operand. For the purposes of the previous sentence,
-                 * a column name preceded by one or more unary "+" operators and/or CAST operators is still considered a column name.
-                 *
-                 * 3. Otherwise, the BINARY collating function is used for comparison.
-                 */
-                let collation_ctx = {
-                    match (left_collation, right_collation) {
-                        (Some((c_left, true)), _) => Some((c_left, true)),
-                        (Some((c_left, from_collate_left)), Some((_, false))) => {
-                            Some((c_left, from_collate_left))
-                        }
-                        (Some((_, false)), Some((c_right, true))) => Some((c_right, true)),
-                        (None, Some((c_right, from_collate_right))) => {
-                            Some((c_right, from_collate_right))
-                        }
-                        _ => None,
+            /*
+             * The rules for determining which collating function to use for a binary comparison
+             * operator (=, <, >, <=, >=, !=, IS, and IS NOT) are as follows:
+             *
+             * 1. If either operand has an explicit collating function assignment using the postfix COLLATE operator,
+             * then the explicit collating function is used for comparison,
+             * with precedence to the collating function of the left operand.
+             *
+             * 2. If either operand is a column, then the collating function of that column is used
+             * with precedence to the left operand. For the purposes of the previous sentence,
+             * a column name preceded by one or more unary "+" operators and/or CAST operators is still considered a column name.
+             *
+             * 3. Otherwise, the BINARY collating function is used for comparison.
+             */
+            let collation_ctx = {
+                match (left_collation_ctx, right_collation_ctx) {
+                    (Some((c_left, true)), _) => Some((c_left, true)),
+                    (_, Some((c_right, true))) => Some((c_right, true)),
+                    (Some((c_left, from_collate_left)), None) => Some((c_left, from_collate_left)),
+                    (None, Some((c_right, from_collate_right))) => {
+                        Some((c_right, from_collate_right))
                     }
-                };
-                program.set_collation(collation_ctx);
+                    (Some((c_left, from_collate_left)), Some((_, false))) => {
+                        Some((c_left, from_collate_left))
+                    }
+                    _ => None,
+                }
+            };
+            program.set_collation(collation_ctx);
 
                 emit_binary_insn(program, op, e1_reg, e2_reg, target_register)?;
                 program.reset_collation();

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -16,6 +16,8 @@ use crate::vdbe::{
 };
 use crate::{Result, Value};
 
+use super::collate::CollationSeq;
+
 #[derive(Debug, Clone, Copy)]
 pub struct ConditionMetadata {
     pub jump_if_condition_is_true: bool,
@@ -53,6 +55,7 @@ macro_rules! emit_cmp_insn {
                 rhs: $rhs,
                 target_pc: $cond.jump_target_when_true,
                 flags: CmpInsFlags::default(),
+                collation: CollationSeq::default(),
             });
         } else {
             $program.emit_insn(Insn::$op_false {
@@ -60,6 +63,7 @@ macro_rules! emit_cmp_insn {
                 rhs: $rhs,
                 target_pc: $cond.jump_target_when_false,
                 flags: CmpInsFlags::default().jump_if_null(),
+                collation: CollationSeq::default(),
             });
         }
     }};
@@ -80,6 +84,7 @@ macro_rules! emit_cmp_null_insn {
                 rhs: $rhs,
                 target_pc: $cond.jump_target_when_true,
                 flags: CmpInsFlags::default().null_eq(),
+                collation: CollationSeq::default(),
             });
         } else {
             $program.emit_insn(Insn::$op_false {
@@ -87,6 +92,7 @@ macro_rules! emit_cmp_null_insn {
                 rhs: $rhs,
                 target_pc: $cond.jump_target_when_false,
                 flags: CmpInsFlags::default().null_eq(),
+                collation: CollationSeq::default(),
             });
         }
     }};
@@ -370,6 +376,7 @@ pub fn translate_condition_expr(
                             rhs: rhs_reg,
                             target_pc: jump_target_when_true,
                             flags: CmpInsFlags::default(),
+                            collation: CollationSeq::default(),
                         });
                     } else {
                         // If this is the last condition, we need to jump to the 'jump_target_when_false' label if there is no match.
@@ -378,6 +385,7 @@ pub fn translate_condition_expr(
                             rhs: rhs_reg,
                             target_pc: condition_metadata.jump_target_when_false,
                             flags: CmpInsFlags::default().jump_if_null(),
+                            collation: CollationSeq::default(),
                         });
                     }
                 }
@@ -399,6 +407,7 @@ pub fn translate_condition_expr(
                         rhs: rhs_reg,
                         target_pc: condition_metadata.jump_target_when_false,
                         flags: CmpInsFlags::default().jump_if_null(),
+                        collation: CollationSeq::default(),
                     });
                 }
                 // If we got here, then none of the conditions were a match, so we jump to the 'jump_target_when_true' label if 'jump_if_condition_is_true'.
@@ -609,6 +618,7 @@ pub fn translate_expr(
                         target_pc: next_case_label,
                         // A NULL result is considered untrue when evaluating WHEN terms.
                         flags: CmpInsFlags::default().jump_if_null(),
+                        collation: CollationSeq::default(),
                     }),
                     // CASE WHEN 0 THEN 0 ELSE 1 becomes ifnot 0 branch to next clause
                     None => program.emit_insn(Insn::IfNot {
@@ -2216,6 +2226,7 @@ fn emit_binary_insn(
                     rhs,
                     target_pc: if_true_label,
                     flags: CmpInsFlags::default(),
+                    collation: CollationSeq::default(),
                 },
                 target_register,
                 if_true_label,
@@ -2232,6 +2243,7 @@ fn emit_binary_insn(
                     rhs,
                     target_pc: if_true_label,
                     flags: CmpInsFlags::default(),
+                    collation: CollationSeq::default(),
                 },
                 target_register,
                 if_true_label,
@@ -2248,6 +2260,7 @@ fn emit_binary_insn(
                     rhs,
                     target_pc: if_true_label,
                     flags: CmpInsFlags::default(),
+                    collation: CollationSeq::default(),
                 },
                 target_register,
                 if_true_label,
@@ -2264,6 +2277,7 @@ fn emit_binary_insn(
                     rhs,
                     target_pc: if_true_label,
                     flags: CmpInsFlags::default(),
+                    collation: CollationSeq::default(),
                 },
                 target_register,
                 if_true_label,
@@ -2280,6 +2294,7 @@ fn emit_binary_insn(
                     rhs,
                     target_pc: if_true_label,
                     flags: CmpInsFlags::default(),
+                    collation: CollationSeq::default(),
                 },
                 target_register,
                 if_true_label,
@@ -2296,6 +2311,7 @@ fn emit_binary_insn(
                     rhs,
                     target_pc: if_true_label,
                     flags: CmpInsFlags::default(),
+                    collation: CollationSeq::default(),
                 },
                 target_register,
                 if_true_label,
@@ -2389,6 +2405,7 @@ fn emit_binary_insn(
                     rhs,
                     target_pc: if_true_label,
                     flags: CmpInsFlags::default().null_eq(),
+                    collation: CollationSeq::default(),
                 },
                 target_register,
                 if_true_label,
@@ -2403,6 +2420,7 @@ fn emit_binary_insn(
                     rhs,
                     target_pc: if_true_label,
                     flags: CmpInsFlags::default().null_eq(),
+                    collation: CollationSeq::default(),
                 },
                 target_register,
                 if_true_label,

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -217,6 +217,7 @@ pub fn group_by_create_pseudo_table(
             notnull: false,
             default: None,
             unique: false,
+            collation: None,
         })
         .collect::<Vec<_>>();
 

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -462,6 +462,7 @@ pub fn group_by_process_single_group(
         start_reg_a: registers.reg_group_exprs_cmp,
         start_reg_b: groups_start_reg,
         count: group_by.exprs.len(),
+        collation: program.curr_collation(),
     });
 
     program.add_comment(

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -120,7 +120,7 @@ pub fn translate_create_index(
         cursor_id: sorter_cursor_id,
         columns: columns.len(),
         order,
-        collation: program.curr_collation(),
+        collations: tbl.column_collations(),
     });
     let content_reg = program.alloc_register();
     program.emit_insn(Insn::OpenPseudo {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -405,6 +405,7 @@ pub fn translate_drop_index(
         rhs: dest_reg,
         target_pc: next_label,
         flags: CmpInsFlags::default(),
+        collation: program.curr_collation(),
     });
 
     // read type of table
@@ -420,6 +421,7 @@ pub fn translate_drop_index(
         rhs: dest_reg,
         target_pc: next_label,
         flags: CmpInsFlags::default(),
+        collation: program.curr_collation(),
     });
 
     program.emit_insn(Insn::RowId {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -120,6 +120,7 @@ pub fn translate_create_index(
         cursor_id: sorter_cursor_id,
         columns: columns.len(),
         order,
+        collation: program.curr_collation(),
     });
     let content_reg = program.alloc_register();
     program.emit_insn(Insn::OpenPseudo {

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -17,6 +17,7 @@ use crate::{
 
 use super::{
     aggregation::translate_aggregation_step,
+    collate::CollationSeq,
     emitter::{OperationMode, TranslateCtx},
     expr::{
         translate_condition_expr, translate_expr, translate_expr_no_constant_opt,
@@ -1127,24 +1128,28 @@ fn emit_seek_termination(
             start_reg,
             num_regs,
             target_pc: loop_end,
+            collation: Some(CollationSeq::Binary),
         }),
         (true, SeekOp::GT) => program.emit_insn(Insn::IdxGT {
             cursor_id: seek_cursor_id,
             start_reg,
             num_regs,
             target_pc: loop_end,
+            collation: Some(CollationSeq::Binary),
         }),
         (true, SeekOp::LE) => program.emit_insn(Insn::IdxLE {
             cursor_id: seek_cursor_id,
             start_reg,
             num_regs,
             target_pc: loop_end,
+            collation: Some(CollationSeq::Binary),
         }),
         (true, SeekOp::LT) => program.emit_insn(Insn::IdxLT {
             cursor_id: seek_cursor_id,
             start_reg,
             num_regs,
             target_pc: loop_end,
+            collation: Some(CollationSeq::Binary),
         }),
         (false, SeekOp::GE) => program.emit_insn(Insn::Ge {
             lhs: rowid_reg.unwrap(),

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -17,7 +17,6 @@ use crate::{
 
 use super::{
     aggregation::translate_aggregation_step,
-    collate::CollationSeq,
     emitter::{OperationMode, TranslateCtx},
     expr::{
         translate_condition_expr, translate_expr, translate_expr_no_constant_opt,
@@ -1128,28 +1127,24 @@ fn emit_seek_termination(
             start_reg,
             num_regs,
             target_pc: loop_end,
-            collation: Some(CollationSeq::Binary),
         }),
         (true, SeekOp::GT) => program.emit_insn(Insn::IdxGT {
             cursor_id: seek_cursor_id,
             start_reg,
             num_regs,
             target_pc: loop_end,
-            collation: Some(CollationSeq::Binary),
         }),
         (true, SeekOp::LE) => program.emit_insn(Insn::IdxLE {
             cursor_id: seek_cursor_id,
             start_reg,
             num_regs,
             target_pc: loop_end,
-            collation: Some(CollationSeq::Binary),
         }),
         (true, SeekOp::LT) => program.emit_insn(Insn::IdxLT {
             cursor_id: seek_cursor_id,
             start_reg,
             num_regs,
             target_pc: loop_end,
-            collation: Some(CollationSeq::Binary),
         }),
         (false, SeekOp::GE) => program.emit_insn(Insn::Ge {
             lhs: rowid_reg.unwrap(),

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -17,6 +17,7 @@ use crate::{
 
 use super::{
     aggregation::translate_aggregation_step,
+    collate::CollationSeq,
     emitter::{OperationMode, TranslateCtx},
     expr::{
         translate_condition_expr, translate_expr, translate_expr_no_constant_opt,
@@ -1151,24 +1152,28 @@ fn emit_seek_termination(
             rhs: start_reg,
             target_pc: loop_end,
             flags: CmpInsFlags::default(),
+            collation: CollationSeq::default(),
         }),
         (false, SeekOp::GT) => program.emit_insn(Insn::Gt {
             lhs: rowid_reg.unwrap(),
             rhs: start_reg,
             target_pc: loop_end,
             flags: CmpInsFlags::default(),
+            collation: CollationSeq::default(),
         }),
         (false, SeekOp::LE) => program.emit_insn(Insn::Le {
             lhs: rowid_reg.unwrap(),
             rhs: start_reg,
             target_pc: loop_end,
             flags: CmpInsFlags::default(),
+            collation: CollationSeq::default(),
         }),
         (false, SeekOp::LT) => program.emit_insn(Insn::Lt {
             lhs: rowid_reg.unwrap(),
             rhs: start_reg,
             target_pc: loop_end,
             flags: CmpInsFlags::default(),
+            collation: CollationSeq::default(),
         }),
         (_, SeekOp::EQ) => {
             panic!("An index termination condition is never EQ")

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -17,7 +17,6 @@ use crate::{
 
 use super::{
     aggregation::translate_aggregation_step,
-    collate::CollationSeq,
     emitter::{OperationMode, TranslateCtx},
     expr::{
         translate_condition_expr, translate_expr, translate_expr_no_constant_opt,
@@ -1152,28 +1151,28 @@ fn emit_seek_termination(
             rhs: start_reg,
             target_pc: loop_end,
             flags: CmpInsFlags::default(),
-            collation: CollationSeq::default(),
+            collation: program.curr_collation(),
         }),
         (false, SeekOp::GT) => program.emit_insn(Insn::Gt {
             lhs: rowid_reg.unwrap(),
             rhs: start_reg,
             target_pc: loop_end,
             flags: CmpInsFlags::default(),
-            collation: CollationSeq::default(),
+            collation: program.curr_collation(),
         }),
         (false, SeekOp::LE) => program.emit_insn(Insn::Le {
             lhs: rowid_reg.unwrap(),
             rhs: start_reg,
             target_pc: loop_end,
             flags: CmpInsFlags::default(),
-            collation: CollationSeq::default(),
+            collation: program.curr_collation(),
         }),
         (false, SeekOp::LT) => program.emit_insn(Insn::Lt {
             lhs: rowid_reg.unwrap(),
             rhs: start_reg,
             target_pc: loop_end,
             flags: CmpInsFlags::default(),
-            collation: CollationSeq::default(),
+            collation: program.curr_collation(),
         }),
         (_, SeekOp::EQ) => {
             panic!("An index termination condition is never EQ")

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -8,6 +8,7 @@
 //! will read rows from the database and filter them according to a WHERE clause.
 
 pub(crate) mod aggregation;
+pub(crate) mod collate;
 pub(crate) mod delete;
 pub(crate) mod emitter;
 pub(crate) mod expr;

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1205,6 +1205,7 @@ mod tests {
             notnull: false,
             default: None,
             unique: false,
+            collation: None,
         }
     }
     fn _create_column_of_type(name: &str, ty: Type) -> Column {

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -73,6 +73,7 @@ pub fn emit_order_by(
             notnull: false,
             default: None,
             unique: false,
+            collation: None,
         });
     }
     for i in 0..result_columns.len() {
@@ -92,6 +93,7 @@ pub fn emit_order_by(
             notnull: false,
             default: None,
             unique: false,
+            collation: None,
         });
     }
 

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -49,13 +49,10 @@ pub fn init_order_by(
      * then the collating sequence of the column is used to determine sort order.
      * If the expression is not a column and has no COLLATE clause, then the BINARY collating sequence is used.
      */
-    let mut collation = None;
-    for (expr, _) in order_by.iter() {
-        match expr {
-            ast::Expr::Collate(_, collation_name) => {
-                collation = Some(CollationSeq::new(collation_name)?);
-                break;
-            }
+    let collations = order_by
+        .iter()
+        .map(|(expr, _)| match expr {
+            ast::Expr::Collate(_, collation_name) => CollationSeq::new(collation_name).map(Some),
             ast::Expr::Column { table, column, .. } => {
                 let table_reference = referenced_tables.get(*table).unwrap();
 
@@ -63,19 +60,16 @@ pub fn init_order_by(
                     crate::bail_parse_error!("column index out of bounds");
                 };
 
-                if table_column.collation.is_some() {
-                    collation = table_column.collation;
-                    break;
-                }
+                Ok(table_column.collation)
             }
-            _ => {}
-        };
-    }
+            _ => Ok(Some(CollationSeq::default())),
+        })
+        .collect::<Result<Vec<_>>>()?;
     program.emit_insn(Insn::SorterOpen {
         cursor_id: sort_cursor,
         columns: order_by.len(),
         order: order_by.iter().map(|(_, direction)| *direction).collect(),
-        collation,
+        collations,
     });
     Ok(())
 }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -610,6 +610,7 @@ impl TableReference {
                     notnull: false,
                     default: None,
                     unique: false,
+                    collation: None,
                 })
                 .collect(),
         )));

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -21,8 +21,6 @@ use crate::{bail_parse_error, Result};
 use limbo_ext::VTabKind;
 use limbo_sqlite3_parser::ast::{fmt::ToTokens, CreateVirtualTable};
 
-use super::collate::CollationSeq;
-
 #[derive(Debug, Clone, Copy)]
 pub enum ParseSchema {
     None,
@@ -721,7 +719,7 @@ pub fn translate_drop_table(
         rhs: table_reg,
         target_pc: next_label,
         flags: CmpInsFlags::default(),
-        collation: CollationSeq::default(),
+        collation: program.curr_collation(),
     });
     program.emit_insn(Insn::Column {
         cursor_id: sqlite_schema_cursor_id,
@@ -733,7 +731,7 @@ pub fn translate_drop_table(
         rhs: table_type,
         target_pc: next_label,
         flags: CmpInsFlags::default(),
-        collation: CollationSeq::default(),
+        collation: program.curr_collation(),
     });
     program.emit_insn(Insn::RowId {
         cursor_id: sqlite_schema_cursor_id,

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -21,6 +21,8 @@ use crate::{bail_parse_error, Result};
 use limbo_ext::VTabKind;
 use limbo_sqlite3_parser::ast::{fmt::ToTokens, CreateVirtualTable};
 
+use super::collate::CollationSeq;
+
 #[derive(Debug, Clone, Copy)]
 pub enum ParseSchema {
     None,
@@ -719,6 +721,7 @@ pub fn translate_drop_table(
         rhs: table_reg,
         target_pc: next_label,
         flags: CmpInsFlags::default(),
+        collation: CollationSeq::default(),
     });
     program.emit_insn(Insn::Column {
         cursor_id: sqlite_schema_cursor_id,
@@ -730,6 +733,7 @@ pub fn translate_drop_table(
         rhs: table_type,
         target_pc: next_label,
         flags: CmpInsFlags::default(),
+        collation: CollationSeq::default(),
     });
     program.emit_insn(Insn::RowId {
         cursor_id: sqlite_schema_cursor_id,

--- a/core/types.rs
+++ b/core/types.rs
@@ -1109,13 +1109,6 @@ pub fn compare_immutable(
     assert_eq!(l.len(), r.len());
     for (i, (l, r)) in l.iter().zip(r).enumerate() {
         let column_order = index_key_sort_order.get_sort_order_for_col(i);
-        let mut l = l;
-        let mut r = r;
-        if !matches!(column_order, SortOrder::Asc) {
-            let tmp = l;
-            l = r;
-            r = tmp;
-        }
         let cmp = match (l, r) {
             (RefValue::Text(left), RefValue::Text(right)) => {
                 collation.compare_strings(left.as_str(), right.as_str())

--- a/core/types.rs
+++ b/core/types.rs
@@ -1104,11 +1104,12 @@ pub fn compare_immutable(
     l: &[RefValue],
     r: &[RefValue],
     index_key_sort_order: IndexKeySortOrder,
-    collation: CollationSeq,
+    collations: &[CollationSeq],
 ) -> std::cmp::Ordering {
     assert_eq!(l.len(), r.len());
     for (i, (l, r)) in l.iter().zip(r).enumerate() {
         let column_order = index_key_sort_order.get_sort_order_for_col(i);
+        let collation = collations.get(i).copied().unwrap_or_default();
         let cmp = match (l, r) {
             (RefValue::Text(left), RefValue::Text(right)) => {
                 collation.compare_strings(left.as_str(), right.as_str())

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -611,10 +611,6 @@ impl ProgramBuilder {
         self.collation = None;
     }
 
-    // pub fn pop_collation(&mut self) -> Option<CollationSeq> {
-    //     self.collations.pop()
-    // }
-
     pub fn build(
         mut self,
         database_header: Arc<SpinLock<DatabaseHeader>>,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -41,8 +41,8 @@ pub struct ProgramBuilder {
     pub parameters: Parameters,
     pub result_columns: Vec<ResultSetColumn>,
     pub table_references: Vec<TableReference>,
-    /// Stack of collation definitions encountered
-    collation: Option<CollationSeq>,
+    /// Curr collation sequence. Bool indicates whether it was set by a COLLATE expr
+    collation: Option<(CollationSeq, bool)>,
 }
 
 #[derive(Debug, Clone)]
@@ -595,12 +595,16 @@ impl ProgramBuilder {
             .unwrap_or_else(|| panic!("Cursor not found: {}", table_identifier))
     }
 
-    pub fn set_collation(&mut self, c: Option<CollationSeq>) {
-        self.collation = c;
+    pub fn set_collation(&mut self, c: Option<(CollationSeq, bool)>) {
+        self.collation = c
+    }
+
+    pub fn curr_collation_ctx(&self) -> Option<(CollationSeq, bool)> {
+        self.collation
     }
 
     pub fn curr_collation(&self) -> Option<CollationSeq> {
-        self.collation
+        self.collation.map(|c| c.0)
     }
 
     pub fn reset_collation(&mut self) {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2141,6 +2141,7 @@ pub fn op_idx_ge(
         start_reg,
         num_regs,
         target_pc,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -2155,7 +2156,12 @@ pub fn op_idx_ge(
             let idx_values = idx_record.get_values();
             let idx_values = &idx_values[..record_from_regs.len()];
             let record_values = record_from_regs.get_values();
-            let ord = compare_immutable(&idx_values, &record_values, cursor.index_key_sort_order);
+            let ord = compare_immutable(
+                &idx_values,
+                &record_values,
+                cursor.index_key_sort_order,
+                collation.unwrap_or_default(),
+            );
             if ord.is_ge() {
                 target_pc.to_offset_int()
             } else {
@@ -2200,6 +2206,7 @@ pub fn op_idx_le(
         start_reg,
         num_regs,
         target_pc,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -2214,7 +2221,12 @@ pub fn op_idx_le(
             let idx_values = idx_record.get_values();
             let idx_values = &idx_values[..record_from_regs.len()];
             let record_values = record_from_regs.get_values();
-            let ord = compare_immutable(&idx_values, &record_values, cursor.index_key_sort_order);
+            let ord = compare_immutable(
+                &idx_values,
+                &record_values,
+                cursor.index_key_sort_order,
+                collation.unwrap_or_default(),
+            );
             if ord.is_le() {
                 target_pc.to_offset_int()
             } else {
@@ -2241,6 +2253,7 @@ pub fn op_idx_gt(
         start_reg,
         num_regs,
         target_pc,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -2255,7 +2268,12 @@ pub fn op_idx_gt(
             let idx_values = idx_record.get_values();
             let idx_values = &idx_values[..record_from_regs.len()];
             let record_values = record_from_regs.get_values();
-            let ord = compare_immutable(&idx_values, &record_values, cursor.index_key_sort_order);
+            let ord = compare_immutable(
+                &idx_values,
+                &record_values,
+                cursor.index_key_sort_order,
+                collation.unwrap_or_default(),
+            );
             if ord.is_gt() {
                 target_pc.to_offset_int()
             } else {
@@ -2282,6 +2300,7 @@ pub fn op_idx_lt(
         start_reg,
         num_regs,
         target_pc,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -2296,7 +2315,12 @@ pub fn op_idx_lt(
             let idx_values = idx_record.get_values();
             let idx_values = &idx_values[..record_from_regs.len()];
             let record_values = record_from_regs.get_values();
-            let ord = compare_immutable(&idx_values, &record_values, cursor.index_key_sort_order);
+            let ord = compare_immutable(
+                &idx_values,
+                &record_values,
+                cursor.index_key_sort_order,
+                collation.unwrap_or_default(),
+            );
             if ord.is_lt() {
                 target_pc.to_offset_int()
             } else {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2765,11 +2765,12 @@ pub fn op_sorter_open(
         cursor_id,
         columns: _,
         order,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
     };
-    let cursor = Sorter::new(order);
+    let cursor = Sorter::new(order, collation.unwrap_or_default());
     let mut cursors = state.cursors.borrow_mut();
     cursors
         .get_mut(*cursor_id)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -537,6 +537,7 @@ pub fn op_eq(
     let cond = *state.registers[lhs].get_owned_value() == *state.registers[rhs].get_owned_value();
     let nulleq = flags.has_nulleq();
     let jump_if_null = flags.has_jump_if_null();
+    let collation = collation.unwrap_or_default();
     match (
         state.registers[lhs].get_owned_value(),
         state.registers[rhs].get_owned_value(),
@@ -548,7 +549,7 @@ pub fn op_eq(
                 state.pc += 1;
             }
         }
-        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+        (Value::Text(lhs), Value::Text(rhs)) => {
             let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
             if order.is_eq() {
                 state.pc = target_pc.to_offset_int();
@@ -591,6 +592,7 @@ pub fn op_ne(
     let cond = *state.registers[lhs].get_owned_value() != *state.registers[rhs].get_owned_value();
     let nulleq = flags.has_nulleq();
     let jump_if_null = flags.has_jump_if_null();
+    let collation = collation.unwrap_or_default();
     match (
         state.registers[lhs].get_owned_value(),
         state.registers[rhs].get_owned_value(),
@@ -602,7 +604,7 @@ pub fn op_ne(
                 state.pc += 1;
             }
         }
-        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+        (Value::Text(lhs), Value::Text(rhs)) => {
             let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
             if order.is_ne() {
                 state.pc = target_pc.to_offset_int();
@@ -643,6 +645,7 @@ pub fn op_lt(
     let rhs = *rhs;
     let target_pc = *target_pc;
     let jump_if_null = flags.has_jump_if_null();
+    let collation = collation.unwrap_or_default();
     match (
         state.registers[lhs].get_owned_value(),
         state.registers[rhs].get_owned_value(),
@@ -654,7 +657,7 @@ pub fn op_lt(
                 state.pc += 1;
             }
         }
-        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+        (Value::Text(lhs), Value::Text(rhs)) => {
             let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
             if order.is_lt() {
                 state.pc = target_pc.to_offset_int();
@@ -695,6 +698,7 @@ pub fn op_le(
     let rhs = *rhs;
     let target_pc = *target_pc;
     let jump_if_null = flags.has_jump_if_null();
+    let collation = collation.unwrap_or_default();
     match (
         state.registers[lhs].get_owned_value(),
         state.registers[rhs].get_owned_value(),
@@ -706,7 +710,7 @@ pub fn op_le(
                 state.pc += 1;
             }
         }
-        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+        (Value::Text(lhs), Value::Text(rhs)) => {
             let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
             if order.is_le() {
                 state.pc = target_pc.to_offset_int();
@@ -747,6 +751,7 @@ pub fn op_gt(
     let rhs = *rhs;
     let target_pc = *target_pc;
     let jump_if_null = flags.has_jump_if_null();
+    let collation = collation.unwrap_or_default();
     match (
         state.registers[lhs].get_owned_value(),
         state.registers[rhs].get_owned_value(),
@@ -758,7 +763,7 @@ pub fn op_gt(
                 state.pc += 1;
             }
         }
-        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+        (Value::Text(lhs), Value::Text(rhs)) => {
             let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
             if order.is_gt() {
                 state.pc = target_pc.to_offset_int();
@@ -799,6 +804,7 @@ pub fn op_ge(
     let rhs = *rhs;
     let target_pc = *target_pc;
     let jump_if_null = flags.has_jump_if_null();
+    let collation = collation.unwrap_or_default();
     match (
         state.registers[lhs].get_owned_value(),
         state.registers[rhs].get_owned_value(),
@@ -810,7 +816,7 @@ pub fn op_ge(
                 state.pc += 1;
             }
         }
-        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+        (Value::Text(lhs), Value::Text(rhs)) => {
             let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
             if order.is_ge() {
                 state.pc = target_pc.to_offset_int();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -940,10 +940,17 @@ pub fn op_open_read(
                 .get_table(&index.table_name)
                 .map_or(None, |table| table.btree());
             let collations = table.map_or(Vec::new(), |table| {
-                table
-                    .column_collations()
-                    .into_iter()
-                    .map(|c| c.unwrap_or_default())
+                index
+                    .columns
+                    .iter()
+                    .map(|c| {
+                        table
+                            .columns
+                            .get(c.pos_in_table)
+                            .unwrap()
+                            .collation
+                            .unwrap_or_default()
+                    })
                     .collect()
             });
             let cursor = BTreeCursor::new_index(
@@ -4245,10 +4252,17 @@ pub fn op_open_write(
             .get_table(&index.table_name)
             .map_or(None, |table| table.btree());
         let collations = table.map_or(Vec::new(), |table| {
-            table
-                .column_collations()
-                .into_iter()
-                .map(|c| c.unwrap_or_default())
+            index
+                .columns
+                .iter()
+                .map(|c| {
+                    table
+                        .columns
+                        .get(c.pos_in_table)
+                        .unwrap()
+                        .collation
+                        .unwrap_or_default()
+                })
                 .collect()
         });
         let cursor = BTreeCursor::new_index(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -525,6 +525,7 @@ pub fn op_eq(
         rhs,
         target_pc,
         flags,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -537,8 +538,8 @@ pub fn op_eq(
     let nulleq = flags.has_nulleq();
     let jump_if_null = flags.has_jump_if_null();
     match (
-        &state.registers[lhs].get_owned_value(),
-        &state.registers[rhs].get_owned_value(),
+        state.registers[lhs].get_owned_value(),
+        state.registers[rhs].get_owned_value(),
     ) {
         (_, Value::Null) | (Value::Null, _) => {
             if (nulleq && cond) || (!nulleq && jump_if_null) {
@@ -547,8 +548,16 @@ pub fn op_eq(
                 state.pc += 1;
             }
         }
-        _ => {
-            if *state.registers[lhs].get_owned_value() == *state.registers[rhs].get_owned_value() {
+        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+            let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
+            if order.is_eq() {
+                state.pc = target_pc.to_offset_int();
+            } else {
+                state.pc += 1;
+            }
+        }
+        (lhs, rhs) => {
+            if *lhs == *rhs {
                 state.pc = target_pc.to_offset_int();
             } else {
                 state.pc += 1;
@@ -570,6 +579,7 @@ pub fn op_ne(
         rhs,
         target_pc,
         flags,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -582,8 +592,8 @@ pub fn op_ne(
     let nulleq = flags.has_nulleq();
     let jump_if_null = flags.has_jump_if_null();
     match (
-        &state.registers[lhs].get_owned_value(),
-        &state.registers[rhs].get_owned_value(),
+        state.registers[lhs].get_owned_value(),
+        state.registers[rhs].get_owned_value(),
     ) {
         (_, Value::Null) | (Value::Null, _) => {
             if (nulleq && cond) || (!nulleq && jump_if_null) {
@@ -592,8 +602,16 @@ pub fn op_ne(
                 state.pc += 1;
             }
         }
-        _ => {
-            if *state.registers[lhs].get_owned_value() != *state.registers[rhs].get_owned_value() {
+        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+            let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
+            if order.is_ne() {
+                state.pc = target_pc.to_offset_int();
+            } else {
+                state.pc += 1;
+            }
+        }
+        (lhs, rhs) => {
+            if *lhs != *rhs {
                 state.pc = target_pc.to_offset_int();
             } else {
                 state.pc += 1;
@@ -615,6 +633,7 @@ pub fn op_lt(
         rhs,
         target_pc,
         flags,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -625,8 +644,8 @@ pub fn op_lt(
     let target_pc = *target_pc;
     let jump_if_null = flags.has_jump_if_null();
     match (
-        &state.registers[lhs].get_owned_value(),
-        &state.registers[rhs].get_owned_value(),
+        state.registers[lhs].get_owned_value(),
+        state.registers[rhs].get_owned_value(),
     ) {
         (_, Value::Null) | (Value::Null, _) => {
             if jump_if_null {
@@ -635,8 +654,16 @@ pub fn op_lt(
                 state.pc += 1;
             }
         }
-        _ => {
-            if *state.registers[lhs].get_owned_value() < *state.registers[rhs].get_owned_value() {
+        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+            let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
+            if order.is_lt() {
+                state.pc = target_pc.to_offset_int();
+            } else {
+                state.pc += 1;
+            }
+        }
+        (lhs, rhs) => {
+            if *lhs < *rhs {
                 state.pc = target_pc.to_offset_int();
             } else {
                 state.pc += 1;
@@ -658,6 +685,7 @@ pub fn op_le(
         rhs,
         target_pc,
         flags,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -668,8 +696,8 @@ pub fn op_le(
     let target_pc = *target_pc;
     let jump_if_null = flags.has_jump_if_null();
     match (
-        &state.registers[lhs].get_owned_value(),
-        &state.registers[rhs].get_owned_value(),
+        state.registers[lhs].get_owned_value(),
+        state.registers[rhs].get_owned_value(),
     ) {
         (_, Value::Null) | (Value::Null, _) => {
             if jump_if_null {
@@ -678,8 +706,16 @@ pub fn op_le(
                 state.pc += 1;
             }
         }
-        _ => {
-            if *state.registers[lhs].get_owned_value() <= *state.registers[rhs].get_owned_value() {
+        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+            let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
+            if order.is_le() {
+                state.pc = target_pc.to_offset_int();
+            } else {
+                state.pc += 1;
+            }
+        }
+        (lhs, rhs) => {
+            if *lhs <= *rhs {
                 state.pc = target_pc.to_offset_int();
             } else {
                 state.pc += 1;
@@ -701,6 +737,7 @@ pub fn op_gt(
         rhs,
         target_pc,
         flags,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -711,8 +748,8 @@ pub fn op_gt(
     let target_pc = *target_pc;
     let jump_if_null = flags.has_jump_if_null();
     match (
-        &state.registers[lhs].get_owned_value(),
-        &state.registers[rhs].get_owned_value(),
+        state.registers[lhs].get_owned_value(),
+        state.registers[rhs].get_owned_value(),
     ) {
         (_, Value::Null) | (Value::Null, _) => {
             if jump_if_null {
@@ -721,8 +758,16 @@ pub fn op_gt(
                 state.pc += 1;
             }
         }
-        _ => {
-            if *state.registers[lhs].get_owned_value() > *state.registers[rhs].get_owned_value() {
+        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+            let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
+            if order.is_gt() {
+                state.pc = target_pc.to_offset_int();
+            } else {
+                state.pc += 1;
+            }
+        }
+        (lhs, rhs) => {
+            if *lhs > *rhs {
                 state.pc = target_pc.to_offset_int();
             } else {
                 state.pc += 1;
@@ -744,6 +789,7 @@ pub fn op_ge(
         rhs,
         target_pc,
         flags,
+        collation,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -754,8 +800,8 @@ pub fn op_ge(
     let target_pc = *target_pc;
     let jump_if_null = flags.has_jump_if_null();
     match (
-        &state.registers[lhs].get_owned_value(),
-        &state.registers[rhs].get_owned_value(),
+        state.registers[lhs].get_owned_value(),
+        state.registers[rhs].get_owned_value(),
     ) {
         (_, Value::Null) | (Value::Null, _) => {
             if jump_if_null {
@@ -764,8 +810,16 @@ pub fn op_ge(
                 state.pc += 1;
             }
         }
-        _ => {
-            if *state.registers[lhs].get_owned_value() >= *state.registers[rhs].get_owned_value() {
+        (OwnedValue::Text(lhs), OwnedValue::Text(rhs)) => {
+            let order = collation.compare_strings(lhs.as_str(), rhs.as_str());
+            if order.is_ge() {
+                state.pc = target_pc.to_offset_int();
+            } else {
+                state.pc += 1;
+            }
+        }
+        (lhs, rhs) => {
+            if *lhs >= *rhs {
                 state.pc = target_pc.to_offset_int();
             } else {
                 state.pc += 1;

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -141,12 +141,13 @@ pub fn insn_to_str(
                 start_reg_a,
                 start_reg_b,
                 count,
+                collation,
             } => (
                 "Compare",
                 *start_reg_a as i32,
                 *start_reg_b as i32,
                 *count as i32,
-                Value::build_text(""),
+                Value::build_text(&format!("k({count}, {})", collation.unwrap_or_default())),
                 0,
                 format!(
                     "r[{}..{}]==r[{}..{}]",

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -817,28 +817,24 @@ pub fn insn_to_str(
                 start_reg,
                 num_regs,
                 target_pc,
-                collation,
             }
             | Insn::IdxGE {
                 cursor_id,
                 start_reg,
                 num_regs,
                 target_pc,
-                collation,
             }
             | Insn::IdxLE {
                 cursor_id,
                 start_reg,
                 num_regs,
                 target_pc,
-                collation,
             }
             | Insn::IdxLT {
                 cursor_id,
                 start_reg,
                 num_regs,
                 target_pc,
-                collation,
             } => (
                 match insn {
                     Insn::IdxGT { .. } => "IdxGT",
@@ -850,7 +846,7 @@ pub fn insn_to_str(
                 *cursor_id as i32,
                 target_pc.to_debug_int(),
                 *start_reg as i32,
-                Value::build_text(&collation.map_or("".to_string(), |c| c.to_string())),
+                Value::build_text(""),
                 0,
                 format!("key=[{}..{}]", start_reg, start_reg + num_regs - 1),
             ),
@@ -890,20 +886,21 @@ pub fn insn_to_str(
                 cursor_id,
                 columns,
                 order,
-                collation,
+                collations,
             } => {
                 let _p4 = String::new();
                 let to_print: Vec<String> = order
                     .iter()
-                    .enumerate()
-                    .map(|(idx, v)| {
-                        if idx == 0 {
-                            collation.unwrap_or_default().to_string()
+                    .zip(collations.iter())
+                    .map(|(v, collation)| {
+                        let sign = match v {
+                            SortOrder::Asc => "",
+                            SortOrder::Desc => "-",
+                        };
+                        if collation.is_some() {
+                            format!("{sign}{}", collation.unwrap())
                         } else {
-                            match v {
-                                SortOrder::Asc => "B".to_string(),
-                                SortOrder::Desc => "-B".to_string(),
-                            }
+                            format!("{sign}B")
                         }
                     })
                     .collect();

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -817,24 +817,28 @@ pub fn insn_to_str(
                 start_reg,
                 num_regs,
                 target_pc,
+                collation,
             }
             | Insn::IdxGE {
                 cursor_id,
                 start_reg,
                 num_regs,
                 target_pc,
+                collation,
             }
             | Insn::IdxLE {
                 cursor_id,
                 start_reg,
                 num_regs,
                 target_pc,
+                collation,
             }
             | Insn::IdxLT {
                 cursor_id,
                 start_reg,
                 num_regs,
                 target_pc,
+                collation,
             } => (
                 match insn {
                     Insn::IdxGT { .. } => "IdxGT",
@@ -846,7 +850,7 @@ pub fn insn_to_str(
                 *cursor_id as i32,
                 target_pc.to_debug_int(),
                 *start_reg as i32,
-                Value::build_text(""),
+                Value::build_text(&collation.map_or("".to_string(), |c| c.to_string())),
                 0,
                 format!("key=[{}..{}]", start_reg, start_reg + num_regs - 1),
             ),

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -211,13 +211,14 @@ pub fn insn_to_str(
                 lhs,
                 rhs,
                 target_pc,
+                collation,
                 ..
             } => (
                 "Eq",
                 *lhs as i32,
                 *rhs as i32,
                 target_pc.to_debug_int(),
-                Value::build_text(""),
+                Value::build_text(&collation.map_or("".to_string(), |c| c.to_string())),
                 0,
                 format!(
                     "if r[{}]==r[{}] goto {}",
@@ -230,13 +231,14 @@ pub fn insn_to_str(
                 lhs,
                 rhs,
                 target_pc,
+                collation,
                 ..
             } => (
                 "Ne",
                 *lhs as i32,
                 *rhs as i32,
                 target_pc.to_debug_int(),
-                Value::build_text(""),
+                Value::build_text(&collation.map_or("".to_string(), |c| c.to_string())),
                 0,
                 format!(
                     "if r[{}]!=r[{}] goto {}",
@@ -249,13 +251,14 @@ pub fn insn_to_str(
                 lhs,
                 rhs,
                 target_pc,
+                collation,
                 ..
             } => (
                 "Lt",
                 *lhs as i32,
                 *rhs as i32,
                 target_pc.to_debug_int(),
-                Value::build_text(""),
+                Value::build_text(&collation.map_or("".to_string(), |c| c.to_string())),
                 0,
                 format!("if r[{}]<r[{}] goto {}", lhs, rhs, target_pc.to_debug_int()),
             ),
@@ -263,13 +266,14 @@ pub fn insn_to_str(
                 lhs,
                 rhs,
                 target_pc,
+                collation,
                 ..
             } => (
                 "Le",
                 *lhs as i32,
                 *rhs as i32,
                 target_pc.to_debug_int(),
-                Value::build_text(""),
+                Value::build_text(&collation.map_or("".to_string(), |c| c.to_string())),
                 0,
                 format!(
                     "if r[{}]<=r[{}] goto {}",
@@ -282,13 +286,14 @@ pub fn insn_to_str(
                 lhs,
                 rhs,
                 target_pc,
+                collation,
                 ..
             } => (
                 "Gt",
                 *lhs as i32,
                 *rhs as i32,
                 target_pc.to_debug_int(),
-                Value::build_text(""),
+                Value::build_text(&collation.map_or("".to_string(), |c| c.to_string())),
                 0,
                 format!("if r[{}]>r[{}] goto {}", lhs, rhs, target_pc.to_debug_int()),
             ),
@@ -296,13 +301,14 @@ pub fn insn_to_str(
                 lhs,
                 rhs,
                 target_pc,
+                collation,
                 ..
             } => (
                 "Ge",
                 *lhs as i32,
                 *rhs as i32,
                 target_pc.to_debug_int(),
-                Value::build_text(""),
+                Value::build_text(&collation.map_or("".to_string(), |c| c.to_string())),
                 0,
                 format!(
                     "if r[{}]>=r[{}] goto {}",

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -886,14 +886,21 @@ pub fn insn_to_str(
                 cursor_id,
                 columns,
                 order,
+                collation,
             } => {
                 let _p4 = String::new();
-                // TODO: to_print should also print the Collation Sequence
                 let to_print: Vec<String> = order
                     .iter()
-                    .map(|v| match v {
-                        SortOrder::Asc => "B".to_string(),
-                        SortOrder::Desc => "-B".to_string(),
+                    .enumerate()
+                    .map(|(idx, v)| {
+                        if idx == 0 {
+                            collation.unwrap_or_default().to_string()
+                        } else {
+                            match v {
+                                SortOrder::Asc => "B".to_string(),
+                                SortOrder::Desc => "-B".to_string(),
+                            }
+                        }
                     })
                     .collect();
                 (

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -887,6 +887,7 @@ pub fn insn_to_str(
                 order,
             } => {
                 let _p4 = String::new();
+                // TODO: to_print should also print the Collation Sequence
                 let to_print: Vec<String> = order
                     .iter()
                     .map(|v| match v {

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -608,6 +608,7 @@ pub enum Insn {
         cursor_id: CursorID,   // P1
         columns: usize,        // P2
         order: Vec<SortOrder>, // P4.
+        collation: Option<CollationSeq>,
     },
 
     /// Insert a row into the sorter.

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -153,6 +153,7 @@ pub enum Insn {
         start_reg_a: usize,
         start_reg_b: usize,
         count: usize,
+        collation: Option<CollationSeq>,
     },
     /// Place the result of rhs bitwise AND lhs in third register.
     BitAnd {

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -556,6 +556,7 @@ pub enum Insn {
         start_reg: usize,
         num_regs: usize,
         target_pc: BranchOffset,
+        collation: Option<CollationSeq>,
     },
 
     /// The P4 register values beginning with P3 form an unpacked index key that omits the PRIMARY KEY. Compare this key value against the index that P1 is currently pointing to, ignoring the PRIMARY KEY or ROWID fields at the end.
@@ -565,6 +566,7 @@ pub enum Insn {
         start_reg: usize,
         num_regs: usize,
         target_pc: BranchOffset,
+        collation: Option<CollationSeq>,
     },
 
     /// The P4 register values beginning with P3 form an unpacked index key that omits the PRIMARY KEY. Compare this key value against the index that P1 is currently pointing to, ignoring the PRIMARY KEY or ROWID fields at the end.
@@ -574,6 +576,7 @@ pub enum Insn {
         start_reg: usize,
         num_regs: usize,
         target_pc: BranchOffset,
+        collation: Option<CollationSeq>,
     },
 
     /// The P4 register values beginning with P3 form an unpacked index key that omits the PRIMARY KEY. Compare this key value against the index that P1 is currently pointing to, ignoring the PRIMARY KEY or ROWID fields at the end.
@@ -583,6 +586,7 @@ pub enum Insn {
         start_reg: usize,
         num_regs: usize,
         target_pc: BranchOffset,
+        collation: Option<CollationSeq>,
     },
 
     /// Decrement the given register and jump to the given PC if the result is zero.

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -556,7 +556,6 @@ pub enum Insn {
         start_reg: usize,
         num_regs: usize,
         target_pc: BranchOffset,
-        collation: Option<CollationSeq>,
     },
 
     /// The P4 register values beginning with P3 form an unpacked index key that omits the PRIMARY KEY. Compare this key value against the index that P1 is currently pointing to, ignoring the PRIMARY KEY or ROWID fields at the end.
@@ -566,7 +565,6 @@ pub enum Insn {
         start_reg: usize,
         num_regs: usize,
         target_pc: BranchOffset,
-        collation: Option<CollationSeq>,
     },
 
     /// The P4 register values beginning with P3 form an unpacked index key that omits the PRIMARY KEY. Compare this key value against the index that P1 is currently pointing to, ignoring the PRIMARY KEY or ROWID fields at the end.
@@ -576,7 +574,6 @@ pub enum Insn {
         start_reg: usize,
         num_regs: usize,
         target_pc: BranchOffset,
-        collation: Option<CollationSeq>,
     },
 
     /// The P4 register values beginning with P3 form an unpacked index key that omits the PRIMARY KEY. Compare this key value against the index that P1 is currently pointing to, ignoring the PRIMARY KEY or ROWID fields at the end.
@@ -586,7 +583,6 @@ pub enum Insn {
         start_reg: usize,
         num_regs: usize,
         target_pc: BranchOffset,
-        collation: Option<CollationSeq>,
     },
 
     /// Decrement the given register and jump to the given PC if the result is zero.
@@ -609,10 +605,10 @@ pub enum Insn {
 
     /// Open a sorter.
     SorterOpen {
-        cursor_id: CursorID,   // P1
-        columns: usize,        // P2
-        order: Vec<SortOrder>, // P4.
-        collation: Option<CollationSeq>,
+        cursor_id: CursorID,                   // P1
+        columns: usize,                        // P2
+        order: Vec<SortOrder>,                 // P4.
+        collations: Vec<Option<CollationSeq>>, // The only reason for using Option<CollationSeq> is so the explain message is the same as in SQLite
     },
 
     /// Insert a row into the sorter.

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -8,6 +8,7 @@ use super::{execute, AggFunc, BranchOffset, CursorID, FuncCtx, InsnFunction, Pag
 use crate::{
     schema::{BTreeTable, Index},
     storage::{pager::CreateBTreeFlags, wal::CheckpointMode},
+    translate::collate::CollationSeq,
 };
 use limbo_macros::Description;
 use limbo_sqlite3_parser::ast::SortOrder;
@@ -218,6 +219,7 @@ pub enum Insn {
         /// Without the jump_if_null flag it would not jump because the logical comparison "id != NULL" is never true.
         /// This flag indicates that if either is null we should still jump.
         flags: CmpInsFlags,
+        collation: CollationSeq,
     },
     /// Compare two registers and jump to the given PC if they are not equal.
     Ne {
@@ -228,6 +230,7 @@ pub enum Insn {
         ///
         /// jump_if_null jumps if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
+        collation: CollationSeq,
     },
     /// Compare two registers and jump to the given PC if the left-hand side is less than the right-hand side.
     Lt {
@@ -236,6 +239,7 @@ pub enum Insn {
         target_pc: BranchOffset,
         /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
+        collation: CollationSeq,
     },
     // Compare two registers and jump to the given PC if the left-hand side is less than or equal to the right-hand side.
     Le {
@@ -244,6 +248,7 @@ pub enum Insn {
         target_pc: BranchOffset,
         /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
+        collation: CollationSeq,
     },
     /// Compare two registers and jump to the given PC if the left-hand side is greater than the right-hand side.
     Gt {
@@ -252,6 +257,7 @@ pub enum Insn {
         target_pc: BranchOffset,
         /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
+        collation: CollationSeq,
     },
     /// Compare two registers and jump to the given PC if the left-hand side is greater than or equal to the right-hand side.
     Ge {
@@ -260,6 +266,7 @@ pub enum Insn {
         target_pc: BranchOffset,
         /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
+        collation: CollationSeq,
     },
     /// Jump to target_pc if r\[reg\] != 0 or (r\[reg\] == NULL && r\[jump_if_null\] != 0)
     If {

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -219,7 +219,7 @@ pub enum Insn {
         /// Without the jump_if_null flag it would not jump because the logical comparison "id != NULL" is never true.
         /// This flag indicates that if either is null we should still jump.
         flags: CmpInsFlags,
-        collation: CollationSeq,
+        collation: Option<CollationSeq>,
     },
     /// Compare two registers and jump to the given PC if they are not equal.
     Ne {
@@ -230,7 +230,7 @@ pub enum Insn {
         ///
         /// jump_if_null jumps if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
-        collation: CollationSeq,
+        collation: Option<CollationSeq>,
     },
     /// Compare two registers and jump to the given PC if the left-hand side is less than the right-hand side.
     Lt {
@@ -239,7 +239,7 @@ pub enum Insn {
         target_pc: BranchOffset,
         /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
-        collation: CollationSeq,
+        collation: Option<CollationSeq>,
     },
     // Compare two registers and jump to the given PC if the left-hand side is less than or equal to the right-hand side.
     Le {
@@ -248,7 +248,7 @@ pub enum Insn {
         target_pc: BranchOffset,
         /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
-        collation: CollationSeq,
+        collation: Option<CollationSeq>,
     },
     /// Compare two registers and jump to the given PC if the left-hand side is greater than the right-hand side.
     Gt {
@@ -257,7 +257,7 @@ pub enum Insn {
         target_pc: BranchOffset,
         /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
-        collation: CollationSeq,
+        collation: Option<CollationSeq>,
     },
     /// Compare two registers and jump to the given PC if the left-hand side is greater than or equal to the right-hand side.
     Ge {
@@ -266,7 +266,7 @@ pub enum Insn {
         target_pc: BranchOffset,
         /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
         flags: CmpInsFlags,
-        collation: CollationSeq,
+        collation: Option<CollationSeq>,
     },
     /// Jump to target_pc if r\[reg\] != 0 or (r\[reg\] == NULL && r\[jump_if_null\] != 0)
     If {

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1,21 +1,26 @@
 use limbo_sqlite3_parser::ast::SortOrder;
 
-use crate::types::{compare_immutable, ImmutableRecord, IndexKeySortOrder};
+use crate::{
+    translate::collate::CollationSeq,
+    types::{compare_immutable, ImmutableRecord, IndexKeySortOrder},
+};
 
 pub struct Sorter {
     records: Vec<ImmutableRecord>,
     current: Option<ImmutableRecord>,
     order: IndexKeySortOrder,
     key_len: usize,
+    collation: CollationSeq,
 }
 
 impl Sorter {
-    pub fn new(order: &[SortOrder]) -> Self {
+    pub fn new(order: &[SortOrder], collation: CollationSeq) -> Self {
         Self {
             records: Vec::new(),
             current: None,
             key_len: order.len(),
             order: IndexKeySortOrder::from_list(order),
+            collation,
         }
     }
     pub fn is_empty(&self) -> bool {
@@ -33,6 +38,7 @@ impl Sorter {
                 &a.values[..self.key_len],
                 &b.values[..self.key_len],
                 self.order,
+                self.collation,
             )
         });
         self.records.reverse();

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -10,17 +10,17 @@ pub struct Sorter {
     current: Option<ImmutableRecord>,
     order: IndexKeySortOrder,
     key_len: usize,
-    collation: CollationSeq,
+    collations: Vec<CollationSeq>,
 }
 
 impl Sorter {
-    pub fn new(order: &[SortOrder], collation: CollationSeq) -> Self {
+    pub fn new(order: &[SortOrder], collations: Vec<CollationSeq>) -> Self {
         Self {
             records: Vec::new(),
             current: None,
             key_len: order.len(),
             order: IndexKeySortOrder::from_list(order),
-            collation,
+            collations,
         }
     }
     pub fn is_empty(&self) -> bool {
@@ -38,7 +38,7 @@ impl Sorter {
                 &a.values[..self.key_len],
                 &b.values[..self.key_len],
                 self.order,
-                self.collation,
+                &self.collations,
             )
         });
         self.records.reverse();

--- a/testing/all.test
+++ b/testing/all.test
@@ -34,3 +34,4 @@ source $testdir/boolean.test
 source $testdir/literal.test
 source $testdir/null.test
 source $testdir/create_table.test
+source $testdir/collate.test

--- a/testing/cli_tests/collate.py
+++ b/testing/cli_tests/collate.py
@@ -67,17 +67,23 @@ class CollateTest(BaseModel):
             "SELECT x FROM t1 WHERE a = d ORDER BY x;",
             "\n".join(map(lambda x: str(x), [1, 4])),
         )
-        
+
         limbo.run_test(
             "Text comparison 'abc'=c is performed using the RTRIM collating sequence.",
             "SELECT x FROM t1 WHERE 'abc' = c ORDER BY x;",
             "\n".join(map(lambda x: str(x), [1, 2, 3])),
         )
-        
+
         limbo.run_test(
             "Text comparison c='abc' is performed using the RTRIM collating sequence.",
             "SELECT x FROM t1 WHERE c = 'abc' ORDER BY x;",
             "\n".join(map(lambda x: str(x), [1, 2, 3])),
+        )
+
+        limbo.run_test(
+            " Grouping is performed using the NOCASE collating sequence (Values 'abc', 'ABC', and 'Abc' are placed in the same group).",
+            "SELECT count(*) FROM t1 GROUP BY d ORDER BY 1;",
+            "\n".join(map(lambda x: str(x), [4])),
         )
 
 

--- a/testing/cli_tests/collate.py
+++ b/testing/cli_tests/collate.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import os
+from cli_tests.test_limbo_cli import TestLimboShell
+from pydantic import BaseModel
+from cli_tests import console
+
+
+sqlite_flags = os.getenv("SQLITE_FLAGS", "-q").split(" ")
+
+
+class CollateTest(BaseModel):
+    name: str
+    db_schema: str = """CREATE TABLE t1(
+        x INTEGER PRIMARY KEY,
+        a,                 /* collating sequence BINARY */
+        b COLLATE BINARY,  /* collating sequence BINARY */
+        c COLLATE RTRIM,   /* collating sequence RTRIM  */
+        d COLLATE NOCASE   /* collating sequence NOCASE */
+    );"""
+    db_path: str = "testing/collate.db"
+
+    def init_db(self):
+        with TestLimboShell(
+            init_commands="",
+            exec_name="sqlite3",
+            flags=f"{self.db_path}",
+        ) as sqlite:
+            sqlite.execute_dot(f".open {self.db_path}")
+            stmt = [self.db_schema]
+            stmt = stmt + [
+                "INSERT INTO t1 VALUES(1,'abc','abc', 'abc  ','abc');",
+                "INSERT INTO t1 VALUES(2,'abc','abc', 'abc',  'ABC');",
+                "INSERT INTO t1 VALUES(3,'abc','abc', 'abc ', 'Abc');",
+                "INSERT INTO t1 VALUES(4,'abc','abc ','ABC',  'abc');",
+            ]
+            stmt.append("SELECT count(*) FROM t1;")
+
+            sqlite.run_test(
+                "Init Collate Db in Sqlite",
+                "".join(stmt),
+                f"{4}",
+            )
+
+    def run(self, limbo: TestLimboShell):
+        limbo.execute_dot(f".open {self.db_path}")
+
+        limbo.run_test(
+            "Text comparison a=b is performed using the BINARY collating sequence",
+            "SELECT x FROM t1 WHERE a = b ORDER BY x;",
+            "\n".join(map(lambda x: str(x), [1, 2, 3])),
+        )
+
+        limbo.run_test(
+            "Text comparison a=b is performed using the RTRIM collating sequence",
+            "SELECT x FROM t1 WHERE a = b COLLATE RTRIM ORDER BY x;",
+            "\n".join(map(lambda x: str(x), [1, 2, 3, 4])),
+        )
+
+        limbo.run_test(
+            "Text comparison d=a is performed using the NOCASE collating sequence",
+            "SELECT x FROM t1 WHERE d = a ORDER BY x;",
+            "\n".join(map(lambda x: str(x), [1, 2, 3, 4])),
+        )
+
+        limbo.run_test(
+            "Text comparison a=d is performed using the BINARY collating sequence.",
+            "SELECT x FROM t1 WHERE a = d ORDER BY x;",
+            "\n".join(map(lambda x: str(x), [1, 4])),
+        )
+
+
+def cleanup(db_fullpath: str):
+    wal_path = f"{db_fullpath}-wal"
+    shm_path = f"{db_fullpath}-shm"
+    paths = [db_fullpath, wal_path, shm_path]
+    for path in paths:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def main():
+    # Test from using examples from Section 7.2
+    # https://sqlite.org/datatype3.html#collation
+    test = CollateTest(name="Smoke collate tests")
+    console.info(test)
+
+    db_path = test.db_path
+    try:
+        test.init_db()
+        # Use with syntax to automatically close shell on error
+        with TestLimboShell("") as limbo:
+            test.run(limbo)
+
+        # test.test_compat()
+    except Exception as e:
+        console.error(f"Test FAILED: {e}")
+        cleanup(db_path)
+        exit(1)
+    # delete db after every compat test so we we have fresh db for next test
+    cleanup(db_path)
+    console.info("All tests passed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/cli_tests/collate.py
+++ b/testing/cli_tests/collate.py
@@ -81,9 +81,21 @@ class CollateTest(BaseModel):
         )
 
         limbo.run_test(
-            " Grouping is performed using the NOCASE collating sequence (Values 'abc', 'ABC', and 'Abc' are placed in the same group).",
+            "Grouping is performed using the NOCASE collating sequence (Values 'abc', 'ABC', and 'Abc' are placed in the same group).",
             "SELECT count(*) FROM t1 GROUP BY d ORDER BY 1;",
             "\n".join(map(lambda x: str(x), [4])),
+        )
+
+        limbo.run_test(
+            "Grouping is performed using the BINARY collating sequence. 'abc' and 'ABC' and 'Abc' form different groups",
+            "SELECT count(*) FROM t1 GROUP BY (d || '') ORDER BY 1;",
+            "\n".join(map(lambda x: str(x), [1, 1, 2])),
+        )
+        
+        limbo.run_test(
+            "Sorting or column c is performed using the RTRIM collating sequence.",
+            "SELECT x FROM t1 ORDER BY c, x;",
+            "\n".join(map(lambda x: str(x), [4, 1, 2, 3])),
         )
 
 

--- a/testing/cli_tests/collate.py
+++ b/testing/cli_tests/collate.py
@@ -91,11 +91,23 @@ class CollateTest(BaseModel):
             "SELECT count(*) FROM t1 GROUP BY (d || '') ORDER BY 1;",
             "\n".join(map(lambda x: str(x), [1, 1, 2])),
         )
-        
+
         limbo.run_test(
             "Sorting or column c is performed using the RTRIM collating sequence.",
             "SELECT x FROM t1 ORDER BY c, x;",
             "\n".join(map(lambda x: str(x), [4, 1, 2, 3])),
+        )
+
+        limbo.run_test(
+            "Sorting of (c||'') is performed using the BINARY collating sequence.",
+            "SELECT x FROM t1 ORDER BY (c||''), x;",
+            "\n".join(map(lambda x: str(x), [4, 2, 3, 1])),
+        )
+
+        limbo.run_test(
+            "Sorting of column c is performed using the NOCASE collating sequence.",
+            "SELECT x FROM t1 ORDER BY c COLLATE NOCASE, x;",
+            "\n".join(map(lambda x: str(x), [2, 4, 3, 1])),
         )
 
 

--- a/testing/cli_tests/collate.py
+++ b/testing/cli_tests/collate.py
@@ -67,6 +67,18 @@ class CollateTest(BaseModel):
             "SELECT x FROM t1 WHERE a = d ORDER BY x;",
             "\n".join(map(lambda x: str(x), [1, 4])),
         )
+        
+        limbo.run_test(
+            "Text comparison 'abc'=c is performed using the RTRIM collating sequence.",
+            "SELECT x FROM t1 WHERE 'abc' = c ORDER BY x;",
+            "\n".join(map(lambda x: str(x), [1, 2, 3])),
+        )
+        
+        limbo.run_test(
+            "Text comparison c='abc' is performed using the RTRIM collating sequence.",
+            "SELECT x FROM t1 WHERE c = 'abc' ORDER BY x;",
+            "\n".join(map(lambda x: str(x), [1, 2, 3])),
+        )
 
 
 def cleanup(db_fullpath: str):

--- a/testing/collate.test
+++ b/testing/collate.test
@@ -18,12 +18,20 @@ do_execsql_test collate-binary-2 {
 } {1}
 
 do_execsql_test collate-rtrim-1 {
-    SELECT 'hat' == ' hAt ' COLLATE RTRIM;
+    SELECT 'hat' == 'hAt ' COLLATE RTRIM;
 } {0}
 
 do_execsql_test collate-rtrim-2 {
-    SELECT 'hat' == ' hat ' COLLATE RTRIM;
+    SELECT 'hat' == 'hat ' COLLATE RTRIM;
 } {1}
+
+do_execsql_test collate-rtrim-3 {
+    SELECT 'hat' == ' hAt ' COLLATE RTRIM;
+} {0}
+
+do_execsql_test collate-rtrim-4 {
+    SELECT 'hat' == ' hat ' COLLATE RTRIM;
+} {0}
 
 do_execsql_test collate-left-precedence {
     SELECT 'hat' COLLATE BINARY == 'hAt' COLLATE NOCASE;

--- a/testing/collate.test
+++ b/testing/collate.test
@@ -25,6 +25,10 @@ do_execsql_test collate-rtrim-2 {
     SELECT 'hat' == ' hat ' COLLATE RTRIM;
 } {1}
 
-do_execsql_test collate-2 {
-    SELECT 'hat' == 'hat' COLLATE NOCASE;
+do_execsql_test collate-left-precedence {
+    SELECT 'hat' COLLATE BINARY == 'hAt' COLLATE NOCASE;
+} {0}
+
+do_execsql_test collate-left-precedence-2 {
+    SELECT 'hat' COLLATE NOCASE == 'hAt' COLLATE BINARY;
 } {1}

--- a/testing/collate.test
+++ b/testing/collate.test
@@ -1,0 +1,30 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# SIMPLE SMOKE TESTS THAT DO NOT DEPEND ON SPECIFIC DATABASE ROWS
+
+do_execsql_test collate-nocase {
+    SELECT 'hat' == 'hAt' COLLATE NOCASE;
+} {1}
+
+do_execsql_test collate-binary-1 {
+    SELECT 'hat' == 'hAt' COLLATE BINARY;
+} {0}
+
+do_execsql_test collate-binary-2 {
+    SELECT 'hat' == 'hat' COLLATE BINARY;
+} {1}
+
+do_execsql_test collate-rtrim-1 {
+    SELECT 'hat' == ' hAt ' COLLATE RTRIM;
+} {0}
+
+do_execsql_test collate-rtrim-2 {
+    SELECT 'hat' == ' hat ' COLLATE RTRIM;
+} {1}
+
+do_execsql_test collate-2 {
+    SELECT 'hat' == 'hat' COLLATE NOCASE;
+} {1}

--- a/testing/collate.test
+++ b/testing/collate.test
@@ -45,3 +45,8 @@ do_execsql_test_in_memory_any_error collate_unique_constraint {
     CREATE TABLE t(a TEXT COLLATE NOCASE PRIMARY KEY);
     INSERT INTO t VALUES ('lol'), ('LOL'), ('lOl');
 }
+
+do_execsql_test_in_memory_any_error collate_unique_constraint {
+    CREATE TABLE t(a TEXT COLLATE NOCASE PRIMARY KEY);
+    INSERT INTO t VALUES ('lol'), ('LOL'), ('lOl');
+}

--- a/testing/collate.test
+++ b/testing/collate.test
@@ -41,7 +41,7 @@ do_execsql_test collate_left_precedence_2 {
     SELECT 'hat' COLLATE NOCASE == 'hAt' COLLATE BINARY;
 } {1}
 
-do_execsql_test_in_memory_error_content collate_unique_constraint {
+do_execsql_test_in_memory_any_error collate_unique_constraint {
     CREATE TABLE t(a TEXT COLLATE NOCASE PRIMARY KEY);
     INSERT INTO t VALUES ('lol'), ('LOL'), ('lOl');
-} {Runtime error: UNIQUE constraint failed: t.a (19)}
+}

--- a/testing/collate.test
+++ b/testing/collate.test
@@ -5,38 +5,43 @@ source $testdir/tester.tcl
 
 # SIMPLE SMOKE TESTS THAT DO NOT DEPEND ON SPECIFIC DATABASE ROWS
 
-do_execsql_test collate-nocase {
+do_execsql_test collate_nocase {
     SELECT 'hat' == 'hAt' COLLATE NOCASE;
 } {1}
 
-do_execsql_test collate-binary-1 {
+do_execsql_test collate_binary_1 {
     SELECT 'hat' == 'hAt' COLLATE BINARY;
 } {0}
 
-do_execsql_test collate-binary-2 {
+do_execsql_test collate_binary_2 {
     SELECT 'hat' == 'hat' COLLATE BINARY;
 } {1}
 
-do_execsql_test collate-rtrim-1 {
+do_execsql_test collate_rtrim_1 {
     SELECT 'hat' == 'hAt ' COLLATE RTRIM;
 } {0}
 
-do_execsql_test collate-rtrim-2 {
+do_execsql_test collate_rtrim_2 {
     SELECT 'hat' == 'hat ' COLLATE RTRIM;
 } {1}
 
-do_execsql_test collate-rtrim-3 {
+do_execsql_test collate_rtrim_3 {
     SELECT 'hat' == ' hAt ' COLLATE RTRIM;
 } {0}
 
-do_execsql_test collate-rtrim-4 {
+do_execsql_test collate_rtrim_4 {
     SELECT 'hat' == ' hat ' COLLATE RTRIM;
 } {0}
 
-do_execsql_test collate-left-precedence {
+do_execsql_test collate_left_precedence {
     SELECT 'hat' COLLATE BINARY == 'hAt' COLLATE NOCASE;
 } {0}
 
-do_execsql_test collate-left-precedence-2 {
+do_execsql_test collate_left_precedence_2 {
     SELECT 'hat' COLLATE NOCASE == 'hAt' COLLATE BINARY;
 } {1}
+
+do_execsql_test_in_memory_error_content collate_unique_constraint {
+    CREATE TABLE t(a TEXT COLLATE NOCASE PRIMARY KEY);
+    INSERT INTO t VALUES ('lol'), ('LOL'), ('lOl');
+} {Runtime error: UNIQUE constraint failed: t.a (19)}

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -15,13 +15,9 @@ test-shell = "cli_tests.cli_test_cases:main"
 test-extensions = "cli_tests.extensions:main"
 test-update = "cli_tests.update:main"
 test-memory = "cli_tests.memory:main"
-<<<<<<< HEAD
 bench-vfs = "cli_tests.vfs_bench:main"
 test-constraint = "cli_tests.constraint:main"
-||||||| parent of b9e03a19 (Removed repeated binary expression translation. Adjusted the set_collation to capture additional context of whether it was set by a Collate expression or not. Added some tests to prove those modifications were necessary.)
-=======
 test-collate = "cli_tests.collate:main"
->>>>>>> b9e03a19 (Removed repeated binary expression translation. Adjusted the set_collation to capture additional context of whether it was set by a Collate expression or not. Added some tests to prove those modifications were necessary.)
 
 [tool.uv]
 package = true

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -15,8 +15,13 @@ test-shell = "cli_tests.cli_test_cases:main"
 test-extensions = "cli_tests.extensions:main"
 test-update = "cli_tests.update:main"
 test-memory = "cli_tests.memory:main"
+<<<<<<< HEAD
 bench-vfs = "cli_tests.vfs_bench:main"
 test-constraint = "cli_tests.constraint:main"
+||||||| parent of b9e03a19 (Removed repeated binary expression translation. Adjusted the set_collation to capture additional context of whether it was set by a Collate expression or not. Added some tests to prove those modifications were necessary.)
+=======
+test-collate = "cli_tests.collate:main"
+>>>>>>> b9e03a19 (Removed repeated binary expression translation. Adjusted the set_collation to capture additional context of whether it was set by a Collate expression or not. Added some tests to prove those modifications were necessary.)
 
 [tool.uv]
 package = true

--- a/testing/tester.tcl
+++ b/testing/tester.tcl
@@ -226,3 +226,13 @@ proc do_execsql_test_in_memory_any_error {test_name sql_statements} {
     set combined_sql [string trim $sql_statements]
     run_test_expecting_any_error $::sqlite_exec $db_name $combined_sql
 }
+
+proc do_execsql_test_in_memory_error_content {test_name sql_statements expected_error_text} {
+    test_put "Running error content test" in-memory $test_name
+
+    # Use ":memory:" special filename for in-memory database
+    set db_name ":memory:"
+
+    set combined_sql [string trim $sql_statements]
+    run_test_expecting_error_content $::sqlite_exec $db_name $combined_sql $expected_error_text
+}

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -1220,6 +1220,7 @@ mod tests {
             );
             let query = format!("INSERT INTO t VALUES ({}, {}, {})", x, y, z);
             log::info!("insert: {}", query);
+            dbg!(&query);
             assert_eq!(
                 limbo_exec_rows(&db, &limbo_conn, &query),
                 sqlite_exec_rows(&sqlite_conn, &query),

--- a/vendored/sqlite3-parser/Cargo.toml
+++ b/vendored/sqlite3-parser/Cargo.toml
@@ -32,8 +32,8 @@ bitflags = "2.0"
 uncased = "0.9.10"
 indexmap = "2.0"
 miette = "7.4.0"
-strum = { version = "0.26", features = ["derive"] }
-strum_macros = "0.26"
+strum = { workspace = true }
+strum_macros = {workspace = true }
 
 [dev-dependencies]
 env_logger = { version = "0.11", default-features = false }


### PR DESCRIPTION
I was implementing `ALTER TABLE .. RENAME TO`, and I noticed that `COLLATE` was necessary for it to work. 

This is a relatively big PR as to properly implement `COLLATE`, I needed to add a field to a couple of instructions that are emitted frequently, and there is a lot of boilerplate that is required when you do such a change. 

My main source of reference was this site from SQLite: https://sqlite.org/datatype3.html#collation. It gives a good description of the precedence of collation in certain expressions. 

I did write a couple of tests that I thought caught the edges cases of `COLLATE`, but honestly, I may have missed a few. I would appreciate some help later to write more tests. 

`Collate` basically just compares two `TEXT` values according to some comparison function. If both values are not `TEXT`, just fallback to the normal comparison we are already doing. `Collate` happens in four main places: 
- `Collate` Expression modifier
- `Binary` Expression
- `Column` Expression
- `Order By` and `Group By`

In `Binary`, `Order By`, `Group By` expressions, the collation sequence for the comparisons can be derived from explicitly with the use of `COLLATE` keyword, or implicitly if there is a `COLLATE` definition in `CREATE TABLE`. If neither are present it defaults to `Binary` collation.

For the `Column` expression, it tries to use collation in `CREATE TABLE` column definition. If not present it defaults to `Binary` collation. 

Lastly, there was some repetition on how the `Binary` expression was being translated, so I removed that part. As mentioned in the `COMPAT.md`, I did not implement custom collation sequences yet, as it would deter me from properly implementing. I have some ideas of how I can extend my current implementation to support that with FFI, but I think that is best served for a different PR. 