### PR TITLE
btree/tablebtree_move_to: micro-optimizations

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -617,6 +617,23 @@ impl PageContent {
         Ok(rowid)
     }
 
+    /// Read the left child page of a table interior cell.
+    #[inline(always)]
+    pub fn cell_table_interior_read_left_child_page(&self, idx: usize) -> Result<u32> {
+        assert!(self.page_type() == PageType::TableInterior);
+        let buf = self.as_ptr();
+        const INTERIOR_PAGE_HEADER_SIZE_BYTES: usize = 12;
+        let cell_pointer_array_start = INTERIOR_PAGE_HEADER_SIZE_BYTES;
+        let cell_pointer = cell_pointer_array_start + (idx * 2);
+        let cell_pointer = self.read_u16(cell_pointer) as usize;
+        Ok(u32::from_be_bytes([
+            buf[cell_pointer],
+            buf[cell_pointer + 1],
+            buf[cell_pointer + 2],
+            buf[cell_pointer + 3],
+        ]))
+    }
+
     /// Read the rowid of a table leaf cell.
     #[inline(always)]
     pub fn cell_table_leaf_read_rowid(&self, idx: usize) -> Result<u64> {

--- a/core/types.rs
+++ b/core/types.rs
@@ -1402,6 +1402,7 @@ impl SeekOp {
     /// A seek with SeekOp::LE implies:
     /// Find the last table/index key that compares less than or equal to the seek key
     /// -> used in backwards iteration.
+    #[inline(always)]
     pub fn iteration_direction(&self) -> IterationDirection {
         match self {
             SeekOp::EQ | SeekOp::GE | SeekOp::GT => IterationDirection::Forwards,


### PR DESCRIPTION
```bash
jussi@Jussis-MacBook-Pro limbo % git co main && cargo build --bin limbo --release && hyperfine --shell=none --warmup 5 './target/release/limbo TPC-H.db "select l_orderkey, 3 as revenue, o_orderdate, o_shippriority from lineitem, orders, customer where c_mktsegment = '\''FURNITURE'\'' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < cast('\''1995-03-29'\'' as datetime) and l_shipdate > cast('\''1995-03-29'\'' as datetime);"'

...

Benchmark 1: ./target/release/limbo TPC-H.db "select l_orderkey, 3 as revenue, o_orderdate, o_shippriority from lineitem, orders, customer where c_mktsegment = 'FURNITURE' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < cast('1995-03-29' as datetime) and l_shipdate > cast('1995-03-29' as datetime);"
  Time (mean ± σ):      2.104 s ±  0.006 s    [User: 1.952 s, System: 0.151 s]
  Range (min … max):    2.094 s …  2.115 s    10 runs
 
jussi@Jussis-MacBook-Pro limbo % git co move-to-micro-opt && cargo build --bin limbo --release && hyperfine --shell=none --warmup 5 './target/release/limbo TPC-H.db "select l_orderkey, 3 as revenue, o_orderdate, o_shippriority from lineitem, orders, customer where c_mktsegment = '\''FURNITURE'\'' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < cast('\''1995-03-29'\'' as datetime) and l_shipdate > cast('\''1995-03-29'\'' as datetime);"'

...

Benchmark 1: ./target/release/limbo TPC-H.db "select l_orderkey, 3 as revenue, o_orderdate, o_shippriority from lineitem, orders, customer where c_mktsegment = 'FURNITURE' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < cast('1995-03-29' as datetime) and l_shipdate > cast('1995-03-29' as datetime);"
  Time (mean ± σ):      2.004 s ±  0.012 s    [User: 1.851 s, System: 0.150 s]
  Range (min … max):    1.990 s …  2.031 s    10 runs
```