### PR TITLE
Fix: unique contraint in auto index creation

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -285,7 +285,7 @@ fn create_table(
     let mut primary_key_columns = vec![];
     let mut cols = vec![];
     let is_strict: bool;
-    let mut unique_sets: Option<Vec<Vec<(String, SortOrder)>>> = None;
+    let mut unique_sets: Vec<Vec<(String, SortOrder)>> = vec![];
     match body {
         CreateTableBody::ColumnsAndConstraints {
             columns,
@@ -332,11 +332,7 @@ fn create_table(
                                 (col_name, column.order.unwrap_or(SortOrder::Asc))
                             })
                             .collect();
-                        if let Some(ref mut unique_sets) = unique_sets {
-                            unique_sets.push(unique_set);
-                        } else {
-                            unique_sets = Some(vec![unique_set]);
-                        }
+                        unique_sets.push(unique_set);
                     }
                 }
             }
@@ -462,7 +458,11 @@ fn create_table(
         primary_key_columns,
         columns: cols,
         is_strict,
-        unique_sets,
+        unique_sets: if unique_sets.is_empty() {
+            None
+        } else {
+            Some(unique_sets)
+        },
     })
 }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -829,7 +829,8 @@ impl Index {
         // I wanted to just chain the iterator above but Rust type system get's messy with Iterators.
         // It would not allow me chain them even by using a core::iter::empty()
         // To circumvent this, I'm having to allocate a second Vec, and extend the other from it.
-        if table.get_rowid_alias_column().is_none() && !table.primary_key_columns.is_empty() {
+        let has_primary_key_index = table.get_rowid_alias_column().is_none() && !table.primary_key_columns.is_empty();
+        if has_primary_key_index {
             let (index_name, root_page) = auto_indices.next().expect(
                 "number of auto_indices in schema should be same number of indices calculated",
             );

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -314,9 +314,12 @@ fn create_table(
                         }
                     } else if let limbo_sqlite3_parser::ast::TableConstraint::Unique {
                         columns,
-                        conflict_clause: _, // TODO: ignore conflict_cause for now
+                        conflict_clause,
                     } = c.constraint
                     {
+                        if conflict_clause.is_some() {
+                            unimplemented!("ON CONFLICT not implemented");
+                        }
                         let unique_set: Vec<_> = columns
                             .into_iter()
                             .map(|column| {
@@ -412,7 +415,10 @@ fn create_table(
                             default = Some(expr.clone())
                         }
                         // TODO: for now we don't check Resolve type of unique
-                        limbo_sqlite3_parser::ast::ColumnConstraint::Unique(..) => {
+                        limbo_sqlite3_parser::ast::ColumnConstraint::Unique(on_conflict) => {
+                            if on_conflict.is_some() {
+                                unimplemented!("ON CONFLICT not implemented");
+                            }
                             unique = true;
                         }
                         _ => {}

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -259,6 +259,7 @@ impl PseudoTable {
             is_rowid_alias: false,
             notnull: false,
             default: None,
+            unique: false,
         });
     }
     pub fn get_column(&self, name: &str) -> Option<(usize, &Column)> {
@@ -365,6 +366,7 @@ fn create_table(
                 let mut primary_key = false;
                 let mut notnull = false;
                 let mut order = SortOrder::Asc;
+                let mut unique = false;
                 for c_def in &col_def.constraints {
                     match &c_def.constraint {
                         limbo_sqlite3_parser::ast::ColumnConstraint::PrimaryKey {
@@ -381,6 +383,10 @@ fn create_table(
                         }
                         limbo_sqlite3_parser::ast::ColumnConstraint::Default(expr) => {
                             default = Some(expr.clone())
+                        }
+                        // TODO: for now we don't check Resolve type of unique
+                        limbo_sqlite3_parser::ast::ColumnConstraint::Unique(..) => {
+                            unique = true;
                         }
                         _ => {}
                     }
@@ -403,6 +409,7 @@ fn create_table(
                     is_rowid_alias: typename_exactly_integer && primary_key,
                     notnull,
                     default,
+                    unique,
                 });
             }
             if options.contains(TableOptions::WITHOUT_ROWID) {
@@ -456,6 +463,7 @@ pub struct Column {
     pub is_rowid_alias: bool,
     pub notnull: bool,
     pub default: Option<Expr>,
+    pub unique: bool,
 }
 
 impl Column {
@@ -658,6 +666,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 is_rowid_alias: false,
                 notnull: false,
                 default: None,
+                unique: false,
             },
             Column {
                 name: Some("name".to_string()),
@@ -667,6 +676,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 is_rowid_alias: false,
                 notnull: false,
                 default: None,
+                unique: false,
             },
             Column {
                 name: Some("tbl_name".to_string()),
@@ -676,6 +686,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 is_rowid_alias: false,
                 notnull: false,
                 default: None,
+                unique: false,
             },
             Column {
                 name: Some("rootpage".to_string()),
@@ -685,6 +696,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 is_rowid_alias: false,
                 notnull: false,
                 default: None,
+                unique: false,
             },
             Column {
                 name: Some("sql".to_string()),
@@ -694,6 +706,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 is_rowid_alias: false,
                 notnull: false,
                 default: None,
+                unique: false,
             },
         ],
     }
@@ -774,6 +787,8 @@ impl Index {
                 "Cannot create automatic index for table without primary key".to_string(),
             ));
         }
+
+        // let unique_columns =
 
         let index_columns = table
             .primary_key_columns
@@ -1188,6 +1203,7 @@ mod tests {
                 is_rowid_alias: false,
                 notnull: false,
                 default: None,
+                unique: false,
             }],
         };
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -325,11 +325,8 @@ fn create_table(
                             .map(|column| {
                                 let col_name = match column.expr {
                                     Expr::Id(id) => normalize_ident(&id.0),
-                                    Expr::Literal(Literal::String(value)) => {
-                                        value.trim_matches('\'').to_owned()
-                                    }
                                     _ => {
-                                        todo!("Unsupported primary key expression");
+                                        todo!("Unsupported unique expression");
                                     }
                                 };
                                 (col_name, column.order.unwrap_or(SortOrder::Asc))

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -216,6 +216,7 @@ pub fn group_by_create_pseudo_table(
             is_rowid_alias: false,
             notnull: false,
             default: None,
+            unique: false,
         })
         .collect::<Vec<_>>();
 

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1204,6 +1204,7 @@ mod tests {
             primary_key: false,
             notnull: false,
             default: None,
+            unique: false,
         }
     }
     fn _create_column_of_type(name: &str, ty: Type) -> Column {
@@ -1238,6 +1239,7 @@ mod tests {
             columns,
             has_rowid: true,
             is_strict: false,
+            unique_sets: None,
         })
     }
 

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -72,6 +72,7 @@ pub fn emit_order_by(
             is_rowid_alias: false,
             notnull: false,
             default: None,
+            unique: false,
         });
     }
     for i in 0..result_columns.len() {
@@ -90,6 +91,7 @@ pub fn emit_order_by(
             is_rowid_alias: false,
             notnull: false,
             default: None,
+            unique: false,
         });
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -597,6 +597,7 @@ impl TableReference {
                     primary_key: false,
                     notnull: false,
                     default: None,
+                    unique: false,
                 })
                 .collect(),
         )));

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -358,7 +358,7 @@ fn check_automatic_pk_index_required(
                         is_descending,
                     } => {
                         let is_integer =
-                            typename.is_some() && typename.unwrap().to_uppercase() == "INTEGER";
+                            typename.is_some() && typename.unwrap().eq_ignore_ascii_case("INTEGER"); // Should match on any case of INTEGER
                         !is_integer || *is_descending
                     }
                     PrimaryKeyDefinitionType::Composite => true,

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -265,6 +265,7 @@ fn check_automatic_pk_index_required(
             options,
         } => {
             let mut primary_key_definition = None;
+            let mut has_unique_definition = false;
 
             // Check table constraints for PRIMARY KEY
             if let Some(constraints) = constraints {
@@ -336,6 +337,8 @@ fn check_automatic_pk_index_required(
                             typename,
                             is_descending: false,
                         });
+                    } else if matches!(constraint.constraint, ast::ColumnConstraint::Unique(..)) {
+                        has_unique_definition = true;
                     }
                 }
             }
