### PR TITLE
EXPLAIN should show a comment for the Insert opcode

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -788,6 +788,7 @@ fn emit_update_insns(
             key_reg: beg,
             record_reg,
             flag: 0,
+            table_name: table_ref.identifier.clone(),
         });
     } else if let Some(vtab) = table_ref.virtual_table() {
         let arg_count = table_ref.columns().len() + 2;

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -387,6 +387,7 @@ pub fn translate_insert(
         key_reg: rowid_reg,
         record_reg: record_register,
         flag: 0,
+        table_name: table_name.to_string(),
     });
 
     if inserting_multiple_rows {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -229,6 +229,7 @@ pub fn emit_schema_entry(
         key_reg: rowid_reg,
         record_reg,
         flag: 0,
+        table_name: tbl_name.to_string(),
     });
 }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3699,6 +3699,7 @@ pub fn op_insert(
         key_reg,
         record_reg,
         flag: _,
+        table_name: _,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1014,14 +1014,15 @@ pub fn insn_to_str(
                 key_reg,
                 record_reg,
                 flag,
+                table_name,
             } => (
                 "Insert",
                 *cursor as i32,
                 *record_reg as i32,
                 *key_reg as i32,
-                OwnedValue::build_text(""),
+                OwnedValue::build_text(&table_name),
                 *flag as u16,
-                "".to_string(),
+                format!("intkey=r[{}] data=r[{}]", key_reg, record_reg),
             ),
             Insn::Delete { cursor_id } => (
                 "Delete",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -644,6 +644,7 @@ pub enum Insn {
         key_reg: usize,    // Must be int.
         record_reg: usize, // Blob of record data.
         flag: usize,       // Flags used by insert, for now not used.
+        table_name: String,
     },
 
     Delete {


### PR DESCRIPTION
After this commit EXPLAIN should show a comment for `Insert`.
```
limbo> explain insert into t (age, name, id) values (20, 'max', 1);
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     9     0                    0   Start at 9
1     OpenWrite          0     2     0                    0
2     Integer            1     2     0                    0   r[2]=1
3     String8            0     3     0     max            0   r[3]='max'
4     Integer            20    4     0                    0   r[4]=20
5     NewRowId           0     1     0                    0
6     MakeRecord         2     3     5                    0   r[5]=mkrec(r[2..4])
7     Insert             0     5     1     t              0   intkey=r[1] data=r[5]
8     Halt               0     0     0                    0
9     Transaction        0     1     0                    0   write=true
10    Goto               0     1     0                    0

```