### PR TITLE
perf/btree: use binary search for Index seek operations

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1027,7 +1027,7 @@ impl BTreeCursor {
     }
 
     /// Specialized version of move_to() for table btrees.
-    fn tablebtree_move_to_binsearch(
+    fn tablebtree_move_to(
         &mut self,
         rowid: u64,
         seek_op: SeekOp,
@@ -1305,13 +1305,13 @@ impl BTreeCursor {
     ) -> Result<CursorResult<Option<u64>>> {
         assert!(self.mv_cursor.is_none());
         self.move_to_root();
-        return_if_io!(self.tablebtree_move_to_binsearch(rowid, seek_op, iter_dir));
+        return_if_io!(self.tablebtree_move_to(rowid, seek_op, iter_dir));
         let page = self.stack.top();
         return_if_locked!(page);
         let contents = page.get().contents.as_ref().unwrap();
         assert!(
             contents.is_leaf(),
-            "tablebtree_seek_binsearch() called on non-leaf page"
+            "tablebtree_seek() called on non-leaf page"
         );
 
         let cell_count = contents.cell_count();
@@ -1648,7 +1648,7 @@ impl BTreeCursor {
         let iter_dir = cmp.iteration_direction();
         match key {
             SeekKey::TableRowId(rowid_key) => {
-                return self.tablebtree_move_to_binsearch(rowid_key, cmp, iter_dir);
+                return self.tablebtree_move_to(rowid_key, cmp, iter_dir);
             }
             SeekKey::IndexKey(index_key) => {
                 return self.indexbtree_move_to(index_key, cmp, iter_dir);

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -309,7 +309,7 @@ mod tests {
             let col_choices = ["x", "y", "z", "nonindexed_col"];
             let col_choices_weights = [10.0, 10.0, 10.0, 3.0];
             let num_cols_in_select = rng.random_range(1..=4);
-            let select_cols = col_choices
+            let mut select_cols = col_choices
                 .choose_multiple_weighted(&mut rng, num_cols_in_select, |s| {
                     let idx = col_choices.iter().position(|c| c == s).unwrap();
                     col_choices_weights[idx]
@@ -319,6 +319,9 @@ mod tests {
                 .iter()
                 .map(|x| x.to_string())
                 .collect::<Vec<_>>();
+
+            // sort select cols by index of col_choices
+            select_cols.sort_by_cached_key(|x| col_choices.iter().position(|c| c == x).unwrap());
 
             let (comp1, comp2, comp3) = all_comps[rng.random_range(0..all_comps.len())];
             // Similarly as for the constraints, generate order by permutations so that the only columns involved in the index seek are potentially part of the ORDER BY.

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -211,32 +211,26 @@ mod tests {
         } else {
             rng_from_time()
         };
+        let table_defs: [&str; 8] = [
+            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y, z))",
+            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y, z))",
+            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y desc, z))",
+            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y, z desc))",
+            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y desc, z))",
+            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y, z desc))",
+            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y desc, z desc))",
+            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y desc, z desc))",
+        ];
         // Create all different 3-column primary key permutations
         let dbs = [
-            TempDatabase::new_with_rusqlite(
-                "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y, z))",
-            ),
-            TempDatabase::new_with_rusqlite(
-                "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y, z))",
-            ),
-            TempDatabase::new_with_rusqlite(
-                "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y desc, z))",
-            ),
-            TempDatabase::new_with_rusqlite(
-                "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y, z desc))",
-            ),
-            TempDatabase::new_with_rusqlite(
-                "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y desc, z))",
-            ),
-            TempDatabase::new_with_rusqlite(
-                "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y desc, z desc))",
-            ),
-            TempDatabase::new_with_rusqlite(
-                "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y, z desc))",
-            ),
-            TempDatabase::new_with_rusqlite(
-                "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y desc, z desc))",
-            ),
+            TempDatabase::new_with_rusqlite(table_defs[0]),
+            TempDatabase::new_with_rusqlite(table_defs[1]),
+            TempDatabase::new_with_rusqlite(table_defs[2]),
+            TempDatabase::new_with_rusqlite(table_defs[3]),
+            TempDatabase::new_with_rusqlite(table_defs[4]),
+            TempDatabase::new_with_rusqlite(table_defs[5]),
+            TempDatabase::new_with_rusqlite(table_defs[6]),
+            TempDatabase::new_with_rusqlite(table_defs[7]),
         ];
         let mut pk_tuples = HashSet::new();
         while pk_tuples.len() < 100000 {
@@ -475,8 +469,8 @@ mod tests {
                     }
 
                     panic!(
-                        "DIFFERENT RESULTS! limbo: {:?}, sqlite: {:?}, seed: {}, query: {}",
-                        limbo, sqlite, seed, query
+                        "DIFFERENT RESULTS! limbo: {:?}, sqlite: {:?}, seed: {}, query: {}, table def: {}",
+                        limbo, sqlite, seed, query, table_defs[i]
                     );
                 }
             }


### PR DESCRIPTION
## Beef

Followup to #1357 which did the same treatment for table btrees only. After this PR, all of our seeks use binary search for both interior and leaf pages.

## Perf comparison

using TPC-H 1GB db for this query:

```sql
limbo> explain select count(1) from lineitem join partsupp on l_partkey = ps_partkey and l_suppkey = ps_suppkey;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     18    0                    0   Start at 18
1     OpenRead           0     10    0                    0   table=lineitem, root=10
2     OpenRead           1     7     0                    0   table=sqlite_autoindex_partsupp_1, root=7
3     Rewind             0     14    0                    0   Rewind lineitem
4       Column           0     1     2                    0   r[2]=lineitem.l_partkey
5       IsNull           2     13    0                    0   if (r[2]==NULL) goto 13
6       Column           0     2     3                    0   r[3]=lineitem.l_suppkey
7       IsNull           3     13    0                    0   if (r[3]==NULL) goto 13
8       SeekGE           1     13    2                    0   key=[2..3] <-- index seek here, for every row in lineitem
9         IdxGT          1     13    2                    0   key=[2..3]
10        Integer        1     5     0                    0   r[5]=1
11        AggStep        0     5     4     count          0   accum=r[4] step(r[5])
12      Next             1     9     0                    0   
13    Next               0     4     0                    0   
14    AggFinal           0     4     0     count          0   accum=r[4]
15    Copy               4     1     0                    0   r[1]=r[4]
16    ResultRow          1     1     0                    0   output=r[1]
17    Halt               0     0     0                    0   
18    Transaction        0     0     0                    0   write=false
19    Goto               0     1     0                    0   
```

main:

```sql
limbo> select count(1) from lineitem join partsupp on l_partkey = ps_partkey and l_suppkey = ps_suppkey;
┌───────────┐
│ count (1) │
├───────────┤
│   6001215 │
└───────────┘
Command stats:
----------------------------
total: 40.292102375 s (this includes parsing/coloring of cli app)
```

PR:

```sql
limbo> select count(1) from lineitem join partsupp on l_partkey = ps_partkey and l_suppkey = ps_suppkey;
┌───────────┐
│ count (1) │
├───────────┤
│   6001215 │
└───────────┘
Command stats:
----------------------------
total: 14.021689916 s (this includes parsing/coloring of cli app)
```

almost 3x faster. buzzkill: still 3x slower than sqlite :)