### PR TITLE
Update Nyrkiö change detection to newest version

### DIFF
--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -49,9 +49,9 @@ jobs:
 
           # parameters of the algorithm. Note: These are global, so we only set them once and for all.
           # Smaller p-value = less change points found. Larger p-value = more, but also more false positives.
-          nyrkio-settings-pvalue: 0.01
+          nyrkio-settings-pvalue: 0.0001
           # Ignore changes smaller than this.
-          nyrkio-settings-threshold: 2%
+          nyrkio-settings-threshold: 0%
 
   clickbench:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -22,12 +22,12 @@ jobs:
       #   run: npm install && npm run build
 
       - name: Bench
-        run: cargo bench --output-format bencher | tee output.txt
+        run: cargo bench  2>&1 | tee output.txt
       - name: Analyze benchmark result with Nyrkiö
         uses: nyrkio/change-detection@HEAD
         with:
           name: turso
-          tool: cargo
+          tool: criterion
           output-file-path: output.txt
 
           # What to do if a change is immediately detected by Nyrkiö.

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -22,18 +22,12 @@ jobs:
       #   run: npm install && npm run build
 
       - name: Bench
-        run: cargo bench  2>&1 | tee output.txt
-      # - name: Bench (fake)
-      #   run: |
-      #       pwd
-      #       ls
-      #       cp .github/data/limbo-cargo-output.txt output.txt
-
+        run: cargo bench | tee output.txt
       - name: Analyze benchmark result with Nyrkiö
-        uses: nyrkio/github-action-benchmark@HEAD
+        uses: nyrkio/change-detection@HEAD
         with:
           name: turso
-          tool: criterion
+          tool: cargo
           output-file-path: output.txt
 
           # What to do if a change is immediately detected by Nyrkiö.
@@ -45,24 +39,19 @@ jobs:
           comment-on-alert: true
           comment-always: false
           # Nyrkiö configuration
-          nyrkio-enable: true
           # Get yours from https://nyrkio.com/docs/getting-started
           nyrkio-token: ${{ secrets.NYRKIO_JWT_TOKEN }}
-          # You may not want share the NYRKIO_JWT_TOKEN token with pull requests, for example.
-          # In that case this task would unnecessarily fail for random contributors. Don't want that:
+          # HTTP requests will fail for all non-core contributors that don't have their own token.
+          # Don't want that to spoil the build, so:
           never-fail: true
           # Make results and change points public, so that any oss contributor can see them
           nyrkio-public: true
 
-          nyrkio-api-root: https://nyrkio.com/api/v0
-          # Make results and change points public, so that any oss contributor can see them
+          # parameters of the algorithm. Note: These are global, so we only set them once and for all.
+          # Smaller p-value = less change points found. Larger p-value = more, but also more false positives.
           nyrkio-settings-pvalue: 0.01%
+          # Ignore changes smaller than this.
           nyrkio-settings-threshold: 2%
-
-          # Old way...
-          # Explicitly set this to null. We don't want threshold based alerts today.
-          external-data-json-path: null
-          gh-repository: null
 
   clickbench:
     runs-on: ubuntu-latest
@@ -76,7 +65,7 @@ jobs:
         run: make clickbench
 
       - name: Analyze LIMBO result with Nyrkiö
-        uses: nyrkio/github-action-benchmark@HEAD
+        uses: nyrkio/change-detection@HEAD
         with:
           name: clickbench/limbo
           tool: time
@@ -90,23 +79,13 @@ jobs:
           comment-on-alert: true
           comment-always: false
           # Nyrkiö configuration
-          nyrkio-enable: true
           # Get yours from https://nyrkio.com/docs/getting-started
           nyrkio-token: ${{ secrets.NYRKIO_JWT_TOKEN }}
-          # You may not want share the NYRKIO_JWT_TOKEN token with pull requests, for example.
-          # In that case this task would unnecessarily fail for random contributors. Don't want that:
+          # HTTP requests will fail for all non-core contributors that don't have their own token.
+          # Don't want that to spoil the build, so:
           never-fail: true
           # Make results and change points public, so that any oss contributor can see them
           nyrkio-public: true
-
-          nyrkio-api-root: https://nyrkio.com/api/v0
-          # Team support = results are visible and manageable to everyone in the same Github org
-          # nyrkio-org: tursodatabase
-
-          # Old way...
-          # Explicitly set this to null. We don't want threshold based alerts today.
-          external-data-json-path: null
-          gh-repository: null
 
       - name: Analyze SQLITE3 result with Nyrkiö
         uses: nyrkio/github-action-benchmark@HEAD
@@ -117,12 +96,6 @@ jobs:
           fail-on-alert: false
           comment-on-alert: true
           comment-always: false
-          nyrkio-enable: true
           nyrkio-token: ${{ secrets.NYRKIO_JWT_TOKEN }}
           never-fail: true
           nyrkio-public: true
-          nyrkio-api-root: https://nyrkio.com/api/v0
-          # nyrkio-org: tursodatabase
-
-          external-data-json-path: null
-          gh-repository: null

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -22,7 +22,7 @@ jobs:
       #   run: npm install && npm run build
 
       - name: Bench
-        run: cargo bench | tee output.txt
+        run: cargo bench --output-format bencher | tee output.txt
       - name: Analyze benchmark result with Nyrkiö
         uses: nyrkio/change-detection@HEAD
         with:

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -49,7 +49,7 @@ jobs:
 
           # parameters of the algorithm. Note: These are global, so we only set them once and for all.
           # Smaller p-value = less change points found. Larger p-value = more, but also more false positives.
-          nyrkio-settings-pvalue: 0.01%
+          nyrkio-settings-pvalue: 0.01
           # Ignore changes smaller than this.
           nyrkio-settings-threshold: 2%
 


### PR DESCRIPTION
(Yes, I changed the name of the repo.)

Also switch back to 'cargo' for the parser, which is the original upstream code. I created 'criterion' because I didn't realize cargo bench spitz half of the text to stdout the other half to stderr.