### PR TITLE
Fix setting default value for primary key on UPDATE

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -686,7 +686,7 @@ fn emit_update_insns(
 
             // don't emit null for pkey of virtual tables. they require first two args
             // before the 'record' to be explicitly non-null
-            if table_column.primary_key && !is_virtual {
+            if table_column.is_rowid_alias && !is_virtual {
                 program.emit_null(target_reg, None);
             } else if is_virtual {
                 program.emit_insn(Insn::VColumn {


### PR DESCRIPTION
I noticed when updating a table with a primary key, it would sometimes set primary key column to null. I believe the problem was due to incorrect condition that was inconsistent with the comment above: "don't emit null for pkey of virtual tables."

cc: @PThorpe92 