@@ -346,7 +349,9 @@ fn check_automatic_pk_index_required(
             }
 
             // Check if we need an automatic index
-            let needs_auto_index = if let Some(primary_key_definition) = &primary_key_definition {
+            let needs_auto_index = if has_unique_definition {
+                true
+            } else if let Some(primary_key_definition) = &primary_key_definition {
                 match primary_key_definition {
                     PrimaryKeyDefinitionType::Simple {
                         typename,

--- a/core/util.rs
+++ b/core/util.rs
@@ -165,7 +165,7 @@ pub fn parse_schema_rows(
                     root_page,
                 } => {
                     let table = schema.get_btree_table(&table_name).unwrap();
-                    let index = schema::Index::automatic_from_primary_key(
+                    let index = schema::Index::automatic_from_primary_key_and_unique(
                         table.as_ref(),
                         &name,
                         root_page as usize,

--- a/core/util.rs
+++ b/core/util.rs
@@ -121,7 +121,7 @@ pub fn parse_schema_rows(
                                     });
                                 }
                                 _ => {
-                                    // Automatic index on primary key, e.g.
+                                    // Automatic index on primary key and/or unique constraint, e.g.
                                     // table|foo|foo|2|CREATE TABLE foo (a text PRIMARY KEY, b)
                                     // index|sqlite_autoindex_foo_1|foo|3|
                                     let index_name = row.get::<&str>(1)?.to_string();
@@ -559,6 +559,12 @@ pub fn columns_from_create_table_body(body: &ast::CreateTableBody) -> crate::Res
                     )
                 }),
                 is_rowid_alias: false,
+                unique: column_def.constraints.iter().any(|c| {
+                    matches!(
+                        c.constraint,
+                        limbo_sqlite3_parser::ast::ColumnConstraint::Unique(..)
+                    )
+                }),
             };
             Some(column)
         })

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -248,6 +248,7 @@ pub enum Register {
 
 /// A row is a the list of registers that hold the values for a filtered row. This row is a pointer, therefore
 /// after stepping again, row will be invalidated to be sure it doesn't point to somewhere unexpected.
+#[derive(Debug)]
 pub struct Row {
     values: *const Register,
     count: usize,

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -180,3 +180,19 @@ do_execsql_test_on_specific_db {:memory:} multi-rows {
     SELECT * FROM test;
 } {1|1
 2|1}
+
+do_execsql_test_on_specific_db {:memory:} unique_insert_no_pkey {
+    CREATE TABLE t2 (x INTEGER, y INTEGER UNIQUE);
+    INSERT INTO t2 (y) VALUES (1);
+    INSERT INTO t2 (y) VALUES (6);
+    SELECT * FROM t2;
+} {|1
+|6}
+
+do_execsql_test_on_specific_db {:memory:} unique_insert_with_pkey {
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY, y INTEGER UNIQUE);
+    INSERT INTO t2 (y) VALUES (1);
+    INSERT INTO t2 (y) VALUES (6);
+    SELECT * FROM t2;
+} {1|1
+2|6}

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -1192,6 +1192,7 @@ mod tests {
                 "CREATE TABLE {} ({})",
                 table.name, columns_with_first_column_as_pk
             );
+            dbg!(&query);
             let limbo = limbo_exec_rows(&db, &limbo_conn, &query);
             let sqlite = sqlite_exec_rows(&sqlite_conn, &query);
 

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1460,7 +1460,7 @@ bitflags::bitflags! {
 }
 
 /// Sort orders
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SortOrder {
     /// `ASC`
     Asc,


### PR DESCRIPTION
Closes #1457 .

```sql
limbo> CREATE table t2 (x INTEGER PRIMARY KEY, y INTEGER UNIQUE);
limbo> SELECT * FROM sqlite_schema;
┌───────┬───────────────────────┬──────────┬──────────┬───────────────────────────────────────────────────────────┐
│ type  │ name                  │ tbl_name │ rootpage │ sql                                                       │
├───────┼───────────────────────┼──────────┼──────────┼───────────────────────────────────────────────────────────┤
│ table │ t2                    │ t2       │        2 │ CREATE TABLE t2 (x INTEGER PRIMARY KEY, y INTEGER UNIQUE) │
├───────┼───────────────────────┼──────────┼──────────┼───────────────────────────────────────────────────────────┤
│ index │ sqlite_autoindex_t2_1 │ t2       │        3 │                                                           │
└───────┴───────────────────────┴──────────┴──────────┴───────────────────────────────────────────────────────────┘
```