### PR TITLE
Update Unique constraint for Primary Keys and Indexes

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -775,12 +775,13 @@ fn emit_update_insns(
             let rowid_reg = beg;
             let idx_cols_start_reg = beg + 1;
 
+
             // copy each index column from the table's column registers into these scratch regs
-            for i in 0..num_cols {
+            for (i, col) in index.columns.iter().enumerate(){
                 // copy from the table's column register over to the index's scratch register
 
                 program.emit_insn(Insn::Copy {
-                    src_reg: idx_cols_start_reg + i,
+                    src_reg: idx_cols_start_reg + col.pos_in_table,
                     dst_reg: idx_start_reg + i,
                     amount: 0,
                 });

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -485,6 +485,7 @@ fn emit_delete_insns(
             program.emit_insn(Insn::OpenWrite {
                 cursor_id: index_cursor_id,
                 root_page: RegisterOrLiteral::Literal(index.root_page),
+                name: index.name.clone(),
             });
             let num_regs = index.columns.len() + 1;
             let start_reg = program.alloc_registers(num_regs);

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -593,6 +593,7 @@ fn emit_program_for_update(
     // Open indexes for update.
     let mut index_cursors = Vec::with_capacity(plan.indexes_to_update.len());
     // TODO: do not reopen if there is table reference using it.
+
     for index in &plan.indexes_to_update {
         let index_cursor = program.alloc_cursor_id(
             Some(index.table_name.clone()),
@@ -603,7 +604,8 @@ fn emit_program_for_update(
             root_page: RegisterOrLiteral::Literal(index.root_page),
             name: index.name.clone(),
         });
-        index_cursors.push(index_cursor);
+        let record_reg = program.alloc_register();
+        index_cursors.push((index_cursor, record_reg));
     }
     open_loop(
         program,
@@ -644,7 +646,7 @@ fn emit_update_insns(
     plan: &UpdatePlan,
     t_ctx: &TranslateCtx,
     program: &mut ProgramBuilder,
-    index_cursors: Vec<usize>,
+    index_cursors: Vec<(usize, usize)>,
 ) -> crate::Result<()> {
     let table_ref = &plan.table_references.first().unwrap();
     let loop_labels = t_ctx.labels_main_loop.first().unwrap();
@@ -670,46 +672,6 @@ fn emit_update_insns(
         },
         _ => return Ok(()),
     };
-
-    // THIS IS SAME CODE AS WE HAVE ON INSERT
-    // allocate cursor id's for each btree index cursor we'll need to populate the indexes
-    // (idx name, root_page, idx cursor id)
-    let idx_cursors = plan
-        .indexes_to_update
-        .iter()
-        .map(|idx| {
-            let record_reg = program.alloc_register();
-            (
-                &idx.name,
-                idx.root_page,
-                program.alloc_cursor_id(
-                    Some(idx.table_name.clone()),
-                    CursorType::BTreeIndex(idx.clone()),
-                ),
-                record_reg,
-            )
-        })
-        .collect::<Vec<(&String, usize, usize, usize)>>();
-
-    if !idx_cursors.is_empty() {
-        let open_indices_label = program.allocate_label();
-
-        // Open all cursors Once
-        program.emit_insn(Insn::Once {
-            target_pc_when_reentered: open_indices_label,
-        });
-
-        // Open all the index btrees for writing
-        for idx_cursor in idx_cursors.iter() {
-            program.emit_insn(Insn::OpenWrite {
-                cursor_id: idx_cursor.2,
-                root_page: idx_cursor.1.into(),
-                name: idx_cursor.0.clone(),
-            });
-        }
-
-        program.preassign_label_to_next_insn(open_indices_label);
-    }
 
     for cond in plan
         .where_clause
@@ -797,86 +759,6 @@ fn emit_update_insns(
         });
     }
 
-    for (pos, index) in plan.indexes_to_update.iter().enumerate() {
-        if index.unique {
-            let (_, _, idx_cursor_id, record_reg) =
-                idx_cursors.get(pos).expect("index cursor should exist");
-
-            let num_cols = index.columns.len();
-            // allocate scratch registers for the index columns plus rowid
-            let idx_start_reg = program.alloc_registers(num_cols + 1);
-
-            let rowid_reg = beg;
-            let idx_cols_start_reg = beg + 1;
-
-            // copy each index column from the table's column registers into these scratch regs
-            for (i, col) in index.columns.iter().enumerate() {
-                // copy from the table's column register over to the index's scratch register
-
-                program.emit_insn(Insn::Copy {
-                    src_reg: idx_cols_start_reg + col.pos_in_table,
-                    dst_reg: idx_start_reg + i,
-                    amount: 0,
-                });
-            }
-            // last register is the rowid
-            program.emit_insn(Insn::Copy {
-                src_reg: rowid_reg,
-                dst_reg: idx_start_reg + num_cols,
-                amount: 0,
-            });
-
-            program.emit_insn(Insn::MakeRecord {
-                start_reg: idx_start_reg,
-                count: num_cols + 1,
-                dest_reg: *record_reg,
-                index_name: Some(index.name.clone()),
-            });
-
-            let constraint_check = program.allocate_label();
-            program.emit_insn(Insn::NoConflict {
-                cursor_id: *idx_cursor_id,
-                target_pc: constraint_check,
-                record_reg: idx_start_reg,
-                num_regs: num_cols,
-            });
-
-            let column_names = index.columns.iter().enumerate().fold(
-                String::with_capacity(50),
-                |mut accum, (idx, col)| {
-                    if idx > 0 {
-                        accum.push_str(", ");
-                    }
-                    accum.push_str(&table_ref.table.get_name());
-                    accum.push('.');
-                    accum.push_str(&col.name);
-
-                    accum
-                },
-            );
-
-            let idx_rowid_reg = program.alloc_register();
-            program.emit_insn(Insn::IdxRowId {
-                cursor_id: *idx_cursor_id,
-                dest: idx_rowid_reg,
-            });
-
-            program.emit_insn(Insn::Eq {
-                lhs: rowid_reg,
-                rhs: idx_rowid_reg,
-                target_pc: constraint_check,
-                flags: CmpInsFlags::default(), // TODO: not sure what type of comparison flag is needed
-            });
-
-            program.emit_insn(Insn::Halt {
-                err_code: SQLITE_CONSTRAINT_PRIMARYKEY, // TODO: distinct between primary key and unique index for error code
-                description: column_names,
-            });
-
-            program.preassign_label_to_next_insn(constraint_check);
-        }
-    }
-
     for cond in plan
         .where_clause
         .iter()
@@ -896,47 +778,6 @@ fn emit_update_insns(
         )?;
     }
 
-    // Update indexes first. Columns that are updated will be translated from an expression and those who aren't modified will be
-    // read from table. Mutiple value index key could be updated partially.
-    for (index, index_cursor) in plan.indexes_to_update.iter().zip(index_cursors) {
-        let index_record_reg_count = index.columns.len() + 1;
-        let index_record_reg_start = program.alloc_registers(index_record_reg_count);
-        for (idx, column) in index.columns.iter().enumerate() {
-            if let Some((_, expr)) = plan.set_clauses.iter().find(|(i, _)| *i == idx) {
-                translate_expr(
-                    program,
-                    Some(&plan.table_references),
-                    expr,
-                    index_record_reg_start + idx,
-                    &t_ctx.resolver,
-                )?;
-            } else {
-                program.emit_insn(Insn::Column {
-                    cursor_id: cursor_id,
-                    column: column.pos_in_table,
-                    dest: index_record_reg_start + idx,
-                });
-            }
-        }
-        program.emit_insn(Insn::RowId {
-            cursor_id: cursor_id,
-            dest: index_record_reg_start + index.columns.len(),
-        });
-        let index_record_reg = program.alloc_register();
-        program.emit_insn(Insn::MakeRecord {
-            start_reg: index_record_reg_start,
-            count: index_record_reg_count,
-            dest_reg: index_record_reg,
-            index_name: Some(index.name.clone()),
-        });
-        program.emit_insn(Insn::IdxInsert {
-            cursor_id: index_cursor,
-            record_reg: index_record_reg,
-            unpacked_start: Some(index_record_reg_start),
-            unpacked_count: Some(index_record_reg_count as u16),
-            flags: IdxInsertFlags::new(),
-        });
-    }
     // we scan a column at a time, loading either the column's values, or the new value
     // from the Set expression, into registers so we can emit a MakeRecord and update the row.
     let start = if is_virtual { beg + 2 } else { beg + 1 };
@@ -1006,11 +847,8 @@ fn emit_update_insns(
         }
     }
 
-    for (pos, index) in plan.indexes_to_update.iter().enumerate() {
+    for (index, (idx_cursor_id, record_reg)) in plan.indexes_to_update.iter().zip(&index_cursors) {
         if index.unique {
-            let (_, _, idx_cursor_id, record_reg) =
-                idx_cursors.get(pos).expect("index cursor should exist");
-
             let num_cols = index.columns.len();
             // allocate scratch registers for the index columns plus rowid
             let idx_start_reg = program.alloc_registers(num_cols + 1);
@@ -1148,7 +986,8 @@ fn emit_update_insns(
         }
 
         // For each index -> insert
-        for (pos, index) in plan.indexes_to_update.iter().enumerate() {
+        for (index, (idx_cursor_id, record_reg)) in plan.indexes_to_update.iter().zip(index_cursors)
+        {
             let num_regs = index.columns.len() + 1;
             let start_reg = program.alloc_registers(num_regs);
 
@@ -1170,18 +1009,15 @@ fn emit_update_insns(
                 dest: start_reg + num_regs - 1,
             });
 
-            let (_, _, idx_cursor_id, record_reg) =
-                idx_cursors.get(pos).expect("index cursor should exist");
-
             program.emit_insn(Insn::IdxDelete {
                 start_reg,
                 num_regs,
-                cursor_id: *idx_cursor_id,
+                cursor_id: idx_cursor_id,
             });
 
             program.emit_insn(Insn::IdxInsert {
-                cursor_id: *idx_cursor_id,
-                record_reg: *record_reg,
+                cursor_id: idx_cursor_id,
+                record_reg: record_reg,
                 unpacked_start: Some(start),
                 unpacked_count: Some((index.columns.len() + 1) as u16),
                 flags: IdxInsertFlags::new(),

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -668,6 +668,25 @@ fn emit_update_insns(
         _ => return Ok(()),
     };
 
+    // dbg!(&plan.indexes);
+    // THIS IS SAME CODE AS WE HAVE ON INSERT
+    // allocate cursor id's for each btree index cursor we'll need to populate the indexes
+    // (idx name, root_page, idx cursor id)
+    let idx_cursors = plan
+        .indexes_to_update
+        .iter()
+        .map(|idx| {
+            (
+                &idx.name,
+                idx.root_page,
+                program.alloc_cursor_id(
+                    Some(idx.table_name.clone()),
+                    CursorType::BTreeIndex(idx.clone()),
+                ),
+            )
+        })
+        .collect::<Vec<(&String, usize, usize)>>();
+
     for cond in plan
         .where_clause
         .iter()

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -968,7 +968,6 @@ fn emit_update_insns(
                     &t_ctx.resolver,
                 )?;
             }
-            // if let Some(rowid_reg) = rowid_set_clause_reg {}
         } else {
             let column_idx_in_index = index.as_ref().and_then(|(idx, _)| {
                 idx.columns
@@ -1187,7 +1186,7 @@ fn emit_update_insns(
             });
         }
 
-        // program.emit_insn(Insn::Delete { cursor_id });
+        program.emit_insn(Insn::Delete { cursor_id });
 
         program.emit_insn(Insn::Insert {
             cursor: cursor_id,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -601,6 +601,7 @@ fn emit_program_for_update(
         program.emit_insn(Insn::OpenWrite {
             cursor_id: index_cursor,
             root_page: RegisterOrLiteral::Literal(index.root_page),
+            name: index.name.clone(),
         });
         index_cursors.push(index_cursor);
     }
@@ -926,6 +927,7 @@ fn emit_update_insns(
             start_reg: index_record_reg_start,
             count: index_record_reg_count,
             dest_reg: index_record_reg,
+            index_name: Some(index.name.clone()),
         });
         program.emit_insn(Insn::IdxInsert {
             cursor_id: index_cursor,
@@ -1004,7 +1006,7 @@ fn emit_update_insns(
         }
     }
 
-    for (pos, index) in plan.indexes.iter().enumerate() {
+    for (pos, index) in plan.indexes_to_update.iter().enumerate() {
         if index.unique {
             let (_, _, idx_cursor_id, record_reg) =
                 idx_cursors.get(pos).expect("index cursor should exist");

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -880,6 +880,7 @@ fn emit_update_insns(
             start_reg: start,
             count: table_ref.columns().len(),
             dest_reg: record_reg,
+            index_name: None,
         });
         program.emit_insn(Insn::Insert {
             cursor: cursor_id,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -688,6 +688,23 @@ fn emit_update_insns(
         })
         .collect::<Vec<(&String, usize, usize)>>();
 
+    let open_indices_label = program.allocate_label();
+    // Open all cursors Once
+    program.emit_insn(Insn::Once {
+        target_pc_when_reentered: open_indices_label,
+    });
+
+    // Open all the index btrees for writing
+    for idx_cursor in idx_cursors.iter() {
+        program.emit_insn(Insn::OpenWrite {
+            cursor_id: idx_cursor.2,
+            root_page: idx_cursor.1.into(),
+            name: idx_cursor.0.clone(),
+        });
+    }
+
+    program.resolve_label(open_indices_label, program.offset());
+
     for cond in plan
         .where_clause
         .iter()

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -100,6 +100,7 @@ pub fn translate_create_index(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: RegisterOrLiteral::Literal(sqlite_table.root_page),
+        name: sqlite_table.name.clone(),
     });
     let sql = create_idx_stmt_to_sql(&tbl_name, &idx_name, unique_if_not_exists, &columns);
     emit_schema_entry(
@@ -181,6 +182,7 @@ pub fn translate_create_index(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: btree_cursor_id,
         root_page: RegisterOrLiteral::Register(root_page_reg),
+        name: idx_name.clone()
     });
 
     let sorted_loop_start = program.allocate_label();

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -165,6 +165,7 @@ pub fn translate_create_index(
         start_reg,
         count: columns.len() + 1,
         dest_reg: record_reg,
+        index_name: Some(idx_name.clone()),
     });
     program.emit_insn(Insn::SorterInsert {
         cursor_id: sorter_cursor_id,
@@ -182,7 +183,7 @@ pub fn translate_create_index(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: btree_cursor_id,
         root_page: RegisterOrLiteral::Register(root_page_reg),
-        name: idx_name.clone()
+        name: idx_name.clone(),
     });
 
     let sorted_loop_start = program.allocate_label();

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -378,6 +378,7 @@ pub fn translate_drop_index(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: RegisterOrLiteral::Literal(sqlite_table.root_page),
+        name: sqlite_table.name.clone(),
     });
 
     let loop_start_label = program.allocate_label();

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -177,6 +177,7 @@ pub fn translate_insert(
         program.emit_insn(Insn::OpenWrite {
             cursor_id,
             root_page: RegisterOrLiteral::Literal(root_page),
+            name: table_name.0.clone(),
         });
 
         // Main loop
@@ -192,6 +193,7 @@ pub fn translate_insert(
         program.emit_insn(Insn::OpenWrite {
             cursor_id,
             root_page: RegisterOrLiteral::Literal(root_page),
+            name: table_name.0.clone(),
         });
 
         populate_column_registers(
@@ -209,6 +211,7 @@ pub fn translate_insert(
         program.emit_insn(Insn::OpenWrite {
             cursor_id: idx_cursor.2,
             root_page: idx_cursor.1.into(),
+            name: idx_cursor.0.clone(),
         });
     }
     // Common record insertion logic for both single and multiple rows

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -1227,6 +1227,7 @@ fn emit_autoindex(
         start_reg: ephemeral_cols_start_reg,
         count: num_regs_to_reserve,
         dest_reg: record_reg,
+        index_name: Some(index.name.clone()),
     });
     program.emit_insn(Insn::IdxInsert {
         cursor_id: index_cursor_id,

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -110,6 +110,7 @@ pub fn init_loop(
                         cursor_id: table_cursor_id
                             .expect("table cursor is always opened in OperationMode::DELETE"),
                         root_page: root_page.into(),
+                        name: btree.name.clone(),
                     });
                 }
                 (OperationMode::UPDATE, Table::BTree(btree)) => {
@@ -118,11 +119,13 @@ pub fn init_loop(
                         cursor_id: table_cursor_id
                             .expect("table cursor is always opened in OperationMode::UPDATE"),
                         root_page: root_page.into(),
+                        name: btree.name.clone(),
                     });
                     if let Some(index_cursor_id) = index_cursor_id {
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id: index_cursor_id,
                             root_page: index.as_ref().unwrap().root_page.into(),
+                            name: index.as_ref().unwrap().name.clone(),
                         });
                     }
                 }
@@ -148,6 +151,7 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id: table_cursor_id,
                             root_page: table.table.get_root_page().into(),
+                            name: table.table.get_name().to_string(),
                         });
                     }
                     _ => {
@@ -174,6 +178,7 @@ pub fn init_loop(
                                     cursor_id: index_cursor_id
                                         .expect("index cursor is always opened in Seek with index"),
                                     root_page: index.root_page.into(),
+                                    name: index.name.clone(),
                                 });
                             }
                             _ => {

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -247,6 +247,7 @@ pub fn sorter_insert(
         start_reg,
         count: column_count,
         dest_reg: record_reg,
+        index_name: None,
     });
     program.emit_insn(Insn::SorterInsert {
         cursor_id,

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -120,6 +120,7 @@ pub fn translate_create_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
+        name: tbl_name.name.0.clone()
     });
 
     // Add the table entry to sqlite_schema
@@ -582,6 +583,7 @@ pub fn translate_create_virtual_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
+        name: table_name.clone()
     });
 
     let sql = create_vtable_body_to_str(&vtab, vtab_module.clone());
@@ -661,6 +663,7 @@ pub fn translate_drop_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
+        name: tbl_name.name.0.clone()
     });
 
     //  1. Remove all entries from the schema table related to the table we are dropping, except for triggers

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -120,7 +120,7 @@ pub fn translate_create_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
-        name: tbl_name.name.0.clone()
+        name: tbl_name.name.0.clone(),
     });
 
     // Add the table entry to sqlite_schema
