### PR TITLE
Properly handle ordering parameters for variables in Update queries

### DIFF
--- a/bindings/go/limbo_test.go
+++ b/bindings/go/limbo_test.go
@@ -608,37 +608,6 @@ func TestJSONFunctions(t *testing.T) {
 	}
 }
 
-func TestBindUpdate(t *testing.T) {
-	conn, err := sql.Open("sqlite3", ":memory:")
-	if err != nil {
-		t.Fatalf("Error opening connection: %v", err)
-	}
-	if _, err = conn.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)"); err != nil {
-		t.Fatalf("Error creating table: %v", err)
-	}
-	if _, err := conn.Exec("INSERT INTO test (id, name) VALUES (1, 'test')"); err != nil {
-		t.Fatalf("Error inserting data: %v", err)
-	}
-	stmt, err := conn.Prepare("UPDATE test SET name = ? WHERE id = ?")
-	if err != nil {
-		t.Fatalf("Error preparing statement: %v", err)
-	}
-	_, err = stmt.Exec(1, "updated")
-	if err != nil {
-		t.Fatalf("Error executing statement: %v", err)
-	}
-	// test if the update was successful
-	row := conn.QueryRow("SELECT id, name FROM test WHERE id = 1")
-	var (
-		id   int
-		name string
-	)
-	row.Scan(&id, &name)
-	if id != 1 || name != "updated" {
-		t.Fatalf("Expected (1, 'updated'), got (%d, %s)", id, name)
-	}
-}
-
 func slicesAreEq(a, b []byte) bool {
 	if len(a) != len(b) {
 		fmt.Printf("LENGTHS NOT EQUAL: %d != %d\n", len(a), len(b))

--- a/bindings/go/limbo_test.go
+++ b/bindings/go/limbo_test.go
@@ -608,6 +608,37 @@ func TestJSONFunctions(t *testing.T) {
 	}
 }
 
+func TestBindUpdate(t *testing.T) {
+	conn, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("Error opening connection: %v", err)
+	}
+	if _, err = conn.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)"); err != nil {
+		t.Fatalf("Error creating table: %v", err)
+	}
+	if _, err := conn.Exec("INSERT INTO test (id, name) VALUES (1, 'test')"); err != nil {
+		t.Fatalf("Error inserting data: %v", err)
+	}
+	stmt, err := conn.Prepare("UPDATE test SET name = ? WHERE id = ?")
+	if err != nil {
+		t.Fatalf("Error preparing statement: %v", err)
+	}
+	_, err = stmt.Exec(1, "updated")
+	if err != nil {
+		t.Fatalf("Error executing statement: %v", err)
+	}
+	// test if the update was successful
+	row := conn.QueryRow("SELECT id, name FROM test WHERE id = 1")
+	var (
+		id   int
+		name string
+	)
+	row.Scan(&id, &name)
+	if id != 1 || name != "updated" {
+		t.Fatalf("Expected (1, 'updated'), got (%d, %s)", id, name)
+	}
+}
+
 func slicesAreEq(a, b []byte) bool {
 	if len(a) != len(b) {
 		fmt.Printf("LENGTHS NOT EQUAL: %d != %d\n", len(a), len(b))

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -4,6 +4,7 @@ use limbo_sqlite3_parser::ast;
 use std::sync::Arc;
 
 use crate::{
+    parameters::UpdatePos,
     schema::{Index, Table},
     translate::result_row::emit_select_result,
     types::SeekOp,
@@ -264,6 +265,7 @@ pub fn open_loop(
                         jump_target_when_true,
                         jump_target_when_false: next,
                     };
+                    program.parameters.set_update_position(UpdatePos::Where);
                     translate_condition_expr(
                         program,
                         tables,
@@ -420,6 +422,7 @@ pub fn open_loop(
                         jump_target_when_true,
                         jump_target_when_false: next,
                     };
+                    program.parameters.set_update_position(UpdatePos::Where);
                     translate_condition_expr(
                         program,
                         tables,
@@ -528,6 +531,8 @@ pub fn open_loop(
                         jump_target_when_true,
                         jump_target_when_false: next,
                     };
+                    // optionally set the parameter position in case we are in an update stmt.
+                    program.parameters.set_update_position(UpdatePos::Where);
                     translate_condition_expr(
                         program,
                         tables,

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -62,6 +62,9 @@ pub fn translate_update(
         approx_num_insns: 20,
         approx_num_labels: 4,
     });
+    // initialize context for translating an update statement to keep track
+    // of variable/parameter positioning
+    program.parameters.init_update_context(body);
     emit_program(&mut program, plan, syms)?;
     Ok(program)
 }


### PR DESCRIPTION
closes #1467 

## The problem:

Our `Parameter` will assign the index to each expression in the order that it's translated. `Update` queries translate the conditional clause before the set clause, so the `b` in `set a = ? where b = ?` will always be assigned to param number 1.
```console
limbo> create table t (a,b,c,d);
limbo> explain update t set a = ? where b = ?;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     16    0                    0   Start at 16
1     OpenWrite          0     2     0                    0
2     Rewind             0     15    0                    0   Rewind t
3       Column           0     1     1                    0   r[1]=t.b         # comparing b
4       Variable         1     2     0                    0   r[2]=parameter(1)  # should be 2
5       Ne               1     2     14                   0   if r[1]!=r[2] goto 14
6       RowId            0     3     0                    0   r[3]=t.rowid
7       IsNull           3     15    0                    0   if (r[3]==NULL) goto 15
8       Variable         2     4     0                    0   r[4]=parameter(2)
9       Column           0     1     5                    0   r[5]=t.b
```

## The solution:

Traverse the `set` and `where` clauses in that order, and store the indexes of each `Variable` (similar to the fix outlined in #1459) for both the set and where clauses. We then keep track of the current position in the translator by setting the state prior to translating the expressions, and the parameters can do a lookup to find the appropriate index to provide as an argument to `Insn::Variable`.


```console
limbo> explain update t set a = ? where b = ? and c between ? and ?;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     22    0                    0   Start at 22
1     OpenWrite          0     2     0                    0
2     Rewind             0     21    0                    0   Rewind t
3       Column           0     1     1                    0   r[1]=t.b
4       Variable         2     2     0                    0   r[2]=parameter(2)
5       Ne               1     2     20                   0   if r[1]!=r[2] goto 20
6       Variable         3     3     0                    0   r[3]=parameter(3)
7       Column           0     2     4                    0   r[4]=t.c
8       Gt               3     4     20                   0   if r[3]>r[4] goto 20
9       Column           0     2     5                    0   r[5]=t.c
10      Variable         4     6     0                    0   r[6]=parameter(4)
11      Gt               5     6     20                   0   if r[5]>r[6] goto 20
12      RowId            0     7     0                    0   r[7]=t.rowid
13      IsNull           7     21    0                    0   if (r[7]==NULL) goto 21
14      Variable         1     8     0                    0   r[8]=parameter(1)
15      Column           0     1     9                    0   r[9]=t.b
```