### PR TITLE
Fix memory leak caused by unclosed virtual table cursors

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -730,7 +730,7 @@ impl VirtualTable {
 
     pub fn open(&self) -> crate::Result<VTabOpaqueCursor> {
         let cursor = unsafe { (self.implementation.open)(self.implementation.ctx) };
-        VTabOpaqueCursor::new(cursor)
+        VTabOpaqueCursor::new(cursor, self.implementation.close)
     }
 
     #[tracing::instrument(skip(cursor))]

--- a/extensions/core/src/vtabs.rs
+++ b/extensions/core/src/vtabs.rs
@@ -15,6 +15,7 @@ pub struct VTabModuleImpl {
     pub name: *const c_char,
     pub create_schema: VtabFnCreateSchema,
     pub open: VtabFnOpen,
+    pub close: VtabFnClose,
     pub filter: VtabFnFilter,
     pub column: VtabFnColumn,
     pub next: VtabFnNext,
@@ -43,6 +44,8 @@ impl VTabModuleImpl {
 pub type VtabFnCreateSchema = unsafe extern "C" fn(args: *const Value, argc: i32) -> *mut c_char;
 
 pub type VtabFnOpen = unsafe extern "C" fn(*const c_void) -> *const c_void;
+
+pub type VtabFnClose = unsafe extern "C" fn(cursor: *const c_void) -> ResultCode;
 
 pub type VtabFnFilter = unsafe extern "C" fn(
     cursor: *const c_void,
@@ -134,6 +137,9 @@ pub trait VTabCursor: Sized {
     fn column(&self, idx: u32) -> Result<Value, Self::Error>;
     fn eof(&self) -> bool;
     fn next(&mut self) -> ResultCode;
+    fn close(&self) -> ResultCode {
+        ResultCode::OK
+    }
 }
 
 #[repr(u8)]


### PR DESCRIPTION
The following code reproduces the leak (memory usage increases over time):

```rust
#[tokio::main]
async fn main() {
    let db = Builder::new_local(":memory:").build().await.unwrap();
    let conn = db.connect().unwrap();

    conn.execute("SELECT load_extension('./target/debug/liblimbo_series');", ())
        .await
        .unwrap();

    loop {
        conn.execute("SELECT * FROM generate_series(1,10,2);", ())
            .await
            .unwrap();
    }
}
```

After switching to the system allocator, the leak becomes detectable with Valgrind:

```
32,000 bytes in 1,000 blocks are definitely lost in loss record 24 of 24
   at 0x538580F: malloc (vg_replace_malloc.c:446)
   by 0x62E15FA: alloc::alloc::alloc (alloc.rs:99)
   by 0x62E172C: alloc::alloc::Global::alloc_impl (alloc.rs:192)
   by 0x62E1530: allocate (alloc.rs:254)
   by 0x62E1530: alloc::alloc::exchange_malloc (alloc.rs:349)
   by 0x62E0271: new<limbo_series::GenerateSeriesCursor> (boxed.rs:257)
   by 0x62E0271: open_GenerateSeriesVTab (lib.rs:19)
   by 0x425D8FA: limbo_core::VirtualTable::open (lib.rs:732)
   by 0x4285DDA: limbo_core::vdbe::execute::op_vopen (execute.rs:890)
   by 0x42351E8: limbo_core::vdbe::Program::step (mod.rs:396)
   by 0x425C638: limbo_core::Statement::step (lib.rs:610)
   by 0x40DB238: limbo::Statement::execute::{{closure}} (lib.rs:181)
   by 0x40D9EAF: limbo::Connection::execute::{{closure}} (lib.rs:109)
   by 0x40D54A1: example::main::{{closure}} (example.rs:26)
```

Interestingly, when using mimalloc, neither Valgrind nor mimalloc’s internal statistics report the leak.