### PR TITLE
Page cache fixes, error handling, refactor, and proper testing

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -8,6 +8,8 @@ pub enum LimboError {
     NotADB,
     #[error("Internal error: {0}")]
     InternalError(String),
+    #[error("Page cache is full")]
+    CacheFull,
     #[error("Parse error: {0}")]
     ParseError(String),
     #[error(transparent)]

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2365,6 +2365,7 @@ impl BTreeCursor {
                         balance_info.pages_to_balance[i].set_dirty();
                         pages_to_balance_new.push(balance_info.pages_to_balance[i].clone());
                     } else {
+                        // FIXME: handle page cache is full
                         let page = self.pager.do_allocate_page(page_type, 0);
                         pages_to_balance_new.push(page);
                         // Since this page didn't exist before, we can set it to cells length as it
@@ -3203,6 +3204,7 @@ impl BTreeCursor {
 
         let root = self.stack.top();
         let root_contents = root.get_contents();
+        // FIXME: handle page cache is full
         let child = self.pager.do_allocate_page(root_contents.page_type(), 0);
 
         tracing::debug!(
@@ -5065,6 +5067,7 @@ fn fill_cell_payload(
         }
 
         // we still have bytes to add, we will need to allocate new overflow page
+        // FIXME: handle page cache is full
         let overflow_page = pager.allocate_overflow_page();
         overflow_pages.push(overflow_page.clone());
         {
@@ -5496,6 +5499,7 @@ mod tests {
             Pager::finish_open(db_header, db_file, Some(wal), io, page_cache, buffer_pool).unwrap()
         };
         let pager = Rc::new(pager);
+        // FIXME: handle page cache is full
         let page1 = pager.allocate_page().unwrap();
         btree_init_page(&page1, PageType::TableLeaf, 0, 4096);
         (pager, page1.get().id)
@@ -5984,9 +5988,11 @@ mod tests {
         }
 
         // Allocate two leaf pages
+        // FIXME: handle page cache is full
         let page3 = cursor.pager.allocate_page()?;
         btree_init_page(&page3, PageType::TableLeaf, 0, 512);
 
+        // FIXME: handle page cache is full
         let page4 = cursor.pager.allocate_page()?;
         btree_init_page(&page4, PageType::TableLeaf, 0, 512);
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2383,10 +2383,11 @@ impl BTreeCursor {
                 for (page, new_id) in pages_to_balance_new.iter().zip(page_numbers) {
                     if new_id != page.get().id {
                         page.get().id = new_id;
-                        self.pager.put_loaded_page(new_id, page.clone());
+                        // FIXME: why would there be another page at this id/frame?
+                        self.pager.put_loaded_page(new_id, page.clone())
+                            .expect("put_loaded_page should not fail here");
                     }
                 }
-
                 #[cfg(debug_assertions)]
                 {
                     tracing::debug!("balance_non_root(parent page_id={})", parent_page.get().id);

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -1,5 +1,6 @@
 use std::{cell::RefCell, collections::HashMap, ptr::NonNull};
 
+use std::sync::Arc;
 use tracing::{debug, trace};
 
 use super::pager::PageRef;
@@ -40,6 +41,13 @@ pub struct DumbLruPageCache {
 unsafe impl Send for DumbLruPageCache {}
 unsafe impl Sync for DumbLruPageCache {}
 
+#[derive(Debug, PartialEq)]
+pub enum CacheError {
+    Locked,
+    Dirty,
+    ActiveRefs,
+}
+
 impl PageCacheKey {
     pub fn new(pgno: usize, max_frame: Option<u64>) -> Self {
         Self { pgno, max_frame }
@@ -59,9 +67,13 @@ impl DumbLruPageCache {
         self.map.borrow().contains_key(key)
     }
 
-    pub fn insert(&mut self, key: PageCacheKey, value: PageRef) {
-        self._delete(key.clone(), false);
+    pub fn insert(&mut self, key: PageCacheKey, value: PageRef) -> Result<(), CacheError> {
         trace!("cache_insert(key={:?})", key);
+        self._delete(key.clone(), false)?;
+        if self.len() >= self.capacity {
+            // Make room before trying to insert
+            self.pop_if_not_dirty()?;
+        }
         let entry = Box::new(PageCacheEntry {
             key: key.clone(),
             next: None,
@@ -73,24 +85,26 @@ impl DumbLruPageCache {
         self.touch(ptr);
 
         self.map.borrow_mut().insert(key, ptr);
-        if self.len() > self.capacity {
-            self.pop_if_not_dirty();
-        }
+        Ok(())
     }
 
-    pub fn delete(&mut self, key: PageCacheKey) {
+    pub fn delete(&mut self, key: PageCacheKey) -> Result<(), CacheError> {
         trace!("cache_delete(key={:?})", key);
         self._delete(key, true)
     }
 
-    pub fn _delete(&mut self, key: PageCacheKey, clean_page: bool) {
-        let ptr = self.map.borrow_mut().remove(&key);
-        if ptr.is_none() {
-            return;
+    // Returns Ok if key is not found
+    pub fn _delete(&mut self, key: PageCacheKey, clean_page: bool) -> Result<(), CacheError> {
+        if !self.contains_key(&key) {
+            return Ok(());
         }
-        let ptr = ptr.unwrap();
-        self.detach(ptr, clean_page);
+
+        let ptr = *self.map.borrow().get(&key).unwrap();
+        // Try to detach from LRU list first, can fail
+        self.detach(ptr, clean_page)?;
+        let ptr = self.map.borrow_mut().remove(&key).unwrap();
         unsafe { std::ptr::drop_in_place(ptr.as_ptr()) };
+        Ok(())
     }
 
     fn get_ptr(&mut self, key: &PageCacheKey) -> Option<NonNull<PageCacheEntry>> {
@@ -120,15 +134,35 @@ impl DumbLruPageCache {
         todo!();
     }
 
-    fn detach(&mut self, mut entry: NonNull<PageCacheEntry>, clean_page: bool) {
+    fn detach(
+        &mut self,
+        mut entry: NonNull<PageCacheEntry>,
+        clean_page: bool,
+    ) -> Result<(), CacheError> {
+        let entry_mut = unsafe { entry.as_mut() };
+        if entry_mut.page.is_locked() {
+            return Err(CacheError::Locked);
+        }
+        if entry_mut.page.is_dirty() {
+            return Err(CacheError::Dirty);
+        }
+
         if clean_page {
-            // evict buffer
-            let page = unsafe { &entry.as_mut().page };
-            page.clear_loaded();
-            debug!("cleaning up page {}", page.get().id);
-            let _ = page.get().contents.take();
+            if let Some(page_mut) = Arc::get_mut(&mut entry_mut.page) {
+                page_mut.clear_loaded();
+                debug!("cleaning up page {}", page_mut.get().id);
+                let _ = page_mut.get().contents.take();
+            } else {
+                let page_id = unsafe { &entry.as_mut().page.get().id };
+                debug!(
+                    "detach page {}: can't clean, there are other references",
+                    page_id
+                );
+                return Err(CacheError::ActiveRefs);
+            }
         }
         self.unlink(entry);
+        Ok(())
     }
 
     fn unlink(&mut self, mut entry: NonNull<PageCacheEntry>) {
@@ -179,27 +213,33 @@ impl DumbLruPageCache {
         self.head.borrow_mut().replace(entry);
     }
 
-    fn pop_if_not_dirty(&mut self) {
+    fn pop_if_not_dirty(&mut self) -> Result<(), CacheError> {
         let tail = *self.tail.borrow();
         if tail.is_none() {
-            return;
+            return Ok(());
         }
+
         let mut tail = tail.unwrap();
         let tail_entry = unsafe { tail.as_mut() };
-        if tail_entry.page.is_dirty() {
-            // TODO: drop from another clean entry?
-            return;
-        }
         tracing::debug!("pop_if_not_dirty(key={:?})", tail_entry.key);
-        self.detach(tail, true);
-        assert!(self.map.borrow_mut().remove(&tail_entry.key).is_some());
+        let key = tail_entry.key.clone();
+
+        // TODO: drop from another clean entry?
+        self.detach(tail, true)?;
+
+        assert!(self.map.borrow_mut().remove(&key).is_some());
+        Ok(())
     }
 
-    pub fn clear(&mut self) {
-        let to_remove: Vec<PageCacheKey> = self.map.borrow().iter().map(|v| v.0.clone()).collect();
-        for key in to_remove {
-            self.delete(key);
+    pub fn clear(&mut self) -> Result<(), CacheError> {
+        let keys_to_remove: Vec<PageCacheKey> = self.map.borrow().keys().cloned().collect();
+        for key in keys_to_remove {
+            self.delete(key)?;
         }
+        assert!(self.head.borrow().is_none());
+        assert!(self.tail.borrow().is_none());
+        assert!(self.map.borrow().is_empty());
+        Ok(())
     }
 
     pub fn print(&mut self) {
@@ -342,6 +382,7 @@ impl DumbLruPageCache {
 mod tests {
     use super::*;
     use crate::io::{Buffer, BufferData};
+    use crate::storage::page_cache::CacheError;
     use crate::storage::pager::{Page, PageRef};
     use crate::storage::sqlite3_ondisk::PageContent;
     use std::{cell::RefCell, num::NonZeroUsize, pin::Pin, rc::Rc, sync::Arc};
@@ -375,12 +416,23 @@ mod tests {
     fn insert_page(cache: &mut DumbLruPageCache, id: usize) -> PageCacheKey {
         let key = create_key(id);
         let page = page_with_content(id);
-        cache.insert(key.clone(), page);
+        assert!(cache.insert(key.clone(), page).is_ok());
         key
     }
 
     fn page_has_content(page: &PageRef) -> bool {
         page.is_loaded() && page.get().contents.is_some()
+    }
+
+    fn insert_and_get_entry(
+        cache: &mut DumbLruPageCache,
+        id: usize,
+    ) -> (PageCacheKey, NonNull<PageCacheEntry>) {
+        let key = create_key(id);
+        let page = page_with_content(id);
+        assert!(cache.insert(key.clone(), page).is_ok());
+        let entry = cache.get_ptr(&key).expect("Entry should exist");
+        (key, entry)
     }
 
     #[test]
@@ -393,7 +445,7 @@ mod tests {
         assert!(cache.tail.borrow().is_some());
         assert_eq!(*cache.head.borrow(), *cache.tail.borrow());
 
-        cache.delete(key1.clone());
+        assert!(cache.delete(key1.clone()).is_ok());
 
         assert_eq!(
             cache.len(),
@@ -425,7 +477,7 @@ mod tests {
             "Initial head check"
         );
 
-        cache.delete(key3.clone());
+        assert!(cache.delete(key3.clone()).is_ok());
 
         assert_eq!(cache.len(), 2, "Length should be 2 after deleting head");
         assert!(
@@ -469,7 +521,7 @@ mod tests {
             "Initial tail check"
         );
 
-        cache.delete(key1.clone()); // Delete tail
+        assert!(cache.delete(key1.clone()).is_ok()); // Delete tail
 
         assert_eq!(cache.len(), 2, "Length should be 2 after deleting tail");
         assert!(
@@ -520,7 +572,7 @@ mod tests {
         let head_ptr_before = cache.head.borrow().unwrap();
         let tail_ptr_before = cache.tail.borrow().unwrap();
 
-        cache.delete(key2.clone()); // Detach a middle element (key2)
+        assert!(cache.delete(key2.clone()).is_ok()); // Detach a middle element (key2)
 
         assert_eq!(cache.len(), 3, "Length should be 3 after deleting middle");
         assert!(
@@ -560,19 +612,19 @@ mod tests {
         let mut cache = DumbLruPageCache::new(5);
         let key1 = create_key(1);
         let page1 = page_with_content(1);
-        cache.insert(key1.clone(), page1.clone());
-        assert!(
-            page_has_content(&page1),
-            "Page content should exist before delete"
-        );
+        assert!(cache.insert(key1.clone(), page1.clone()).is_ok());
+        assert!(page_has_content(&page1));
         cache.verify_list_integrity();
 
-        cache.delete(key1.clone());
+        let result = cache.delete(key1.clone());
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), CacheError::ActiveRefs);
+        assert_eq!(cache.len(), 1);
+
+        drop(page1);
+
+        assert!(cache.delete(key1).is_ok());
         assert_eq!(cache.len(), 0);
-        assert!(
-            !page_has_content(&page1),
-            "Page content should be removed after delete"
-        );
         cache.verify_list_integrity();
     }
 
@@ -583,28 +635,21 @@ mod tests {
         let page1_v1 = page_with_content(1);
         let page1_v2 = page_with_content(1);
 
-        cache.insert(key1.clone(), page1_v1.clone());
-        assert!(
-            page_has_content(&page1_v1),
-            "Page1 V1 content should exist initially"
-        );
+        assert!(cache.insert(key1.clone(), page1_v1.clone()).is_ok());
+        assert_eq!(cache.len(), 1);
         cache.verify_list_integrity();
 
-        cache.insert(key1.clone(), page1_v2.clone()); // Trigger delete page1_v1
+        // Fail to insert v2 as v1 is still referenced
+        let result = cache.insert(key1.clone(), page1_v2.clone());
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), CacheError::ActiveRefs);
+        assert_eq!(cache.len(), 1); // Page v1 should remain in cache
+        assert!(page_has_content(&page1_v1));
 
-        assert_eq!(
-            cache.len(),
-            1,
-            "Cache length should still be 1 after replace"
-        );
-        assert!(
-            !page_has_content(&page1_v1),
-            "Page1 V1 content should be cleaned after being replaced in cache"
-        );
-        assert!(
-            page_has_content(&page1_v2),
-            "Page1 V2 content should exist after insert"
-        );
+        drop(page1_v1);
+        assert!(cache.insert(key1.clone(), page1_v2.clone()).is_ok());
+        assert_eq!(cache.len(), 1);
+        assert!(page_has_content(&page1_v2));
 
         let current_page = cache.get(&key1).unwrap();
         assert!(
@@ -620,7 +665,7 @@ mod tests {
         let mut cache = DumbLruPageCache::new(5);
         let key_nonexist = create_key(99);
 
-        cache.delete(key_nonexist.clone()); // no-op
+        assert!(cache.delete(key_nonexist.clone()).is_ok()); // no-op
     }
 
     #[test]
@@ -630,6 +675,114 @@ mod tests {
         let key2 = insert_page(&mut cache, 2);
         assert_eq!(cache.get(&key2).unwrap().get().id, 2);
         assert!(cache.get(&key1).is_none());
+    }
+
+    #[test]
+    fn test_detach_locked_page() {
+        let mut cache = DumbLruPageCache::new(5);
+        let (_, mut entry) = insert_and_get_entry(&mut cache, 1);
+        unsafe { entry.as_mut().page.set_locked() };
+        assert_eq!(cache.detach(entry, false), Err(CacheError::Locked));
+        cache.verify_list_integrity();
+    }
+
+    #[test]
+    fn test_detach_dirty_page() {
+        let mut cache = DumbLruPageCache::new(5);
+        let (key, mut entry) = insert_and_get_entry(&mut cache, 1);
+        cache.get(&key).expect("Page should exist");
+        unsafe { entry.as_mut().page.set_dirty() };
+        assert_eq!(cache.detach(entry, false), Err(CacheError::Dirty));
+        cache.verify_list_integrity();
+    }
+
+    #[test]
+    fn test_detach_with_active_reference_clean() {
+        let mut cache = DumbLruPageCache::new(5);
+        let (key, entry) = insert_and_get_entry(&mut cache, 1);
+        let page_ref = cache.get(&key);
+        assert_eq!(cache.detach(entry, true), Err(CacheError::ActiveRefs));
+        drop(page_ref);
+        cache.verify_list_integrity();
+    }
+
+    #[test]
+    fn test_detach_with_active_reference_no_clean() {
+        let mut cache = DumbLruPageCache::new(5);
+        let (key, entry) = insert_and_get_entry(&mut cache, 1);
+        cache.get(&key).expect("Page should exist");
+        assert!(cache.detach(entry, false).is_ok());
+        assert!(cache.map.borrow_mut().remove(&key).is_some());
+        cache.verify_list_integrity();
+    }
+
+    #[test]
+    fn test_detach_without_cleaning() {
+        let mut cache = DumbLruPageCache::new(5);
+        let (key, entry) = insert_and_get_entry(&mut cache, 1);
+        assert!(cache.detach(entry, false).is_ok());
+        assert!(cache.map.borrow_mut().remove(&key).is_some());
+        cache.verify_list_integrity();
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn test_detach_with_cleaning() {
+        let mut cache = DumbLruPageCache::new(5);
+        let (key, entry) = insert_and_get_entry(&mut cache, 1);
+        let page = cache.get(&key).expect("Page should exist");
+        assert!(page_has_content(&page));
+        drop(page);
+        assert!(cache.detach(entry, true).is_ok());
+        // Internal testing: the page is still in map, so we use it to check content
+        let page = cache.peek(&key, false).expect("Page should exist in map");
+        assert!(!page_has_content(&page));
+        assert!(cache.map.borrow_mut().remove(&key).is_some());
+        cache.verify_list_integrity();
+    }
+
+    #[test]
+    fn test_detach_only_element_preserves_integrity() {
+        let mut cache = DumbLruPageCache::new(5);
+        let (_, entry) = insert_and_get_entry(&mut cache, 1);
+        assert!(cache.detach(entry, false).is_ok());
+        assert!(
+            cache.head.borrow().is_none(),
+            "Head should be None after detaching only element"
+        );
+        assert!(
+            cache.tail.borrow().is_none(),
+            "Tail should be None after detaching only element"
+        );
+    }
+
+    #[test]
+    fn test_detach_with_multiple_pages() {
+        let mut cache = DumbLruPageCache::new(5);
+        let (key1, _) = insert_and_get_entry(&mut cache, 1);
+        let (key2, entry2) = insert_and_get_entry(&mut cache, 2);
+        let (key3, _) = insert_and_get_entry(&mut cache, 3);
+        let head_key = unsafe { cache.head.borrow().unwrap().as_ref().key.clone() };
+        let tail_key = unsafe { cache.tail.borrow().unwrap().as_ref().key.clone() };
+        assert_eq!(head_key, key3, "Head should be key3");
+        assert_eq!(tail_key, key1, "Tail should be key1");
+        assert!(cache.detach(entry2, false).is_ok());
+        let head_entry = unsafe { cache.head.borrow().unwrap().as_ref() };
+        let tail_entry = unsafe { cache.tail.borrow().unwrap().as_ref() };
+        assert_eq!(head_entry.key, key3, "Head should still be key3");
+        assert_eq!(tail_entry.key, key1, "Tail should still be key1");
+        assert_eq!(
+            unsafe { head_entry.next.unwrap().as_ref().key.clone() },
+            key1,
+            "Head's next should point to tail after middle element detached"
+        );
+        assert_eq!(
+            unsafe { tail_entry.prev.unwrap().as_ref().key.clone() },
+            key3,
+            "Tail's prev should point to head after middle element detached"
+        );
+        assert!(cache.map.borrow_mut().remove(&key2).is_some());
+        cache.verify_list_integrity();
     }
 
     #[test]
@@ -653,9 +806,9 @@ mod tests {
                     let key = PageCacheKey::new(id_page as usize, Some(id_frame));
                     #[allow(clippy::arc_with_non_send_sync)]
                     let page = Arc::new(Page::new(id_page as usize));
+                    lru.push(key.clone(), page.clone());
                     // println!("inserting page {:?}", key);
-                    cache.insert(key.clone(), page.clone());
-                    lru.push(key, page);
+                    cache.insert(key.clone(), page); // move page so there's no reference left here
                     assert!(cache.len() <= 10);
                 }
                 1 => {
@@ -712,7 +865,7 @@ mod tests {
     fn test_page_cache_delete() {
         let mut cache = DumbLruPageCache::new(2);
         let key1 = insert_page(&mut cache, 1);
-        cache.delete(key1.clone());
+        assert!(cache.delete(key1.clone()).is_ok());
         assert!(cache.get(&key1).is_none());
     }
 
@@ -721,7 +874,7 @@ mod tests {
         let mut cache = DumbLruPageCache::new(2);
         let key1 = insert_page(&mut cache, 1);
         let key2 = insert_page(&mut cache, 2);
-        cache.clear();
+        assert!(cache.clear().is_ok());
         assert!(cache.get(&key1).is_none());
         assert!(cache.get(&key2).is_none());
     }

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -224,6 +224,14 @@ mod tests {
 
     use super::PageCacheKey;
 
+    fn insert_page(cache: &mut DumbLruPageCache, id: usize) -> PageCacheKey {
+        let key = PageCacheKey::new(id, None);
+        #[allow(clippy::arc_with_non_send_sync)]
+        let page = Arc::new(Page::new(id));
+        cache.insert(key.clone(), page.clone());
+        key
+    }
+
     #[test]
     fn test_page_cache_evict() {
         let mut cache = DumbLruPageCache::new(1);
@@ -325,14 +333,6 @@ mod tests {
         cache.clear();
         assert!(cache.get(&key1).is_none());
         assert!(cache.get(&key2).is_none());
-    }
-
-    fn insert_page(cache: &mut DumbLruPageCache, id: usize) -> PageCacheKey {
-        let key = PageCacheKey::new(id, None);
-        #[allow(clippy::arc_with_non_send_sync)]
-        let page = Arc::new(Page::new(id));
-        cache.insert(key.clone(), page.clone());
-        key
     }
 
     #[test]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tracing::trace;
 
-use super::page_cache::{DumbLruPageCache, PageCacheKey};
+use super::page_cache::{CacheError, DumbLruPageCache, PageCacheKey};
 use super::wal::{CheckpointMode, CheckpointStatus};
 
 pub struct PageInner {
@@ -22,6 +22,7 @@ pub struct PageInner {
     pub id: usize,
 }
 
+#[derive(Debug)]
 pub struct Page {
     pub inner: UnsafeCell<PageInner>,
 }
@@ -213,6 +214,7 @@ impl Pager {
         })
     }
 
+    // FIXME: handle no room in page cache
     pub fn btree_create(&self, flags: &CreateBTreeFlags) -> u32 {
         let page_type = match flags {
             _ if flags.is_table() => PageType::TableLeaf,
@@ -226,6 +228,7 @@ impl Pager {
 
     /// Allocate a new overflow page.
     /// This is done when a cell overflows and new space is needed.
+    // FIXME: handle no room in page cache
     pub fn allocate_overflow_page(&self) -> PageRef {
         let page = self.allocate_page().unwrap();
         tracing::debug!("Pager::allocate_overflow_page(id={})", page.get().id);
@@ -240,6 +243,7 @@ impl Pager {
 
     /// Allocate a new page to the btree via the pager.
     /// This marks the page as dirty and writes the page header.
+    // FIXME: handle no room in page cache
     pub fn do_allocate_page(&self, page_type: PageType, offset: usize) -> PageRef {
         let page = self.allocate_page().unwrap();
         crate::btree_init_page(&page, page_type, offset, self.usable_space() as u16);
@@ -387,6 +391,7 @@ impl Pager {
     }
 
     /// Changes the size of the page cache.
+    // FIXME: handle no room in page cache
     pub fn change_page_cache_size(&self, capacity: usize) {
         let mut page_cache = self.page_cache.write();
         page_cache.resize(capacity);
@@ -631,6 +636,7 @@ impl Pager {
         Gets a new page that increasing the size of the page or uses a free page.
         Currently free list pages are not yet supported.
     */
+    // FIXME: handle no room in page cache
     #[allow(clippy::readonly_write_lock)]
     pub fn allocate_page(&self) -> Result<PageRef> {
         let header = &self.db_header;
@@ -654,21 +660,29 @@ impl Pager {
             }
         }
 
+        // FIXME: should reserve page cache entry before modifying the database
         let page = allocate_page(header.database_size as usize, &self.buffer_pool, 0);
         {
             // setup page and add to cache
             page.set_dirty();
             self.add_dirty(page.get().id);
-            let mut cache = self.page_cache.write();
             let max_frame = match &self.wal {
                 Some(wal) => wal.borrow().get_max_frame(),
                 None => 0,
             };
 
             let page_key = PageCacheKey::new(page.get().id, Some(max_frame));
-            cache.insert(page_key, page.clone());
+            let mut cache = self.page_cache.write();
+            match cache.insert(page_key, page.clone()) {
+                Err(CacheError::Full) => return Err(LimboError::CacheFull),
+                Err(_) => {
+                    return Err(LimboError::InternalError(
+                        "Unknown error inserting page to cache".into(),
+                    ))
+                }
+                Ok(_) => return Ok(page),
+            }
         }
-        Ok(page)
     }
 
     pub fn put_loaded_page(&self, id: usize, page: PageRef) {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tracing::trace;
 
-use super::page_cache::{CacheError, DumbLruPageCache, PageCacheKey};
+use super::page_cache::{CacheError, DumbLruPageCache, PageCacheKey, CacheResizeResult};
 use super::wal::{CheckpointMode, CheckpointStatus};
 
 pub struct PageInner {
@@ -405,10 +405,9 @@ impl Pager {
     }
 
     /// Changes the size of the page cache.
-    // FIXME: handle no room in page cache
-    pub fn change_page_cache_size(&self, capacity: usize) {
+    pub fn change_page_cache_size(&self, capacity: usize) -> Result<CacheResizeResult> {
         let mut page_cache = self.page_cache.write();
-        page_cache.resize(capacity)
+        Ok(page_cache.resize(capacity))
     }
 
     pub fn add_dirty(&self, page_id: usize) {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -306,7 +306,7 @@ impl Pager {
     }
 
     /// Reads a page from the database.
-    pub fn read_page(&self, page_idx: usize) -> Result<PageRef> {
+    pub fn read_page(&self, page_idx: usize) -> Result<PageRef, LimboError> {
         tracing::trace!("read_page(page_idx = {})", page_idx);
         let mut page_cache = self.page_cache.write();
         let max_frame = match &self.wal {
@@ -328,9 +328,14 @@ impl Pager {
                 {
                     page.set_uptodate();
                 }
-                // TODO(pere) ensure page is inserted, we should probably first insert to page cache
-                // and if successful, read frame or page
-                page_cache.insert(page_key, page.clone());
+                // TODO(pere) should probably first insert to page cache, and if successful,
+                // read frame or page
+                match page_cache.insert(page_key, page.clone()) {
+                    Ok(_) => {}
+                    Err(CacheError::Full) => return Err(LimboError::CacheFull),
+                    Err(CacheError::KeyExists) => unreachable!("Page should not exist in cache after get() miss"),
+                    Err(e) => return Err(LimboError::InternalError(format!("Failed to insert page into cache: {:?}", e))),
+                }
                 return Ok(page);
             }
         }
@@ -340,8 +345,12 @@ impl Pager {
             page.clone(),
             page_idx,
         )?;
-        // TODO(pere) ensure page is inserted
-        page_cache.insert(page_key, page.clone());
+        match page_cache.insert(page_key, page.clone()) {
+            Ok(_) => {}
+            Err(CacheError::Full) => return Err(LimboError::CacheFull),
+            Err(CacheError::KeyExists) => unreachable!("Page should not exist in cache after get() miss"),
+            Err(e) => return Err(LimboError::InternalError(format!("Failed to insert page into cache: {:?}", e))),
+        }
         Ok(page)
     }
 
@@ -363,18 +372,23 @@ impl Pager {
                 {
                     page.set_uptodate();
                 }
-                // TODO(pere) ensure page is inserted
-                if !page_cache.contains_key(&page_key) {
-                    page_cache.insert(page_key, page.clone());
+                match page_cache.insert(page_key, page.clone()) {
+                    Err(CacheError::KeyExists) => {}, // Exists but same page, not error
+                    Err(CacheError::Full) => return Err(LimboError::CacheFull),
+                    Err(e) => return Err(LimboError::InternalError(format!("Failed to insert page into cache during load: {:?}", e))),
+                    Ok(_) => {}
                 }
                 return Ok(());
             }
         }
 
-        // TODO(pere) ensure page is inserted
-        if !page_cache.contains_key(&page_key) {
-            page_cache.insert(page_key, page.clone());
-        }
+        match page_cache.insert(page_key, page.clone()) {
+             Err(CacheError::KeyExists) => {}, // Ensures same page
+             Err(CacheError::Full) => return Err(LimboError::CacheFull),
+             Err(e) => return Err(LimboError::InternalError(format!("Failed to insert page into cache during load: {:?}", e))),
+             Ok(_) => {}
+        };
+
         sqlite3_ondisk::begin_read_page(
             self.db_file.clone(),
             self.buffer_pool.clone(),
@@ -394,7 +408,7 @@ impl Pager {
     // FIXME: handle no room in page cache
     pub fn change_page_cache_size(&self, capacity: usize) {
         let mut page_cache = self.page_cache.write();
-        page_cache.resize(capacity);
+        page_cache.resize(capacity)
     }
 
     pub fn add_dirty(&self, page_id: usize) {
@@ -430,8 +444,9 @@ impl Pager {
                         }
                         // This page is no longer valid.
                         // For example:
-                        // We took page with key (page_num, max_frame) -- this page is no longer valid for that max_frame so it must be invalidated.
-                        cache.delete(page_key);
+                        // We took page with key (page_num, max_frame) -- this page is no longer valid for that max_frame
+                        // so it must be invalidated. There shouldn't be any active refs.
+                        cache.delete(page_key).map_err(|e| {LimboError::InternalError(format!("Failed to delete page {:?} from cache during flush: {:?}. Might be actively referenced.", page_id, e))})?;
                     }
                     self.dirty_pages.borrow_mut().clear();
                     self.flush_info.borrow_mut().state = FlushState::WaitAppendFrames;
@@ -556,7 +571,7 @@ impl Pager {
             }
         }
         // TODO: only clear cache of things that are really invalidated
-        self.page_cache.write().clear();
+        self.page_cache.write().clear().expect("Failed to clear page cache");
         checkpoint_result
     }
 
@@ -685,16 +700,35 @@ impl Pager {
         }
     }
 
-    pub fn put_loaded_page(&self, id: usize, page: PageRef) {
+    pub fn put_loaded_page(&self, id: usize, page: PageRef) -> Result<(), LimboError> {
         let mut cache = self.page_cache.write();
-        // cache insert invalidates previous page
         let max_frame = match &self.wal {
             Some(wal) => wal.borrow().get_max_frame(),
             None => 0,
         };
         let page_key = PageCacheKey::new(id, Some(max_frame));
-        cache.insert(page_key, page.clone());
+
+        // FIXME: is this correct? Why would there be another version of the page?
+        // Check if there's an existing page at this key and remove it
+        // This can happen when a page is being updated during a transaction
+        // or when WAL frames are being managed
+        if let Some(_existing_page_ref) = cache.get(&page_key) {
+            cache.delete(page_key.clone()).map_err(|e| {
+                LimboError::InternalError(format!(
+                    "put_loaded_page failed to remove old version of page {:?}: {:?}.",
+                    page_key, e
+                ))
+            })?;
+        }
+
+        cache.insert(page_key, page.clone()).map_err(|e| {
+            LimboError::InternalError(format!(
+                "Failed to insert loaded page {} into cache: {:?}", id, e
+            ))
+        })?;
+
         page.set_loaded();
+        Ok(())
     }
 
     pub fn usable_size(&self) -> usize {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4068,6 +4068,7 @@ pub fn op_create_btree(
         // TODO: implement temp databases
         todo!("temp databases not implemented yet");
     }
+    // FIXME: handle page cache is full
     let root_page = pager.btree_create(flags);
     state.registers[*root] = Register::OwnedValue(OwnedValue::Integer(root_page as i64));
     state.pc += 1;
@@ -4443,6 +4444,7 @@ pub fn op_open_ephemeral(
         &CreateBTreeFlags::new_index()
     };
 
+    // FIXME: handle page cache is full
     let root_page = pager.btree_create(flag);
 
     let (_, cursor_type) = program.cursor_ref.get(cursor_id).unwrap();


### PR DESCRIPTION
From the ashes of https://github.com/tursodatabase/limbo/pull/1331, here is an improved PR.

* Cache full: on `insert()` keep walking back the list of pages until it can make room for the page (what kickstarted this whole PR, and Pere's innocent "Can we have some testing here?")
* Stricter checks on page cache entry eviction, fail if there are other active `PageRefs`
* Fixed insert behavior
* Thorough tests handling edge cases with nicer helpers
* Fixed existing page cache tests to deal with new failures
* Implemented `resize()` matching SQLite behavior
* Improved result types with error `enum`s, return `enum`s instead of `bool`, and using `Result`
* Where possible, tried to "rustify"

Missing:
* Updates to `pager.rs` and `btree.rs` to handle page cache full, and tests.

Will change the PR out of draft after missing bits.

@pereman2 please review