### PR TITLE
Add time.Time support to Go driver parameter binding

### DIFF
--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"runtime"
+	"time"
 	"unsafe"
 )
 
@@ -244,6 +245,12 @@ func buildArgs(args []driver.Value) ([]limboValue, func(), error) {
 			blob := makeBlob(val)
 			pinner.Pin(blob)
 			*(*uintptr)(unsafe.Pointer(&limboVal.Value)) = uintptr(unsafe.Pointer(blob))
+		case time.Time: // Add this case
+			limboVal.Type = textVal
+			timeStr := val.Format(time.RFC3339)
+			cstr := CString(timeStr)
+			pinner.Pin(cstr)
+			*(*uintptr)(unsafe.Pointer(&limboVal.Value)) = uintptr(unsafe.Pointer(cstr))
 		default:
 			return nil, pinner.Unpin, fmt.Errorf("unsupported type: %T", v)
 		}


### PR DESCRIPTION
### Problem
The Limbo Go driver currently throws an "unsupported type" error when trying to bind `time.Time` values as query parameters. This requires applications to manually convert datetime values to strings before passing them to queries.

### Solution
Added `time.Time` support to the `buildArgs` function in `types.go`. The implementation:
- Converts `time.Time` to RFC3339 format strings 
- Uses the existing `textVal` type for storage
- Maintains compatibility with Limbo's datetime handling

### Example Usage
```go
// Previously failed with "unsupported type: time.Time"
now := time.Now()
db.Exec("INSERT INTO events (timestamp) VALUES (?)", now)

// Now works as expected
```
### Testing

I tested with various datetime operations:

- Parameter binding with time.Time
- Round-trip storage and retrieval
- Compatibility with existing datetime functions

Values are stored in standard ISO8601/RFC3339 format which I believe is same as sqlite.
