### PR TITLE
Save history on exit

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -558,11 +558,13 @@ impl Limbo {
             }
             Ok(cmd) => match cmd.command {
                 Command::Exit(args) => {
+                    self.save_history();
                     std::process::exit(args.code);
                 }
                 Command::Quit => {
                     let _ = self.writeln("Exiting Limbo SQL Shell.");
                     let _ = self.close_conn();
+                    self.save_history();
                     std::process::exit(0)
                 }
                 Command::Open(args) => {
@@ -1008,12 +1010,16 @@ impl Limbo {
             Ok(input)
         }
     }
+
+    fn save_history(&mut self) {
+        if let Some(rl) = &mut self.rl {
+            let _ = rl.save_history(HISTORY_FILE.as_path());
+        }
+    }
 }
 
 impl Drop for Limbo {
     fn drop(&mut self) {
-        if let Some(rl) = &mut self.rl {
-            let _ = rl.save_history(HISTORY_FILE.as_path());
-        }
+        self.save_history()
     }
 }


### PR DESCRIPTION
Before this change, the history was only saved when the shell was interrupted (e.g., Ctrl-C pressed twice). With this change, history is now also saved when the `.exit` or `.quit` commands are used.

I attempted to add shell tests to cover the changes introduced in this PR, but emulating a terminal/TTY that would work cross-platform seems to require significant changes to `TestLimboShell` and `LimboShell`. For example, the `pty` module [currently doesn't support Windows](https://bugs.python.org/issue41663). I'm open to experimenting, but I’m unsure if complicating these classes is worthwhile, as saving history doesn't seem to be critical. 

Additionally, it might be worth considering a refactor of the CLI so that exit and cleanup operations are performed in one place.