### PR TITLE
testing/py: rename debug_print() to run_debug()

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,7 +46,7 @@ def test_uuid():
     limbo.quit()
 ```
 
-You can use run_test, run_test_fn, or debug_print to interact with the shell and validate results. 
+You can use run_test, run_test_fn, or run_debug to interact with the shell and validate results. 
 The constructor takes an optional argument with the `sql` you want to initiate the tests with.  You can also enable blob testing or override the executable and flags.
 
 Use these Python-based tests for validating:

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -530,7 +530,7 @@ def test_drop_virtual_table():
     ext_path = "target/debug/liblimbo_ext_tests"
     limbo = TestLimboShell()
     limbo.execute_dot(f".load {ext_path}")
-    limbo.debug_print(
+    limbo.run_debug(
         "create virtual table t using kv_store;",
     )
     limbo.run_test_fn(".schema", lambda res: "CREATE VIRTUAL TABLE t" in res)
@@ -587,7 +587,7 @@ def test_create_virtual_table():
     limbo = TestLimboShell()
     limbo.execute_dot(f".load {ext_path}")
 
-    limbo.debug_print("CREATE VIRTUAL TABLE t1 USING kv_store;")
+    limbo.run_debug("CREATE VIRTUAL TABLE t1 USING kv_store;")
     limbo.run_test_fn(
         "CREATE VIRTUAL TABLE t1 USING kv_store;",
         lambda res: "× Parse error: Table t1 already exists" == res,
@@ -599,7 +599,7 @@ def test_create_virtual_table():
         "create virtual table with IF NOT EXISTS succeeds",
     )
 
-    limbo.debug_print("CREATE TABLE t2 (col INTEGER);")
+    limbo.run_debug("CREATE TABLE t2 (col INTEGER);")
     limbo.run_test_fn(
         "CREATE VIRTUAL TABLE t2 USING kv_store;",
         lambda res: "× Parse error: Table t2 already exists" == res,
@@ -611,7 +611,7 @@ def test_create_virtual_table():
         "create virtual table with IF NOT EXISTS succeeds",
     )
 
-    limbo.debug_print("CREATE VIRTUAL TABLE t3 USING kv_store;")
+    limbo.run_debug("CREATE VIRTUAL TABLE t3 USING kv_store;")
     limbo.run_test_fn(
         "CREATE TABLE t3 (col INTEGER);",
         lambda res: "× Parse error: Table t3 already exists" == res,

--- a/testing/cli_tests/test_limbo_cli.py
+++ b/testing/cli_tests/test_limbo_cli.py
@@ -141,7 +141,7 @@ INSERT INTO t VALUES (zeroblob(1024 - 1), zeroblob(1024 - 2), zeroblob(1024 - 3)
             f"Actual:\n{repr(actual)}"
         )
 
-    def debug_print(self, sql: str):
+    def run_debug(self, sql: str):
         console.debug(f"debugging: {sql}", _stack_offset=2)
         actual = self.shell.execute(sql)
         console.debug(f"OUTPUT:\n{repr(actual)}", _stack_offset=2)


### PR DESCRIPTION
I wasted a few minutes staring at #1471 because I thought `limbo.debug_print()` just prints the sql, but it actually executes it too