### PR TITLE
Fix panic on async io due to reading locked page

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1944,6 +1944,7 @@ impl BTreeCursor {
                 let current_sibling = sibling_pointer;
                 for i in (0..=current_sibling).rev() {
                     let page = self.pager.read_page(pgno as usize)?;
+                    return_if_locked!(page);
                     debug_validate_cells!(&page.get_contents(), self.usable_space() as u16);
                     pages_to_balance[i].replace(page);
                     assert_eq!(

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1944,8 +1944,11 @@ impl BTreeCursor {
                 let current_sibling = sibling_pointer;
                 for i in (0..=current_sibling).rev() {
                     let page = self.pager.read_page(pgno as usize)?;
-                    return_if_locked!(page);
-                    debug_validate_cells!(&page.get_contents(), self.usable_space() as u16);
+                    #[cfg(debug_assertions)]
+                    {
+                        return_if_locked!(page);
+                        debug_validate_cells!(&page.get_contents(), self.usable_space() as u16);
+                    }
                     pages_to_balance[i].replace(page);
                     assert_eq!(
                         parent_contents.overflow_cells.len(),


### PR DESCRIPTION
closes  #1417
Man chasing this down was much much harder than it should have been.

We very frequently call `read_page` then push the return value onto the page stack, or otherwise use it without it necessarily needing to not be 'in progress' of IO, so it was tricky to figure out where this was happening and it had me thinking that it was something wrong with the changes to `io_uring` on my branch.