### PR TITLE
Mark WHERE terms as consumed instead of deleting them

### DIFF
--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1276,6 +1276,7 @@ mod tests {
         WhereTerm {
             expr: Expr::Binary(Box::new(lhs), op, Box::new(rhs)),
             from_outer_join: None,
+            consumed: false,
         }
     }
 

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -557,6 +557,7 @@ pub fn parse_where(
             out_where_clause.push(WhereTerm {
                 expr,
                 from_outer_join: None,
+                consumed: false,
             });
         }
         Ok(())
@@ -1016,6 +1017,7 @@ fn parse_join<'a>(
                         } else {
                             None
                         },
+                        consumed: false,
                     });
                 }
             }
@@ -1085,6 +1087,7 @@ fn parse_join<'a>(
                     out_where_clause.push(WhereTerm {
                         expr,
                         from_outer_join: if outer { Some(cur_table_idx) } else { None },
+                        consumed: false,
                     });
                 }
                 using = Some(distinct_names);

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -83,7 +83,6 @@ pub fn emit_subquery<'a>(
         reg_offset: plan.offset.map(|_| program.alloc_register()),
         reg_limit_offset_sum: plan.offset.map(|_| program.alloc_register()),
         resolver: Resolver::new(t_ctx.resolver.symbol_table),
-        omit_predicates: Vec::new(),
     };
     let subquery_body_end_label = program.allocate_label();
     program.emit_insn(Insn::InitCoroutine {


### PR DESCRIPTION
We've run into trouble in multiple places due to the fact that we delete terms from the where clause (e.g. when a constant condition is removed, or the term becomes part of an index seek key).

A simpler solution is to add a flag indicating that the term is consumed (used), so that it is not translated in the main loop anymore when WHERE clause terms are evaluated.

note: CI failures are unrelated