### PR TITLE
bindings/rust: Add Statement.columns() support

### DIFF
--- a/bindings/java/rs_src/limbo_statement.rs
+++ b/bindings/java/rs_src/limbo_statement.rs
@@ -138,7 +138,7 @@ pub extern "system" fn Java_tech_turso_core_LimboStatement_columns<'local>(
 
     for i in 0..num_columns {
         let column_name = stmt.stmt.get_column_name(i);
-        let str = env.new_string(column_name.as_str()).unwrap();
+        let str = env.new_string(column_name.into_owned()).unwrap();
         env.set_object_array_element(&obj_arr, i as i32, str)
             .unwrap();
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -190,6 +190,39 @@ impl Statement {
             }
         }
     }
+
+    pub fn columns(&self) -> Vec<Column> {
+        let stmt = self.inner.lock().unwrap();
+
+        let n = stmt.num_columns();
+
+        let mut cols = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let name = stmt.get_column_name(i).into_owned();
+            cols.push(Column {
+                name,
+                decl_type: None, // TODO
+            });
+        }
+
+        cols
+    }
+}
+
+pub struct Column {
+    name: String,
+    decl_type: Option<String>,
+}
+
+impl Column {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn decl_type(&self) -> Option<&str> {
+        self.decl_type.as_deref()
+    }
 }
 
 pub trait IntoValue {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -591,7 +591,7 @@ impl Statement {
         self.program.result_columns.len()
     }
 
-    pub fn get_column_name(&self, idx: usize) -> Cow<String> {
+    pub fn get_column_name(&self, idx: usize) -> Cow<str> {
         let column = &self.program.result_columns[idx];
         match column.name(&self.program.table_references) {
             Some(name) => Cow::Borrowed(name),

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -120,16 +120,16 @@ mod tests {
 
         let columns = stmt.num_columns();
         assert_eq!(columns, 3);
-        assert_eq!(stmt.get_column_name(0), "foo".into());
-        assert_eq!(stmt.get_column_name(1), "bar".into());
-        assert_eq!(stmt.get_column_name(2), "baz".into());
+        assert_eq!(stmt.get_column_name(0), "foo");
+        assert_eq!(stmt.get_column_name(1), "bar");
+        assert_eq!(stmt.get_column_name(2), "baz");
 
         let stmt = conn.prepare("select foo, bar from test;")?;
 
         let columns = stmt.num_columns();
         assert_eq!(columns, 2);
-        assert_eq!(stmt.get_column_name(0), "foo".into());
-        assert_eq!(stmt.get_column_name(1), "bar".into());
+        assert_eq!(stmt.get_column_name(0), "foo");
+        assert_eq!(stmt.get_column_name(1), "bar");
 
         let stmt = conn.prepare("delete from test;")?;
         let columns = stmt.num_columns();


### PR DESCRIPTION
This PR adds the statement.columns() function, inspired from Rusqlite: https://docs.rs/rusqlite/latest/rusqlite/struct.Statement.html#method.columns

Note that the rusqlite documentation says

> If associated DB schema can be altered concurrently, you should make sure that current statement has already been stepped once before calling this method.

Do we have this requirement as well?

The first commit is just the rust binding. The second commit implements the column name for the rowid column.