### PR TITLE
Fix handling of empty strings in prepared statements

### DIFF
--- a/bindings/javascript/__test__/better-sqlite3.spec.mjs
+++ b/bindings/javascript/__test__/better-sqlite3.spec.mjs
@@ -31,6 +31,13 @@ test("Statement.run() returns correct result object", async (t) => {
   t.deepEqual(rows, { changes: 1, lastInsertRowid: 1 });
 });
 
+test("Empty prepared statement should throw", async (t) => {
+    const [db] = await connect(":memory:");
+    t.throws(() => {
+        db.prepare("");
+    }, { instanceOf: Error });
+});
+
 const connect = async (path) => {
   const db = new Database(path);
   return [db];

--- a/bindings/javascript/__test__/limbo.spec.mjs
+++ b/bindings/javascript/__test__/limbo.spec.mjs
@@ -1,27 +1,26 @@
 import test from "ava";
 
-import { Database } from "../index.js"; 
+import { Database } from "../index.js";
 
 test("Open in-memory database", async (t) => {
-    const [db] = await connect(":memory:");
-    t.is(db.memory, true);
+  const [db] = await connect(":memory:");
+  t.is(db.memory, true);
 });
 
-
 test("Statement.get() returns data", async (t) => {
-    const [db] = await connect(":memory:");
-    const stmt = db.prepare("SELECT 1");
-    const result = stmt.get();
-    t.is(result["1"], 1);
-    const result2 = stmt.get();
-    t.is(result2["1"], 1);
+  const [db] = await connect(":memory:");
+  const stmt = db.prepare("SELECT 1");
+  const result = stmt.get();
+  t.is(result["1"], 1);
+  const result2 = stmt.get();
+  t.is(result2["1"], 1);
 });
 
 test("Statement.get() returns null when no data", async (t) => {
-    const [db] = await connect(":memory:");
-    const stmt = db.prepare("SELECT 1 WHERE 1 = 2");
-    const result = stmt.get();
-    t.is(result, undefined);
+  const [db] = await connect(":memory:");
+  const stmt = db.prepare("SELECT 1 WHERE 1 = 2");
+  const result = stmt.get();
+  t.is(result, undefined);
 });
 
 // run() isn't 100% compatible with better-sqlite3
@@ -30,11 +29,21 @@ test("Statement.run() returns correct result object", async (t) => {
   const [db] = await connect(":memory:");
   db.prepare("CREATE TABLE users (name TEXT)").run();
   db.prepare("INSERT INTO users (name) VALUES (?)").run(["Alice"]);
-  let rows = db.prepare("SELECT * FROM users").all()
+  let rows = db.prepare("SELECT * FROM users").all();
   t.deepEqual(rows, [{ name: "Alice" }]);
 });
 
+test("Empty prepared statement should throw", async (t) => {
+  const [db] = await connect(":memory:");
+  t.throws(
+    () => {
+      db.prepare("");
+    },
+    { instanceOf: Error },
+  );
+});
+
 const connect = async (path) => {
-    const db = new Database(path);
-    return [db];
+  const db = new Database(path);
+  return [db];
 };

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -325,6 +325,10 @@ pub struct Connection {
 
 impl Connection {
     pub fn prepare(self: &Rc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
+        if sql.as_ref().is_empty() {
+            return Err(LimboError::InvalidArgument("The supplied SQL string contains no statements".to_string()));
+        }
+
         let sql = sql.as_ref();
         tracing::trace!("Preparing: {}", sql);
         let mut parser = Parser::new(sql.as_bytes());
@@ -355,7 +359,10 @@ impl Connection {
                 Cmd::ExplainQueryPlan(_stmt) => todo!(),
             }
         } else {
-            todo!()
+            // Shouln't happen
+            Err(LimboError::ParseError(
+                "The supplied SQL string contains no statements".to_string(),
+            ))
         }
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -326,7 +326,9 @@ pub struct Connection {
 impl Connection {
     pub fn prepare(self: &Rc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
         if sql.as_ref().is_empty() {
-            return Err(LimboError::InvalidArgument("The supplied SQL string contains no statements".to_string()));
+            return Err(LimboError::InvalidArgument(
+                "The supplied SQL string contains no statements".to_string(),
+            ));
         }
 
         let sql = sql.as_ref();


### PR DESCRIPTION
When `prepare()` is called with an empty string it should throw an error (e.g `ApiMisuse` in rusqlite). I'm testing only in JS but it should throw to any bind.