### PR TITLE
CREATE VIRTUAL TABLE fixes

### DIFF
--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -484,10 +484,12 @@ pub fn translate_create_virtual_table(
                 approx_num_labels: 1,
             });
             let init_label = program.emit_init();
+            let start_offset = program.offset();
             program.emit_halt();
             program.preassign_label_to_next_insn(init_label);
             program.emit_transaction(true);
             program.emit_constant_insns();
+            program.emit_goto(start_offset);
             return Ok(program);
         }
         bail_parse_error!("Table {} already exists", tbl_name);

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -475,19 +475,22 @@ pub fn translate_create_virtual_table(
     if !vtab_module.module_kind.eq(&VTabKind::VirtualTable) {
         bail_parse_error!("module {} is not a virtual table", module_name_str);
     };
-    if schema.get_table(&table_name).is_some() && *if_not_exists {
-        let mut program = ProgramBuilder::new(ProgramBuilderOpts {
-            query_mode,
-            num_cursors: 1,
-            approx_num_insns: 5,
-            approx_num_labels: 1,
-        });
-        let init_label = program.emit_init();
-        program.emit_halt();
-        program.preassign_label_to_next_insn(init_label);
-        program.emit_transaction(true);
-        program.emit_constant_insns();
-        return Ok(program);
+    if schema.get_table(&table_name).is_some() {
+        if *if_not_exists {
+            let mut program = ProgramBuilder::new(ProgramBuilderOpts {
+                query_mode,
+                num_cursors: 1,
+                approx_num_insns: 5,
+                approx_num_labels: 1,
+            });
+            let init_label = program.emit_init();
+            program.emit_halt();
+            program.preassign_label_to_next_insn(init_label);
+            program.emit_transaction(true);
+            program.emit_constant_insns();
+            return Ok(program);
+        }
+        bail_parse_error!("Table {} already exists", tbl_name);
     }
 
     let mut program = ProgramBuilder::new(ProgramBuilderOpts {

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -593,12 +593,22 @@ def test_create_virtual_table():
         lambda res: "× Parse error: Table t1 already exists" == res,
         "create virtual table fails if virtual table with the same name already exists",
     )
+    limbo.run_test_fn(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS t1 USING kv_store;",
+        null,
+        "create virtual table with IF NOT EXISTS succeeds",
+    )
 
     limbo.debug_print("CREATE TABLE t2 (col INTEGER);")
     limbo.run_test_fn(
         "CREATE VIRTUAL TABLE t2 USING kv_store;",
         lambda res: "× Parse error: Table t2 already exists" == res,
         "create virtual table fails if regular table with the same name already exists",
+    )
+    limbo.run_test_fn(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS t2 USING kv_store;",
+        null,
+        "create virtual table with IF NOT EXISTS succeeds",
     )
 
     limbo.debug_print("CREATE VIRTUAL TABLE t3 USING kv_store;")


### PR DESCRIPTION
This PR fixes two bugs in `CREATE VIRTUAL TABLE` (see individual commits for details).

I added a test in `extensions.py` instead of the TCL test suite because it's currently more convenient - there’s no existing framework for loading extensions in TCL tests. However, I believe the test should eventually be moved to TCL, as it verifies behavior expected to be compatible with SQLite and is independent of any specific extension.

I've seen a PR proposing to migrate TCL tests to Rust, so please let me know if moving this test to TCL would still be valuable.