### PR TITLE
Fix incorrect between expression documentation

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -200,7 +200,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | (NOT) MATCH               | No      |                                          |
 | IS (NOT)                  | Yes     |                                          |
 | IS (NOT) DISTINCT FROM    | Yes     |                                          |
-| (NOT) BETWEEN ... AND ... | No      |                                          |
+| (NOT) BETWEEN ... AND ... | Yes     | Expression is rewritten in the optimizer |
 | (NOT) IN (subquery)       | No      |                                          |
 | (NOT) EXISTS (subquery)   | No      |                                          |
 | CASE WHEN THEN ELSE END   | Yes     |                                          |

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -186,7 +186,9 @@ pub fn translate_condition_expr(
     resolver: &Resolver,
 ) -> Result<()> {
     match expr {
-        ast::Expr::Between { .. } => todo!(),
+        ast::Expr::Between { .. } => {
+            unreachable!("expression should have been rewritten in optmizer")
+        }
         ast::Expr::Binary(lhs, ast::Operator::And, rhs) => {
             // In a binary AND, never jump to the parent 'jump_target_when_true' label on the first condition, because
             // the second condition MUST also be true. Instead we instruct the child expression to jump to a local
@@ -492,7 +494,9 @@ pub fn translate_expr(
         return Ok(target_register);
     }
     match expr {
-        ast::Expr::Between { .. } => todo!(),
+        ast::Expr::Between { .. } => {
+            unreachable!("expression should have been rewritten in optmizer")
+        }
         ast::Expr::Binary(e1, op, e2) => {
             // Check if both sides of the expression are equivalent and reuse the same register if so
             if exprs_are_equivalent(e1, e2) {


### PR DESCRIPTION
I was reading through the `translate_expr` function and `COMPAT.md` to see what was not implemented yet. I saw that `Expr::Between` was marked as a `todo!` so I set trying to implement it only to find that it was being rewritten in the optimizer haha. This PR just adjusts the docs and add an `unreachable` in the appropriate locations.