### PR TITLE
Emit `IdxDelete` instruction and some fixes on seek after deletion

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5159,8 +5159,10 @@ mod tests {
         fast_lock::SpinLock,
         io::{Buffer, Completion, MemoryIO, OpenFlags, IO},
         storage::{
-            database::DatabaseFile, page_cache::DumbLruPageCache, sqlite3_ondisk,
-            sqlite3_ondisk::DatabaseHeader,
+            database::DatabaseFile,
+            page_cache::DumbLruPageCache,
+            pager::CreateBTreeFlags,
+            sqlite3_ondisk::{self, DatabaseHeader},
         },
         types::Text,
         vdbe::Register,
@@ -5678,6 +5680,81 @@ mod tests {
             }
         }
     }
+
+    fn btree_index_insert_fuzz_run(attempts: usize, inserts: usize) {
+        let (mut rng, seed) = if std::env::var("SEED").is_ok() {
+            let seed = std::env::var("SEED").unwrap();
+            let seed = seed.parse::<u64>().unwrap();
+            let rng = ChaCha8Rng::seed_from_u64(seed);
+            (rng, seed)
+        } else {
+            rng_from_time()
+        };
+        let mut seen = HashSet::new();
+        tracing::info!("super seed: {}", seed);
+        for _ in 0..attempts {
+            let (pager, _) = empty_btree();
+            let index_root_page = pager.btree_create(&CreateBTreeFlags::new_index());
+            let index_root_page = index_root_page as usize;
+            let mut cursor = BTreeCursor::new(None, pager.clone(), index_root_page);
+            let mut keys = Vec::new();
+            tracing::info!("seed: {}", seed);
+            for _ in 0..inserts {
+                let key = {
+                    let result;
+                    loop {
+                        let cols = (0..10)
+                            .map(|_| (rng.next_u64() % (1 << 30)) as i64)
+                            .collect::<Vec<_>>();
+                        if seen.contains(&cols) {
+                            continue;
+                        } else {
+                            seen.insert(cols.clone());
+                        }
+                        result = cols;
+                        break;
+                    }
+                    result
+                };
+                keys.push(key.clone());
+                let value = ImmutableRecord::from_registers(
+                    &key.iter()
+                        .map(|col| Register::OwnedValue(OwnedValue::Integer(*col)))
+                        .collect::<Vec<_>>(),
+                );
+                run_until_done(
+                    || {
+                        cursor.insert(
+                            &BTreeKey::new_index_key(&value),
+                            cursor.is_write_in_progress(),
+                        )
+                    },
+                    pager.deref(),
+                )
+                .unwrap();
+                keys.sort();
+                cursor.move_to_root();
+            }
+            keys.sort();
+            cursor.move_to_root();
+            for key in keys.iter() {
+                tracing::trace!("seeking key: {:?}", key);
+                run_until_done(|| cursor.next(), pager.deref()).unwrap();
+                let record = cursor.record();
+                let record = record.as_ref().unwrap();
+                let cursor_key = record.get_values();
+                assert_eq!(
+                    cursor_key,
+                    &key.iter()
+                        .map(|col| RefValue::Integer(*col))
+                        .collect::<Vec<_>>(),
+                    "key {:?} is not found",
+                    key
+                );
+            }
+        }
+    }
+
     #[test]
     pub fn test_drop_odd() {
         let db = get_database();
@@ -5729,6 +5806,11 @@ mod tests {
             tracing::info!("======= size:{} =======", size);
             btree_insert_fuzz_run(2, 1024, |_| size);
         }
+    }
+
+    #[test]
+    pub fn btree_index_insert_fuzz_run_equal_size() {
+        btree_index_insert_fuzz_run(2, 1024 * 32);
     }
 
     #[test]

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -50,6 +50,11 @@ pub fn prepare_delete_plan(
         crate::bail_corrupt_error!("Table is neither a virtual table nor a btree table");
     };
     let name = tbl_name.name.0.as_str().to_string();
