### PR TITLE
Fix: allow page_size=65536

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5545,7 +5545,7 @@ mod tests {
         let db_file = Arc::new(DatabaseFile::new(io_file));
 
         let buffer_pool = Rc::new(BufferPool::new(page_size as usize));
-        let wal_shared = WalFileShared::open_shared(&io, "test.wal", page_size as u32).unwrap();
+        let wal_shared = WalFileShared::open_shared(&io, "test.wal", page_size).unwrap();
         let wal_file = WalFile::new(io.clone(), page_size, wal_shared, buffer_pool.clone());
         let wal = Rc::new(RefCell::new(wal_file));
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -257,7 +257,7 @@ impl Pager {
     /// In other words, if the page size is 512, then the reserved space size cannot exceed 32.
     pub fn usable_space(&self) -> usize {
         let db_header = self.db_header.lock();
-        (db_header.page_size - db_header.reserved_space as u16) as usize
+        (db_header.get_page_size() - db_header.reserved_space as u32) as usize
     }
 
     #[inline(always)]
@@ -685,7 +685,7 @@ impl Pager {
 
     pub fn usable_size(&self) -> usize {
         let db_header = self.db_header.lock();
-        (db_header.page_size - db_header.reserved_space as u16) as usize
+        (db_header.get_page_size() - db_header.reserved_space as u32) as usize
     }
 }
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -246,7 +246,7 @@ pub struct WalFile {
 
     sync_state: RefCell<SyncState>,
     syncing: Rc<RefCell<bool>>,
-    page_size: usize,
+    page_size: u32,
 
     shared: Arc<UnsafeCell<WalFileShared>>,
     ongoing_checkpoint: OngoingCheckpoint,
@@ -688,7 +688,7 @@ impl Wal for WalFile {
 impl WalFile {
     pub fn new(
         io: Arc<dyn IO>,
-        page_size: usize,
+        page_size: u32,
         shared: Arc<UnsafeCell<WalFileShared>>,
         buffer_pool: Rc<BufferPool>,
     ) -> Self {
@@ -728,7 +728,7 @@ impl WalFile {
     fn frame_offset(&self, frame_id: u64) -> usize {
         assert!(frame_id > 0, "Frame ID must be 1-based");
         let page_size = self.page_size;
-        let page_offset = (frame_id - 1) * (page_size + WAL_FRAME_HEADER_SIZE) as u64;
+        let page_offset = (frame_id - 1) * (page_size + WAL_FRAME_HEADER_SIZE as u32) as u64;
         let offset = WAL_HEADER_SIZE as u64 + page_offset;
         offset as usize
     }
@@ -743,7 +743,7 @@ impl WalFileShared {
     pub fn open_shared(
         io: &Arc<dyn IO>,
         path: &str,
-        page_size: u16,
+        page_size: u32,
     ) -> Result<Arc<UnsafeCell<WalFileShared>>> {
         let file = io.open_file(path, crate::io::OpenFlags::Create, false)?;
         let header = if file.size()? > 0 {
@@ -764,7 +764,7 @@ impl WalFileShared {
             let mut wal_header = WalHeader {
                 magic,
                 file_format: 3007000,
-                page_size: page_size as u32,
+                page_size,
                 checkpoint_seq: 0, // TODO implement sequence number
                 salt_1: io.generate_random_number() as u32,
                 salt_2: io.generate_random_number() as u32,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -261,7 +261,7 @@ fn query_pragma(
             program.emit_result_row(register, 1);
         }
         PragmaName::PageSize => {
-            program.emit_int(database_header.lock().page_size.into(), register);
+            program.emit_int(database_header.lock().get_page_size().into(), register);
             program.emit_result_row(register, 1);
         }
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4522,7 +4522,7 @@ pub fn op_open_ephemeral(
     let db_file = Arc::new(FileMemoryStorage::new(file));
 
     let db_header = Pager::begin_open(db_file.clone())?;
-    let buffer_pool = Rc::new(BufferPool::new(db_header.lock().page_size as usize));
+    let buffer_pool = Rc::new(BufferPool::new(db_header.lock().get_page_size() as usize));
     let page_cache = Arc::new(RwLock::new(DumbLruPageCache::new(10)));
 
     let pager = Rc::new(Pager::finish_open(


### PR DESCRIPTION
Since `page_size` in `DatabaseHeader` can be 1 representing 65526 bytes, it can't be used it directly.  Additionally, we should use `u32` instead of `u16` or `usize` in other contexts.
