### PR TITLE
Eliminate a superfluous read transaction when doing PRAGMA user_version

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -256,7 +256,6 @@ fn query_pragma(
             }
         }
         PragmaName::UserVersion => {
-            program.emit_transaction(false);
             program.emit_insn(Insn::ReadCookie {
                 db: 0,
                 dest: register,


### PR DESCRIPTION
This PR removes an unnecessary read transaction.

Bytecode before this PR:
```
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     5     0                    0   Start at 5
1     Transaction        0     0     0                    0   write=false
2     ReadCookie         0     1     6                    0
3     ResultRow          1     1     0                    0   output=r[1]
4     Halt               0     0     0                    0
5     Transaction        0     0     0                    0   write=false
6     Goto               0     1     0                    0
```
Bytecode after this PR:
```limbo> explain PRAGMA user_version;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     4     0                    0   Start at 4
1     ReadCookie         0     1     6                    0
2     ResultRow          1     1     0                    0   output=r[1]
3     Halt               0     0     0                    0
4     Transaction        0     0     0                    0   write=false
5     Goto               0     1     0                    0
```