@@ -237,6 +237,7 @@ pub fn emit_schema_entry(
         start_reg: type_reg,
         count: 5,
         dest_reg: record_reg,
+        index_name: None,
     });
 
     program.emit_insn(Insn::Insert {
@@ -564,6 +565,7 @@ pub fn translate_create_virtual_table(
             start_reg: args_start,
             count: args_vec.len(),
             dest_reg: args_record_reg,
+            index_name: None,
         });
         Some(args_record_reg)
     } else {
@@ -583,7 +585,7 @@ pub fn translate_create_virtual_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
-        name: table_name.clone()
+        name: table_name.clone(),
     });
 
     let sql = create_vtable_body_to_str(&vtab, vtab_module.clone());
@@ -663,7 +665,7 @@ pub fn translate_drop_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
-        name: tbl_name.name.0.clone()
+        name: tbl_name.name.0.clone(),
     });
 
     //  1. Remove all entries from the schema table related to the table we are dropping, except for triggers

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1444,6 +1444,7 @@ pub fn op_make_record(
         start_reg,
         count,
         dest_reg,
+        ..
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1122,6 +1122,7 @@ pub fn insn_to_str(
             Insn::OpenWrite {
                 cursor_id,
                 root_page,
+                name,
                 ..
             } => (
                 "OpenWrite",
@@ -1133,7 +1134,7 @@ pub fn insn_to_str(
                 0,
                 OwnedValue::build_text(""),
                 0,
-                "".to_string(),
+                format!("root={}; {}", root_page, name),
             ),
             Insn::Copy {
                 src_reg,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -529,20 +529,25 @@ pub fn insn_to_str(
                 start_reg,
                 count,
                 dest_reg,
-            } => (
-                "MakeRecord",
-                *start_reg as i32,
-                *count as i32,
-                *dest_reg as i32,
-                OwnedValue::build_text(""),
-                0,
-                format!(
-                    "r[{}]=mkrec(r[{}..{}])",
-                    dest_reg,
-                    start_reg,
-                    start_reg + count - 1,
-                ),
-            ),
+                index_name,
+            } => {
+                let for_index = index_name.as_ref().map(|name| format!(" ;for {}", name));
+                (
+                    "MakeRecord",
+                    *start_reg as i32,
+                    *count as i32,
+                    *dest_reg as i32,
+                    OwnedValue::build_text(""),
+                    0,
+                    format!(
+                        "r[{}]=mkrec(r[{}..{}]){}",
+                        dest_reg,
+                        start_reg,
+                        start_reg + count - 1,
+                        for_index.unwrap_or("".to_string())
+                    ),
+                )
+            }
             Insn::ResultRow { start_reg, count } => (
                 "ResultRow",
                 *start_reg as i32,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1086,15 +1086,22 @@ pub fn insn_to_str(
                 target_pc,
                 record_reg,
                 num_regs,
-            } => (
-                "NoConflict",
-                *cursor_id as i32,
-                target_pc.to_debug_int(),
-                *record_reg as i32,
-                OwnedValue::build_text(&format!("{num_regs}")),
-                0,
-                format!("key=r[{}]", record_reg),
-            ),
+            } => {
+                let key = if *num_regs > 0 {
+                    format!("key=r[{}..{}]", record_reg, record_reg + num_regs - 1)
+                } else {
+                    format!("key=r[{}]", record_reg)
+                };
+                (
+                    "NoConflict",
+                    *cursor_id as i32,
+                    target_pc.to_debug_int(),
+                    *record_reg as i32,
+                    OwnedValue::build_text(&format!("{num_regs}")),
+                    0,
+                    key,
+                )
+            }
             Insn::NotExists {
                 cursor,
                 rowid_reg,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -531,7 +531,7 @@ pub fn insn_to_str(
                 dest_reg,
                 index_name,
             } => {
-                let for_index = index_name.as_ref().map(|name| format!(" ;for {}", name));
+                let for_index = index_name.as_ref().map(|name| format!("; for {}", name));
                 (
                     "MakeRecord",
                     *start_reg as i32,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -82,7 +82,7 @@ impl IdxInsertFlags {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub enum RegisterOrLiteral<T: Copy> {
+pub enum RegisterOrLiteral<T: Copy + std::fmt::Display> {
     Register(usize),
     Literal(T),
 }
@@ -90,6 +90,15 @@ pub enum RegisterOrLiteral<T: Copy> {
 impl From<PageIdx> for RegisterOrLiteral<PageIdx> {
     fn from(value: PageIdx) -> Self {
         RegisterOrLiteral::Literal(value)
+    }
+}
+
+impl<T: Copy + std::fmt::Display> std::fmt::Display for RegisterOrLiteral<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Literal(lit) => lit.fmt(f),
+            Self::Register(reg) => reg.fmt(f),
+        }
     }
 }
 

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -708,6 +708,7 @@ pub enum Insn {
     OpenWrite {
         cursor_id: CursorID,
         root_page: RegisterOrLiteral<PageIdx>,
+        name: String,
     },
 
     Copy {

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -373,6 +373,7 @@ pub enum Insn {
         start_reg: usize, // P1
         count: usize,     // P2
         dest_reg: usize,  // P3
+        index_name: Option<String>,
     },
 
     /// Emit a row of results.

--- a/flake.nix
+++ b/flake.nix
@@ -24,10 +24,17 @@
 
         lib = pkgs.lib;
 
+        # Custom SQLite package with debug enabled
+        sqlite-debug = pkgs.sqlite.overrideAttrs (oldAttrs: rec {
+          name = "sqlite-debug-${oldAttrs.version}";
+          configureFlags = oldAttrs.configureFlags ++ [ "--enable-debug" ];
+          dontStrip = true;
+          separateDebugInfo = true;
+        });
+
         cargoArtifacts = craneLib.buildDepsOnly {
           src = ./.;
           pname = "limbo";
-          stritcDeps = true;
           nativeBuildInputs = with pkgs; [ python3 ];
         };
 
@@ -58,7 +65,7 @@
         devShells.default = with pkgs; mkShell {
           nativeBuildInputs = [
             clang
-            sqlite
+            sqlite-debug  # Use debug-enabled SQLite
             gnumake
             tcl
             python3

--- a/testing/cli_tests/constraint.py
+++ b/testing/cli_tests/constraint.py
@@ -304,9 +304,8 @@ def generate_test(col_amount: int, primary_keys: int) -> ConstraintTest:
 
     update_errors = []
     if len(insert_stmts) > 1:
-        update_errors = [
-            table.generate_update() for _ in table.columns if col.primary_key
-        ]
+        # TODO: As we have no rollback we just generate one update statement
+        update_errors = [table.generate_update()]
 
     return ConstraintTest(
         table=table,
@@ -327,7 +326,6 @@ def custom_test_1() -> ConstraintTest:
         "INSERT INTO users VALUES (2, 'bob');",
     ]
     update_stmts = [
-        "UPDATE users SET id = 3;",
         "UPDATE users SET id = 2, username = 'bob' WHERE id == 1;",
     ]
     return ConstraintTest(

--- a/testing/cli_tests/constraint.py
+++ b/testing/cli_tests/constraint.py
@@ -230,12 +230,24 @@ class Table(BaseModel):
 
         return f"INSERT INTO {self.name} VALUES ({vals});"
 
+    # These statements should always cause a constraint error as there is no where clause here
+    def generate_update(self) -> str:
+        vals = [
+            f"{col.name} = {col.col_type.generate(fake)}"
+            for col in self.columns
+            if col.primary_key
+        ]
+        vals = ", ".join(vals)
+
+        return f"UPDATE {self.name} SET {vals};"
+
 
 class ConstraintTest(BaseModel):
     table: Table
     db_path: str = "testing/constraint.db"
     insert_stmts: list[str]
     insert_errors: list[str]
+    update_errors: list[str]
 
     def run(
         self,
@@ -257,6 +269,14 @@ class ConstraintTest(BaseModel):
             f"SELECT count(*) from {self.table.name};",
             str(len(self.insert_stmts)),
         )
+
+        for update_stmt in self.update_errors:
+            limbo.run_test_fn(
+                update_stmt,
+                lambda val: "Runtime error: UNIQUE constraint failed" in val,
+            )
+
+        # TODO: When we implement rollbacks, have a test here to assure the values did not change
 
 
 def validate_with_expected(result: str, expected: str):
@@ -281,8 +301,18 @@ def generate_test(col_amount: int, primary_keys: int) -> ConstraintTest:
 
     table = Table(columns=cols, name=fake.word())
     insert_stmts = [table.generate_insert() for _ in range(col_amount)]
+
+    update_errors = []
+    if len(insert_stmts) > 1:
+        update_errors = [
+            table.generate_update() for _ in table.columns if col.primary_key
+        ]
+
     return ConstraintTest(
-        table=table, insert_stmts=insert_stmts, insert_errors=insert_stmts
+        table=table,
+        insert_stmts=insert_stmts,
+        insert_errors=insert_stmts,
+        update_errors=update_errors,
     )
 
 
@@ -296,8 +326,15 @@ def custom_test_1() -> ConstraintTest:
         "INSERT INTO users VALUES (1, 'alice');",
         "INSERT INTO users VALUES (2, 'bob');",
     ]
+    update_stmts = [
+        "UPDATE users SET id = 3;",
+        "UPDATE users SET id = 2, username = 'bob' WHERE id == 1;",
+    ]
     return ConstraintTest(
-        table=table, insert_stmts=insert_stmts, insert_errors=insert_stmts
+        table=table,
+        insert_stmts=insert_stmts,
+        insert_errors=insert_stmts,
+        update_errors=update_stmts,
     )
 
 


### PR DESCRIPTION
This PR attempts to implement Primary Key and Indexes. It supports Update for Primary Keys as a RowId Alias, Composite Primary Keys, and Indexes. I tried to resemble as much as possible how SQLite emits the Opcodes.

~Additionally, to support this I had to fix a bug in the how we searched for the next records in the `Next` opcode, by introducing a Set of seen row id's. The problem was that, you need to delete the previous record and then insert the new record to update. When we did that in a `Rewind` loop, the current cell index in the cursor was always pointing to the incorrect place because we were searching for the next record without checking if we had seen it before. However, I am not sure how this affects the Btree.~
EDIT: After seeing how bad my fix was, I tried a different approach that is more in line with what SQLite does. When performing a `Delete` in the btree, we can save the current `rowid` (`TableBtree`) or the current `record` for (`IndexBtree`), and then restore the correct position later in the `next` function by seeking to the saved context. I'm just not knowledgeable enough yet to be efficient  of when we can avoid saving the context and doing the seek later. 