+    let indexes = schema
+        .get_indices(table.get_name())
+        .iter()
+        .cloned()
+        .collect();
     let mut table_references = vec![TableReference {
         table,
         identifier: name,
@@ -82,6 +87,7 @@ pub fn prepare_delete_plan(
         limit: resolved_limit,
         offset: resolved_offset,
         contains_constant_false_condition: false,
+        indexes,
     };
 
     Ok(Plan::Delete(plan))

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -297,6 +297,8 @@ pub struct DeletePlan {
     pub offset: Option<isize>,
     /// query contains a constant condition that is always false
     pub contains_constant_false_condition: bool,
+    /// Indexes that must be updated by the delete operation.
+    pub indexes: Vec<Arc<Index>>,
 }
 
 #[derive(Debug, Clone)]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1810,11 +1810,17 @@ pub fn op_row_id(
             let rowid = {
                 let mut index_cursor = state.get_cursor(index_cursor_id);
                 let index_cursor = index_cursor.as_btree_mut();
-                index_cursor.rowid()?
+                let record = index_cursor.record();
+                let record = record.as_ref().unwrap();
+                let rowid = record.get_values().last().unwrap();
+                match rowid {
+                    RefValue::Integer(rowid) => *rowid as u64,
+                    _ => todo!(),
+                }
             };
             let mut table_cursor = state.get_cursor(table_cursor_id);
             let table_cursor = table_cursor.as_btree_mut();
-            match table_cursor.seek(SeekKey::TableRowId(rowid.unwrap()), SeekOp::EQ)? {
+            match table_cursor.seek(SeekKey::TableRowId(rowid), SeekOp::EQ)? {
                 CursorResult::Ok(_) => None,
                 CursorResult::IO => Some((index_cursor_id, table_cursor_id)),
             }
@@ -2069,7 +2075,6 @@ pub fn op_idx_ge(
             let idx_values = idx_record.get_values();
             let idx_values = &idx_values[..record_from_regs.len()];
             let record_values = record_from_regs.get_values();
-            let record_values = &record_values[..idx_values.len()];
             let ord = compare_immutable(&idx_values, &record_values, cursor.index_key_sort_order);
             if ord.is_ge() {
                 target_pc.to_offset_int()
@@ -3759,6 +3764,34 @@ pub fn op_delete(
     Ok(InsnFunctionStepResult::Step)
 }
 
+pub fn op_idx_delete(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    pager: &Rc<Pager>,
+    mv_store: Option<&Rc<MvStore>>,
+) -> Result<InsnFunctionStepResult> {
+    let Insn::IdxDelete {
+        cursor_id,
+        start_reg,
+        num_regs,
+    } = insn
+    else {
+        unreachable!("unexpected Insn {:?}", insn)
+    };
+    let record = make_record(&state.registers, start_reg, num_regs);
+    {
+        let mut cursor = state.get_cursor(*cursor_id);
+        let cursor = cursor.as_btree_mut();
+        return_if_io!(cursor.seek(SeekKey::IndexKey(&record), SeekOp::EQ));
+        return_if_io!(cursor.delete());
+    }
+    let prev_changes = program.n_change.get();
+    program.n_change.set(prev_changes + 1);
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
 pub fn op_idx_insert(
     program: &Program,
     state: &mut ProgramState,
@@ -3766,7 +3799,6 @@ pub fn op_idx_insert(
     pager: &Rc<Pager>,
     mv_store: Option<&Rc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
-    dbg!("op_idx_insert_");
     if let Insn::IdxInsert {
         cursor_id,
         record_reg,
@@ -3807,7 +3839,6 @@ pub fn op_idx_insert(
                 }
             };
 
-            dbg!(moved_before);
             // Start insertion of row. This might trigger a balance procedure which will take care of moving to different pages,
             // therefore, we don't want to seek again if that happens, meaning we don't want to return on io without moving to the following opcode
             // because it could trigger a movement to child page after a balance root which will leave the current page as the root page.

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1037,6 +1037,19 @@ pub fn insn_to_str(
                 0,
                 "".to_string(),
             ),
+            Insn::IdxDelete {
+                cursor_id,
+                start_reg,
+                num_regs,
+            } => (
+                "IdxDelete",
+                *cursor_id as i32,
+                *start_reg as i32,
+                *num_regs as i32,
+                OwnedValue::build_text(""),
+                0,
+                "".to_string(),
+            ),
             Insn::NewRowid {
                 cursor,
                 rowid_reg,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -650,6 +650,12 @@ pub enum Insn {
         cursor_id: CursorID,
     },
 
+    IdxDelete {
+        start_reg: usize,
+        num_regs: usize,
+        cursor_id: CursorID,
+    },
+
     NewRowid {
         cursor: CursorID,        // P1
         rowid_reg: usize,        // P2  Destination register to store the new rowid
@@ -948,6 +954,7 @@ impl Insn {
             Insn::Once { .. } => execute::op_once,
             Insn::NotFound { .. } => execute::op_not_found,
             Insn::Affinity { .. } => execute::op_affinity,
+            Insn::IdxDelete { .. } => execute::op_idx_delete,
         }
     }
 }


### PR DESCRIPTION
Previously `DELETE FROM ...` only emitted deletes for main table, but this is incorrect as we want to remove entries from index tables as well.