### PR TITLE
Fix infinite loop when inserting multiple rows

### DIFF
--- a/testing/insert.test
+++ b/testing/insert.test
@@ -173,3 +173,10 @@ do_execsql_test_on_specific_db {:memory:} named-insert-2 {
     INSERT INTO test (col_b, col_d, col_c) VALUES ('1', '2', '4');
     SELECT * FROM test;
 } {1|Empty|1|4|2}
+
+do_execsql_test_on_specific_db {:memory:} multi-rows {
+    CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, col);
+    INSERT INTO test (col) VALUES (1),(1);
+    SELECT * FROM test;
+} {1|1
+2|1}


### PR DESCRIPTION
Due to constant instruction reshuffling introduced in #1359, it is advisable not to do either of the following:

1. Use raw offsets as jump targets
2. Use `program.resolve_label(my_label, program.offset())` when it is uncertain what the next instruction will be

Instead, if you want a label to point to "whatever instruction follows the last one", you should use `program.preassign_label_to_next_insn(label)`, which will work correctly even with instruction rerdering