### PR TITLE
Read only mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,7 @@ dependencies = [
 name = "limbo_core"
 version = "0.0.19"
 dependencies = [
+ "bitflags 2.9.0",
  "built",
  "cfg_block",
  "chrono",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -73,6 +73,7 @@ parking_lot = "0.12.3"
 crossbeam-skiplist = "0.1.3"
 tracing = "0.1.41"
 ryu = "1.0.19"
+bitflags = "2.9.0"
 
 [build-dependencies]
 chrono = { version = "0.4.38", default-features = false }

--- a/core/error.rs
+++ b/core/error.rs
@@ -51,6 +51,8 @@ pub enum LimboError {
     IntegerOverflow,
     #[error("Schema is locked for write")]
     SchemaLocked,
+    #[error("Database Connection is read-only")]
+    ReadOnly,
 }
 
 #[macro_export]

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -139,11 +139,15 @@ impl WrappedIOUring {
 impl IO for UringIO {
     fn open_file(&self, path: &str, flags: OpenFlags, direct: bool) -> Result<Arc<dyn File>> {
         trace!("open_file(path = {})", path);
-        let file = std::fs::File::options()
-            .read(true)
-            .write(true)
-            .create(matches!(flags, OpenFlags::Create))
-            .open(path)?;
+        let mut file = std::fs::File::options();
+        file.read(true);
+
+        if !flags.contains(OpenFlags::ReadOnly) {
+            file.write(true);
+            file.create(flags.contains(OpenFlags::Create));
+        }
+
+        let file = file.open(path)?;
         // Let's attempt to enable direct I/O. Not all filesystems support it
         // so ignore any errors.
         let fd = file.as_fd();
@@ -158,7 +162,7 @@ impl IO for UringIO {
             file,
         });
         if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err() {
-            uring_file.lock_file(true)?;
+            uring_file.lock_file(!flags.contains(OpenFlags::ReadOnly))?;
         }
         Ok(uring_file)
     }

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use bitflags::bitflags;
 use cfg_block::cfg_block;
 use std::fmt;
 use std::sync::Arc;
@@ -19,18 +20,20 @@ pub trait File: Send + Sync {
     fn size(&self) -> Result<u64>;
 }
 
-#[derive(Copy, Clone)]
-pub enum OpenFlags {
-    None,
-    Create,
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct OpenFlags(i32);
+
+bitflags! {
+    impl OpenFlags: i32 {
+        const None = 0b00000000;
+        const Create = 0b0000001;
+        const ReadOnly = 0b0000010;
+    }
 }
 
-impl OpenFlags {
-    pub fn to_flags(&self) -> i32 {
-        match self {
-            Self::None => 0,
-            Self::Create => 1,
-        }
+impl Default for OpenFlags {
+    fn default() -> Self {
+        Self::Create
     }
 }
 

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -24,7 +24,7 @@ impl IO for VfsMod {
         })?;
         let ctx = self.ctx as *mut c_void;
         let vfs = unsafe { &*self.ctx };
-        let file = unsafe { (vfs.open)(ctx, c_path.as_ptr(), flags.to_flags(), direct) };
+        let file = unsafe { (vfs.open)(ctx, c_path.as_ptr(), flags.0, direct) };
         if file.is_null() {
             return Err(LimboError::ExtensionError("File not found".to_string()));
         }

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -19,11 +19,15 @@ unsafe impl Sync for WindowsIO {}
 impl IO for WindowsIO {
     fn open_file(&self, path: &str, flags: OpenFlags, direct: bool) -> Result<Arc<dyn File>> {
         trace!("open_file(path = {})", path);
-        let file = std::fs::File::options()
-            .read(true)
-            .write(true)
-            .create(matches!(flags, OpenFlags::Create))
-            .open(path)?;
+        let mut file = std::fs::File::options();
+        file.read(true);
+
+        if !flags.contains(OpenFlags::ReadOnly) {
+            file.write(true);
+            file.create(flags.contains(OpenFlags::Create));
+        }
+
+        let file = file.open(path)?;
         Ok(Arc::new(WindowsFile {
             file: RefCell::new(file),
         }))


### PR DESCRIPTION
Closes #1413 . Basically, SQLite emits a check in a transaction to see if it is attempting to write. If the db is in read only mode, it throws an error, else the statement is executed. Mirroring how Rusqlite does it, I modified the `OpenFlags` to use bitflags to better configure how we open our VFS. This modification, will enable us to run tests against the same database in parallel.