### PR TITLE
bindings/wasm: add types property for typescript setting

### DIFF
--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "main": "./node/dist/index.cjs",
   "module": "./web/dist/index.js",
+  "types": "./web/dist/index.d.ts",
   "exports": {
     ".": {
       "node": "./node/dist/index.cjs",


### PR DESCRIPTION
This pull request includes a small change to the `bindings/wasm/package.json` file. The change adds a `types` field pointing to the TypeScript declaration file for the package (`[bindings/wasm/package.jsonR15](diffhunk://#diff-1f41234b939ba148924b9bbfedd557853ebcd22351a9c300e568ce7af0291babR15)`).