### PR TITLE
implement Clone for Arc<Mutex> types

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -297,4 +297,8 @@ impl Row {
             limbo_core::OwnedValue::Blob(items) => Ok(Value::Blob(items.to_vec())),
         }
     }
+
+    pub fn column_count(&self) -> usize {
+        self.values.len()
+    }
 }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -129,6 +129,14 @@ pub struct Statement {
     inner: Arc<Mutex<limbo_core::Statement>>,
 }
 
+impl Clone for Statement {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
 unsafe impl Send for Statement {}
 unsafe impl Sync for Statement {}
 
@@ -239,6 +247,14 @@ pub struct Transaction {}
 
 pub struct Rows {
     inner: Arc<Mutex<limbo_core::Statement>>,
+}
+
+impl Clone for Rows {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 unsafe impl Send for Rows {}


### PR DESCRIPTION
`Statement` and `Rows` both have a private Arc, implementing clone avoids users needing to Arc<Mutex> it again.