### PR TITLE
bindings/java: Remove disabled annotation for UPDATE and DELETE 

### DIFF
--- a/bindings/java/src/test/java/tech/turso/jdbc4/JDBC4StatementTest.java
+++ b/bindings/java/src/test/java/tech/turso/jdbc4/JDBC4StatementTest.java
@@ -83,7 +83,7 @@ class JDBC4StatementTest {
   }
 
   @Test
-  @Disabled("Refer to sqlite-jdbc implementation and fix this test")
+  @Disabled("limbo's total_changes() works differently from sqlite's total_changes()")
   void execute_update_should_return_number_of_updated_elements() throws Exception {
     assertThat(stmt.executeUpdate("CREATE TABLE s1 (c1 INT);")).isEqualTo(0);
     assertThat(stmt.executeUpdate("INSERT INTO s1 VALUES (1), (2), (3);")).isEqualTo(3);

--- a/bindings/java/src/test/java/tech/turso/jdbc4/JDBC4StatementTest.java
+++ b/bindings/java/src/test/java/tech/turso/jdbc4/JDBC4StatementTest.java
@@ -1,7 +1,10 @@
 package tech.turso.jdbc4;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -40,7 +43,6 @@ class JDBC4StatementTest {
   }
 
   @Test
-  @Disabled("UPDATE not supported yet")
   void execute_update_should_return_false() throws Exception {
     stmt.execute("CREATE TABLE users (id INT PRIMARY KEY, username TEXT);");
     stmt.execute("INSERT INTO users VALUES (1, 'limbo');");
@@ -81,16 +83,15 @@ class JDBC4StatementTest {
   }
 
   @Test
-  @Disabled("Limbo update not yet supported")
+  @Disabled("Refer to sqlite-jdbc implementation and fix this test")
   void execute_update_should_return_number_of_updated_elements() throws Exception {
-    assertThat(stmt.executeUpdate("CREATE TABLE s1 (c1);")).isEqualTo(0);
+    assertThat(stmt.executeUpdate("CREATE TABLE s1 (c1 INT);")).isEqualTo(0);
     assertThat(stmt.executeUpdate("INSERT INTO s1 VALUES (1), (2), (3);")).isEqualTo(3);
 
     assertThat(stmt.executeUpdate("UPDATE s1 SET c1 = 0;")).isEqualTo(3);
   }
 
   @Test
-  @Disabled("Limbo delete has a bug")
   void execute_update_should_return_number_of_deleted_elements() throws Exception {
     assertThat(stmt.executeUpdate("CREATE TABLE s1 (c1);")).isEqualTo(0);
     assertThat(stmt.executeUpdate("INSERT INTO s1 VALUES (1), (2), (3);")).isEqualTo(3);


### PR DESCRIPTION
## Changes 
Since limbo now supports UPDATE and DELETE, I'm planning to implement the rest of the features for integrating JDBC and limbo. 

Since limbo's [total_changes() function seems to work differently in compared to the sqlite's](https://discord.com/channels/1258658826257961020/1321869557459058778/1368830400985563176), let's remove the `@Disabled` annotation from `execute_update_should_return_number_of_updated_elements` test  after the issue is handled. 

## Reference 

https://github.com/tursodatabase/limbo/issues/615