### PR TITLE
Add state machine for op_idx_delete + DeleteState simplification

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -903,6 +903,26 @@ impl ImmutableRecord {
     }
 }
 
+impl Display for ImmutableRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for value in &self.values {
+            match value {
+                RefValue::Null => write!(f, "NULL")?,
+                RefValue::Integer(i) => write!(f, "Integer({})", *i)?,
+                RefValue::Float(flo) => write!(f, "Float({})", *flo)?,
+                RefValue::Text(text_ref) => write!(f, "Text({})", text_ref.as_str())?,
+                RefValue::Blob(raw_slice) => {
+                    write!(f, "Blob({})", String::from_utf8_lossy(raw_slice.to_slice()))?
+                }
+            }
+            if value != self.values.last().unwrap() {
+                write!(f, ", ")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl Clone for ImmutableRecord {
     fn clone(&self) -> Self {
         let mut new_values = Vec::new();

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -43,7 +43,7 @@ use crate::CheckpointStatus;
 #[cfg(feature = "json")]
 use crate::json::JsonCacheCell;
 use crate::{Connection, MvStore, Result, TransactionState};
-use execute::{InsnFunction, InsnFunctionStepResult};
+use execute::{InsnFunction, InsnFunctionStepResult, OpIdxDeleteState};
 
 use rand::{
     distributions::{Distribution, Uniform},
@@ -257,6 +257,7 @@ pub struct ProgramState {
     halt_state: Option<HaltState>,
     #[cfg(feature = "json")]
     json_cache: JsonCacheCell,
+    op_idx_delete_state: Option<OpIdxDeleteState>,
 }
 
 impl ProgramState {
@@ -280,6 +281,7 @@ impl ProgramState {
             halt_state: None,
             #[cfg(feature = "json")]
             json_cache: JsonCacheCell::new(),
+            op_idx_delete_state: None,
         }
     }
 


### PR DESCRIPTION
DeleteState had a bit too many unnecessary states so I removed them. Usually we care about having a different state when I/O is triggered requiring a state to be stored for later.

Furthermore, there was a bug with op_idx_delete where if balance is triggered, op_idx_delete wouldn't be re-entrant. So a state machine was added to prevent that from happening.