### PR TITLE
github: Disable setup-node yarn cache

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -50,8 +50,6 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: 20
-          cache: yarn
-          cache-dependency-path: bindings/javascript
       - name: Install
         uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}
@@ -83,9 +81,7 @@ jobs:
         if: matrix.settings.target == 'x86_64-pc-windows-msvc'
         with:
           node-version: 20
-#          cache: yarn
           architecture: x64
-#          cache-dependency-path: bindings/javascript
       - name: Build in docker
         uses: addnab/docker-run-action@v3
         if: ${{ matrix.settings.docker }}
@@ -123,8 +119,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: yarn
-          cache-dependency-path: bindings/javascript
           architecture: x64
       - name: Install dependencies
         run: yarn install
@@ -155,8 +149,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: yarn
-          cache-dependency-path: bindings/javascript
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
@@ -180,8 +172,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
-          cache-dependency-path: bindings/javascript
       - name: Install dependencies
         run: yarn install
       - name: Download macOS x64 artifact
@@ -218,8 +208,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
-          cache-dependency-path: bindings/javascript
       - name: Install dependencies
         run: yarn install
       - name: Download all artifacts


### PR DESCRIPTION
The setup-node fails sporadically with the following error:

```
Error: Could not get yarn cache folder path for /home/runner/work/limbo/limbo/bindings/javascript/docs
```

This seems to be a known issue that's not fixed despite the issue being closed: https://github.com/actions/setup-node/issues/887

Let's disable yarn caching for setup-node in an attempt to reduce CI failing randomly.