### PR TITLE
Add time.Time and bool data types support in Go adapter

### DIFF
--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -243,6 +243,13 @@ func buildArgs(args []driver.Value) ([]limboValue, func(), error) {
 		case float64:
 			limboVal.Type = realVal
 			limboVal.Value = *(*[8]byte)(unsafe.Pointer(&val))
+		case bool:
+			limboVal.Type = intVal
+			boolAsInt := int64(0)
+			if val {
+				boolAsInt = 1
+			}
+			limboVal.Value = *(*[8]byte)(unsafe.Pointer(&boolAsInt))
 		case string:
 			limboVal.Type = textVal
 			cstr := CString(val)


### PR DESCRIPTION
PR #1442 added support for using time.Time as query parameters.

Scanning time.Time values from query results still fails:

`sql: Scan error on column index 4, name "mod_time": unsupported Scan, storing driver.Value type string into type *time.Time`

This change modifies the `toGoValue` function to detect RFC3339 formatted datetime strings and convert them back to time.Time objects when reading from the database. This provides complete roundtrip support for time.Time values.

Also added boolean support by converting Go bool values to integers (0 for false, 1 for true) when binding parameters, following SQLite's convention for representing boolean values.
