### PR TITLE
Add PRAGMA schema_version

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -117,7 +117,7 @@ pub struct DatabaseHeader {
     pub freelist_pages: u32,
 
     /// The schema cookie. Incremented when the database schema changes.
-    schema_cookie: u32,
+    pub schema_cookie: u32,
 
     /// The schema format number. Supported formats are 1, 2, 3, and 4.
     schema_format: u32,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -154,6 +154,10 @@ fn update_pragma(
             // TODO: Implement updating user_version
             todo!("updating user_version not yet implemented")
         }
+        PragmaName::SchemaVersion => {
+            // TODO: Implement updating schema_version
+            todo!("updating schema_version not yet implemented")
+        }
         PragmaName::TableInfo => {
             // because we need control over the write parameter for the transaction,
             // this should be unreachable. We have to force-call query_pragma before
@@ -257,6 +261,14 @@ fn query_pragma(
                 db: 0,
                 dest: register,
                 cookie: Cookie::UserVersion,
+            });
+            program.emit_result_row(register, 1);
+        }
+        PragmaName::SchemaVersion => {
+            program.emit_insn(Insn::ReadCookie {
+                db: 0,
+                dest: register,
+                cookie: Cookie::SchemaVersion,
             });
             program.emit_result_row(register, 1);
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4336,6 +4336,7 @@ pub fn op_read_cookie(
     }
     let cookie_value = match cookie {
         Cookie::UserVersion => pager.db_header.lock().user_version.into(),
+        Cookie::SchemaVersion => pager.db_header.lock().schema_cookie.into(),
         cookie => todo!("{cookie:?} is not yet implement for ReadCookie"),
     };
     state.registers[*dest] = Register::OwnedValue(OwnedValue::Integer(cookie_value));

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1624,6 +1624,8 @@ pub enum PragmaName {
     PageCount,
     /// Return the page size of the database in bytes.
     PageSize,
+    /// Returns schema version of the database file.
+    SchemaVersion,
     /// returns information about the columns of a table
     TableInfo,
     /// Returns the user version of the database file.


### PR DESCRIPTION
This PR adds `PRAGMA schema_version` to get the value of the schema-version integer at offset 40 in the database header.