### PR TITLE
bindings/go: Upgrade ebitengine/purego to allow for use with go 1.23.9

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -3,6 +3,6 @@ module github.com/tursodatabase/limbo
 go 1.23.4
 
 require (
-	github.com/ebitengine/purego v0.8.2
+	github.com/ebitengine/purego v0.8.3-0.20250507171810-1638563e3615
 	golang.org/x/sys v0.29.0
 )

--- a/bindings/go/go.sum
+++ b/bindings/go/go.sum
@@ -1,4 +1,6 @@
 github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.8.3-0.20250507171810-1638563e3615 h1:W7mpP4uiOAbBOdDnRXT9EUdauFv7bz+ERT5rPIord00=
+github.com/ebitengine/purego v0.8.3-0.20250507171810-1638563e3615/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
Go 1.23.9 introduced a change with to it's linker that caused a `duplicate symbol` error with purego 1.82

this is the recommended fix per https://github.com/golang/go/issues/73617 