### PR TITLE
Optimization: only initialize `Rustyline` if we are in a tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,6 @@ dependencies = [
  "libc",
  "limbo_core",
  "miette",
- "nix 0.29.0",
  "nu-ansi-term 0.50.1",
  "rustyline",
  "shlex",
@@ -1713,7 +1712,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,9 +1575,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libgit2-sys"
@@ -1702,8 +1702,10 @@ dependencies = [
  "ctrlc",
  "dirs 5.0.1",
  "env_logger 0.10.2",
+ "libc",
  "limbo_core",
  "miette",
+ "nix 0.29.0",
  "nu-ansi-term 0.50.1",
  "rustyline",
  "shlex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,6 +1713,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,6 @@ limbo_core = { path = "../core", default-features = true, features = [
     "completion",
 ] }
 miette = { version = "7.4.0", features = ["fancy"] }
-nix = "0.29.0"
 nu-ansi-term = "0.50.1"
 rustyline = { version = "15.0.0", default-features = true, features = [
     "derive",
@@ -44,6 +43,14 @@ tracing = "0.1.41"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
+[target.'cfg(target_family = "unix")'.dependencies]
+nix = "0.29.0"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59.0", features = [
+    "Win32_Foundation",
+    "Win32_System_Console",
+] }
 
 [features]
 default = ["io_uring"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,10 +28,12 @@ csv = "1.3.1"
 ctrlc = "3.4.4"
 dirs = "5.0.1"
 env_logger = "0.10.1"
+libc = "0.2.172"
 limbo_core = { path = "../core", default-features = true, features = [
     "completion",
 ] }
 miette = { version = "7.4.0", features = ["fancy"] }
+nix = "0.29.0"
 nu-ansi-term = "0.50.1"
 rustyline = { version = "15.0.0", default-features = true, features = [
     "derive",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,15 +43,6 @@ tracing = "0.1.41"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
-[target.'cfg(target_family = "unix")'.dependencies]
-nix = "0.29.0"
-
-[target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59.0", features = [
-    "Win32_Foundation",
-    "Win32_System_Console",
-] }
-
 [features]
 default = ["io_uring"]
 io_uring = ["limbo_core/io_uring"]

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -7,6 +7,7 @@ use crate::{
     helper::LimboHelper,
     input::{get_io, get_writer, DbLocation, OutputMode, Settings},
     opcodes_dictionary::OPCODE_DESCRIPTIONS,
+    HISTORY_FILE,
 };
 use comfy_table::{Attribute, Cell, CellAlignment, Color, ContentArrangement, Row, Table};
 use limbo_core::{Database, LimboError, OwnedValue, Statement, StepResult};
@@ -14,10 +15,10 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 use clap::Parser;
-use rustyline::{history::DefaultHistory, Editor};
+use rustyline::{error::ReadlineError, history::DefaultHistory, Editor};
 use std::{
     fmt,
-    io::{self, Write},
+    io::{self, BufRead as _, Write},
     path::PathBuf,
     rc::Rc,
     sync::{
@@ -62,7 +63,7 @@ pub struct Opts {
 
 const PROMPT: &str = "limbo> ";
 
-pub struct Limbo<'a> {
+pub struct Limbo {
     pub prompt: String,
     io: Arc<dyn limbo_core::IO>,
     writer: Box<dyn Write>,
@@ -70,7 +71,7 @@ pub struct Limbo<'a> {
     pub interrupt_count: Arc<AtomicUsize>,
     input_buff: String,
     opts: Settings,
-    pub rl: &'a mut Editor<LimboHelper, DefaultHistory>,
+    pub rl: Option<Editor<LimboHelper, DefaultHistory>>,
 }
 
 struct QueryStatistics {
@@ -105,8 +106,8 @@ macro_rules! query_internal {
 
 static COLORS: &[Color] = &[Color::Green, Color::Black, Color::Grey];
 
-impl<'a> Limbo<'a> {
-    pub fn new(rl: &'a mut rustyline::Editor<LimboHelper, DefaultHistory>) -> anyhow::Result<Self> {
+impl Limbo {
+    pub fn new() -> anyhow::Result<Self> {
         let opts = Opts::parse();
         let db_file = opts
             .database
@@ -133,8 +134,6 @@ impl<'a> Limbo<'a> {
             )
         };
         let conn = db.connect()?;
-        let h = LimboHelper::new(conn.clone(), io.clone());
-        rl.set_helper(Some(h));
         let interrupt_count = Arc::new(AtomicUsize::new(0));
         {
             let interrupt_count: Arc<AtomicUsize> = Arc::clone(&interrupt_count);
@@ -154,10 +153,17 @@ impl<'a> Limbo<'a> {
             interrupt_count,
             input_buff: String::new(),
             opts: Settings::from(opts),
-            rl,
+            rl: None,
         };
         app.first_run(sql, quiet)?;
         Ok(app)
+    }
+
+    pub fn with_readline(mut self, mut rl: Editor<LimboHelper, DefaultHistory>) -> Self {
+        let h = LimboHelper::new(self.conn.clone(), self.io.clone());
+        rl.set_helper(Some(h));
+        self.rl = Some(rl);
+        self
     }
 
     fn first_run(&mut self, sql: Option<String>, quiet: bool) -> io::Result<()> {
@@ -470,8 +476,9 @@ impl<'a> Limbo<'a> {
         }
     }
 
-    fn reset_line(&mut self, line: &str) -> rustyline::Result<()> {
-        self.rl.add_history_entry(line.to_owned())?;
+    fn reset_line(&mut self, _line: &str) -> rustyline::Result<()> {
+        // Entry is auto added to history
+        // self.rl.add_history_entry(line.to_owned())?;
         self.interrupt_count.store(0, Ordering::SeqCst);
         Ok(())
     }
@@ -972,5 +979,35 @@ impl<'a> Limbo<'a> {
         let buff = self.input_buff.clone();
         self.run_query(buff.as_str());
         self.reset_input();
+    }
+
+    pub fn readline(&mut self) -> Result<String, ReadlineError> {
+        if let Some(rl) = &mut self.rl {
+            Ok(rl.readline(&self.prompt)?)
+        } else {
+            let mut input = String::new();
+            println!("");
+            let mut reader = std::io::stdin().lock();
+            if reader.read_line(&mut input)? == 0 {
+                return Err(ReadlineError::Eof.into());
+            }
+            // Remove trailing newline
+            if input.ends_with('\n') {
+                input.pop();
+                if input.ends_with('\r') {
+                    input.pop();
+                }
+            }
+
+            Ok(input)
+        }
+    }
+}
+
+impl Drop for Limbo {
+    fn drop(&mut self) {
+        if let Some(rl) = &mut self.rl {
+            let _ = rl.save_history(HISTORY_FILE.as_path());
+        }
     }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -5,8 +5,6 @@ mod helper;
 mod input;
 mod opcodes_dictionary;
 
-#[cfg(unix)]
-use nix::unistd::isatty;
 use rustyline::{error::ReadlineError, Config, Editor};
 use std::{
     path::PathBuf,
@@ -29,7 +27,7 @@ fn main() -> anyhow::Result<()> {
     let mut app = app::Limbo::new()?;
     let _guard = app.init_tracing()?;
 
-    if is_a_tty() {
+    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
         let mut rl = Editor::with_config(rustyline_config())?;
         if HISTORY_FILE.exists() {
             rl.load_history(HISTORY_FILE.as_path())?;
@@ -71,62 +69,4 @@ fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
-}
-
-/// Return whether or not STDIN is a TTY
-fn is_a_tty() -> bool {
-    #[cfg(unix)]
-    {
-        isatty(libc::STDIN_FILENO).unwrap_or(false)
-    }
-    #[cfg(windows)]
-    {
-        let handle = windows::get_std_handle(windows::console::STD_INPUT_HANDLE);
-        match handle {
-            Ok(handle) => {
-                // If this function doesn't fail then fd is a TTY
-                windows::get_console_mode(handle).is_ok()
-            }
-            Err(_) => false,
-        }
-    }
-}
-
-// Code acquired from Rustyline
-#[cfg(windows)]
-mod windows {
-    use std::io;
-    use windows_sys::Win32::Foundation::{self as foundation, BOOL, FALSE, HANDLE};
-    pub use windows_sys::Win32::System::Console as console;
-
-    pub fn get_console_mode(handle: HANDLE) -> rustyline::Result<console::CONSOLE_MODE> {
-        let mut original_mode = 0;
-        check(unsafe { console::GetConsoleMode(handle, &mut original_mode) })?;
-        Ok(original_mode)
-    }
-
-    pub fn get_std_handle(fd: console::STD_HANDLE) -> rustyline::Result<HANDLE> {
-        let handle = unsafe { console::GetStdHandle(fd) };
-        check_handle(handle)
-    }
-
-    fn check_handle(handle: HANDLE) -> rustyline::Result<HANDLE> {
-        if handle == foundation::INVALID_HANDLE_VALUE {
-            Err(io::Error::last_os_error())?;
-        } else if handle.is_null() {
-            Err(io::Error::new(
-                io::ErrorKind::Other,
-                "no stdio handle available for this process",
-            ))?;
-        }
-        Ok(handle)
-    }
-
-    fn check(rc: BOOL) -> io::Result<()> {
-        if rc == FALSE {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(())
-        }
-    }
 }


### PR DESCRIPTION
This is small nitpick, but it will be useful for #1258. If we are testing or just piping some sql through stdin, we can just not initialize `Rustyline` and save some execution time. 

On `Select 1` bench, I got a minor performance bump, but it starts to become less apparent on more complex queries. 
<img width="759" alt="image" src="https://github.com/user-attachments/assets/12e22675-e081-4284-a5ed-15d53a9c5579" />
