### PR TITLE
Count optimization

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4258,8 +4258,7 @@ impl BTreeCursor {
              ** this page contains countable entries. Increment the entry counter
              ** accordingly.
              */
-            // TODO: (pedrocarlo) does not take into account if "tree is not an int-key tree" condition
-            if contents.is_leaf() {
+            if !matches!(contents.page_type(), PageType::TableInterior) {
                 self.count += contents.cell_count();
             }
 
@@ -4286,7 +4285,7 @@ impl BTreeCursor {
 
                     let cell_idx = self.stack.current_cell_index() as usize;
 
-                    if !(cell_idx > contents.cell_count()) {
+                    if cell_idx <= contents.cell_count() {
                         break;
                     }
                 }

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -289,7 +289,7 @@ pub fn emit_query<'a>(
         OperationMode::SELECT,
     )?;
 
-    if plan.is_simple_count {
+    if plan.is_simple_count() {
         emit_simple_count(program, t_ctx, plan)?;
         return Ok(t_ctx.reg_result_cols_start.unwrap());
     }

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -23,8 +23,8 @@ use super::group_by::{
 use super::main_loop::{close_loop, emit_loop, init_loop, open_loop, LeftJoinMetadata, LoopLabels};
 use super::order_by::{emit_order_by, init_order_by, SortMetadata};
 use super::plan::{JoinOrderMember, Operation, SelectPlan, TableReference, UpdatePlan};
-use super::select::emit_simple_count;
 use super::schema::ParseSchema;
+use super::select::emit_simple_count;
 use super::subquery::emit_subqueries;
 
 #[derive(Debug)]
@@ -289,6 +289,11 @@ pub fn emit_query<'a>(
         OperationMode::SELECT,
     )?;
 
+    if plan.is_simple_count {
+        emit_simple_count(program, t_ctx, plan)?;
+        return Ok(t_ctx.reg_result_cols_start.unwrap());
+    }
+
     for where_term in plan
         .where_clause
         .iter()
@@ -310,22 +315,20 @@ pub fn emit_query<'a>(
         program.preassign_label_to_next_insn(jump_target_when_true);
     }
 
-    if !plan.is_simple_count {
-        // Set up main query execution loop
-        open_loop(
-            program,
-            t_ctx,
-            &plan.table_references,
-            &plan.join_order,
-            &plan.where_clause,
-        )?;
+    // Set up main query execution loop
+    open_loop(
+        program,
+        t_ctx,
+        &plan.table_references,
+        &plan.join_order,
+        &plan.where_clause,
+    )?;
 
-        // Process result columns and expressions in the inner loop
-        emit_loop(program, t_ctx, plan)?;
+    // Process result columns and expressions in the inner loop
+    emit_loop(program, t_ctx, plan)?;
 
-        // Clean up and close the main execution loop
-        close_loop(program, t_ctx, &plan.table_references, &plan.join_order)?;
-    }
+    // Clean up and close the main execution loop
+    close_loop(program, t_ctx, &plan.table_references, &plan.join_order)?;
 
     program.preassign_label_to_next_insn(after_main_loop_label);
 
@@ -345,11 +348,7 @@ pub fn emit_query<'a>(
         group_by_emit_row_phase(program, t_ctx, plan)?;
     } else if !plan.aggregates.is_empty() {
         // Handle aggregation without GROUP BY
-        if plan.is_simple_count {
-            emit_simple_count(program, t_ctx, plan)?;
-        } else {
-            emit_ungrouped_aggregation(program, t_ctx, plan)?;
-        }
+        emit_ungrouped_aggregation(program, t_ctx, plan)?;
         // Single row result for aggregates without GROUP BY, so ORDER BY not needed
         order_by_necessary = false;
     }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -308,6 +308,8 @@ pub struct SelectPlan {
     pub contains_constant_false_condition: bool,
     /// query type (top level or subquery)
     pub query_type: SelectQueryType,
+    /// if the query is of the format `SELECT count(*) FROM <tbl>`. This is set after the SelectPlan is create
+    pub is_simple_count: bool,
 }
 
 impl SelectPlan {

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -493,7 +493,6 @@ fn estimate_num_labels(select: &SelectPlan) -> usize {
 ///
 /// Checks to see if the query is of the format `SELECT count(*) FROM <tbl>`
 pub fn is_simple_count(plan: &SelectPlan) -> bool {
-    // TODO: (pedrocarlo) check for HAVING clause
     if !plan.where_clause.is_empty()
         || plan.aggregates.len() != 1
         || matches!(plan.query_type, SelectQueryType::Subquery { .. })
@@ -525,7 +524,7 @@ pub fn is_simple_count(plan: &SelectPlan) -> bool {
         filter_over: None,
     };
     let result_col_expr = &plan.result_columns.get(0).unwrap().expr;
-    if *result_col_expr != count || *result_col_expr != count_star {
+    if *result_col_expr != count && *result_col_expr != count_star {
         return false;
     }
     true

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1,4 +1,4 @@
-use super::emitter::emit_program;
+use super::emitter::{emit_program, TranslateCtx};
 use super::plan::{select_star, JoinOrderMember, Operation, Search, SelectQueryType};
 use super::planner::Scope;
 use crate::function::{AggFunc, ExtFunc, Func};
@@ -10,6 +10,7 @@ use crate::translate::planner::{
 };
 use crate::util::normalize_ident;
 use crate::vdbe::builder::{ProgramBuilderOpts, QueryMode};
+use crate::vdbe::insn::Insn;
 use crate::SymbolTable;
 use crate::{schema::Schema, vdbe::builder::ProgramBuilder, Result};
 use limbo_sqlite3_parser::ast::{self, SortOrder};
@@ -483,4 +484,68 @@ fn estimate_num_labels(select: &SelectPlan) -> usize {
         init_halt_labels + table_labels + group_by_labels + order_by_labels + condition_labels;
 
     num_labels
+}
+
+/// Reference: https://github.com/sqlite/sqlite/blob/5db695197b74580c777b37ab1b787531f15f7f9f/src/select.c#L8613
+///
+/// Checks to see if the query is of the format `SELECT count(*) FROM <tbl>`
+pub fn is_simple_count(plan: &SelectPlan) -> bool {
+    // TODO: (pedrocarlo) check for HAVING clause
+    if !plan.where_clause.is_empty()
+        || plan.aggregates.len() != 1
+        || matches!(plan.query_type, SelectQueryType::Subquery { .. })
+        || plan.table_references.len() != 1
+        || plan.result_columns.len() != 1
+        || plan.group_by.is_some()
+    // TODO: (pedrocarlo) maybe can optimize to use the count optmization with more columns
+    {
+        return false;
+    }
+    let table_ref = plan.table_references.first().unwrap();
+    if !matches!(table_ref.table, crate::schema::Table::BTree(..)) {
+        return false;
+    }
+    let agg = plan.aggregates.first().unwrap();
+    if !matches!(agg.func, AggFunc::Count0) {
+        return false;
+    }
+    true
+}
+
+pub fn emit_simple_count<'a>(
+    program: &mut ProgramBuilder,
+    _t_ctx: &mut TranslateCtx<'a>,
+    plan: &'a SelectPlan,
+) -> Result<()> {
+    let cursors = plan
+        .table_references
+        .get(0)
+        .unwrap()
+        .resolve_cursors(program)?;
+
+    let cursor_id = {
+        match cursors {
+            (_, Some(cursor_id)) | (Some(cursor_id), None) => cursor_id,
+            _ => panic!("cursor for table should have been opened"),
+        }
+    };
+
+    // TODO: I think this allocation can be avoided if we are smart with the `TranslateCtx`
+    let target_reg = program.alloc_register();
+
+    program.emit_insn(Insn::Count {
+        cursor_id,
+        target_reg,
+        exact: true,
+    });
+
+    program.emit_insn(Insn::Close { cursor_id });
+    let output_reg = program.alloc_register();
+    program.emit_insn(Insn::Copy {
+        src_reg: target_reg,
+        dst_reg: output_reg,
+        amount: 0,
+    });
+    program.emit_result_row(output_reg, 1);
+    Ok(())
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4749,6 +4749,17 @@ pub fn op_affinity(
     Ok(InsnFunctionStepResult::Step)
 }
 
+pub fn op_count(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    pager: &Rc<Pager>,
+    mv_store: Option<&Rc<MvStore>>,
+) -> Result<InsnFunctionStepResult> {
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
 fn exec_lower(reg: &OwnedValue) -> Option<OwnedValue> {
     match reg {
         OwnedValue::Text(t) => Some(OwnedValue::build_text(&t.as_str().to_lowercase())),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4756,6 +4756,24 @@ pub fn op_count(
     pager: &Rc<Pager>,
     mv_store: Option<&Rc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
+    let Insn::Count {
+        cursor_id,
+        target_reg,
+        exact,
+    } = insn
+    else {
+        unreachable!("unexpected Insn {:?}", insn)
+    };
+
+    let count = {
+        let mut cursor = must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "Count");
+        let cursor = cursor.as_btree_mut();
+        let count = return_if_io!(cursor.count());
+        count
+    };
+
+    state.registers[*target_reg] = Register::OwnedValue(OwnedValue::Integer(count as i64));
+
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1448,6 +1448,19 @@ pub fn insn_to_str(
                         .join(", ")
                 ),
             ),
+            Insn::Count {
+                cursor_id,
+                target_reg,
+                exact,
+            } => (
+                "Count",
+                *cursor_id as i32,
+                *target_reg as i32,
+                if *exact { 0 } else { 1 },
+                OwnedValue::build_text(""),
+                0,
+                "".to_string(),
+            ),
         };
     format!(
         "{:<4}  {:<17}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -857,6 +857,16 @@ pub enum Insn {
         count: NonZeroUsize,
         affinities: String,
     },
+
+    /// Store the number of entries (an integer value) in the table or index opened by cursor P1 in register P2.
+    ///
+    /// If P3==0, then an exact count is obtained, which involves visiting every btree page of the table.
+    /// But if P3 is non-zero, an estimate is returned based on the current cursor position.
+    Count {
+        cursor_id: CursorID,
+        target_reg: usize,
+        exact: bool,
+    },
 }
 
 impl Insn {
@@ -977,6 +987,7 @@ impl Insn {
             Insn::NotFound { .. } => execute::op_not_found,
             Insn::Affinity { .. } => execute::op_affinity,
             Insn::IdxDelete { .. } => execute::op_idx_delete,
+            Insn::Count { .. } => execute::op_count,
         }
     }
 }


### PR DESCRIPTION
After reading #1123, I wanted to see what optimizations I could do. Sqlite optimizes `count` aggregation for the following case: `SELECT count() FROM <tbl>`. This is so widely used, that they made an optimization just for it in the form of the `COUNT` opcode. 

This PR thus implements this optimization by creating the `COUNT` opcode, and checking in the select emitter if we the query is a Simple Count Query. If it is, we just emit the Opcode instead of going through a Rewind loop, saving on execution time. 

The screenshots below show a huge decrease in execution time. 

- **Main**
<img width="383" alt="image" src="https://github.com/user-attachments/assets/99a9dec4-e7c5-41db-ba67-4eafa80dd2e6" />

- **Count Optimization**
<img width="435" alt="image" src="https://github.com/user-attachments/assets/e93b3233-92e6-4736-aa60-b52b2477179f" />

