### PR TITLE
Fix autoindex of primary key marked as unique

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -915,8 +915,8 @@ impl Index {
                 if col.unique {
                     // Unique columns in Table should always be named
                     let col_name = col.name.as_ref().unwrap();
-                    if has_primary_key_index 
-                        && table.primary_key_columns.len() == 1 
+                    if has_primary_key_index
+                        && table.primary_key_columns.len() == 1
                         && &table.primary_key_columns.first().as_ref().unwrap().0 == col_name {
                             // skip unique columns that are satisfied with pk constraint
                             return None;
@@ -961,45 +961,50 @@ impl Index {
         }
 
         if let Some(unique_sets) = table.unique_sets.as_ref() {
-            let unique_set_indices = unique_sets.iter().filter(|set| {
-                    if has_primary_key_index 
-                        && table.primary_key_columns.len() == set.len() 
-                        && table.primary_key_columns.iter().all(|col| set.contains(col)) {
-                            // skip unique columns that are satisfied with pk constraint
-                            return false;
-
+            let unique_set_indices = unique_sets
+                .iter()
+                .filter(|set| {
+                    if has_primary_key_index
+                        && table.primary_key_columns.len() == set.len()
+                        && table
+                            .primary_key_columns
+                            .iter()
+                            .all(|col| set.contains(col))
+                    {
+                        // skip unique columns that are satisfied with pk constraint
+                        return false;
                     } else {
                         true
                     }
-
-            }).map(|set| {
-                let (index_name, root_page) = auto_indices.next().expect(
+                })
+                .map(|set| {
+                    let (index_name, root_page) = auto_indices.next().expect(
                     "number of auto_indices in schema should be same number of indices calculated",
                 );
 
-                let index_cols = set.iter().map(|(col_name, order)| {
-                    let Some((pos_in_table, _)) = table.get_column(col_name) else {
-                        // This is clearly an invariant that should be maintained, so a panic seems more correct here
-                        panic!(
-                            "Column {} is in index {} but not found in table {}",
-                            col_name, index_name, table.name
-                        );
-                    };
-                    IndexColumn {
-                        name: normalize_ident(col_name),
-                        order: *order,
-                        pos_in_table,
+                    let index_cols = set.iter().map(|(col_name, order)| {
+                        let Some((pos_in_table, _)) = table.get_column(col_name) else {
+                            // This is clearly an invariant that should be maintained, so a panic seems more correct here
+                            panic!(
+                                "Column {} is in index {} but not found in table {}",
+                                col_name, index_name, table.name
+                            );
+                        };
+                        IndexColumn {
+                            name: normalize_ident(col_name),
+                            order: *order,
+                            pos_in_table,
+                        }
+                    });
+                    Index {
+                        name: normalize_ident(index_name.as_str()),
+                        table_name: table.name.clone(),
+                        root_page,
+                        columns: index_cols.collect(),
+                        unique: true,
+                        ephemeral: false,
                     }
                 });
-                Index {
-                    name: normalize_ident(index_name.as_str()),
-                    table_name: table.name.clone(),
-                    root_page,
-                    columns: index_cols.collect(),
-                    unique: true,
-                    ephemeral: false,
-                }
-            });
             indices.extend(unique_set_indices);
         }
 
@@ -1583,7 +1588,7 @@ mod tests {
             vec![
                 ("sqlite_autoindex_t1_1".to_string(), 2),
                 ("sqlite_autoindex_t1_2".to_string(), 3),
-                ],
+            ],
         )?;
 
         assert!(indexes.len() == 2);

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -422,16 +422,10 @@ fn check_automatic_pk_index_required(
             if auto_index_pk && !pk_is_unique {
                 total_indices += 1;
             }
-            dbg!(total_indices);
 
             if total_indices > 0 {
-                if total_indices == 1 {
-                    let index_reg = program.alloc_register();
-                    Ok(Some(index_reg..index_reg + 1))
-                } else {
-                    let index_start_reg = program.alloc_registers(total_indices + 1);
-                    Ok(Some(index_start_reg..index_start_reg + total_indices + 1))
-                }
+                let index_start_reg = program.alloc_registers(total_indices);
+                Ok(Some(index_start_reg..index_start_reg + total_indices))
             } else {
                 Ok(None)
             }


### PR DESCRIPTION
Primary keys that are marked as unique constraint, do not need to have separate indexes, one is enough. In the case primary key is integer, therefore rowid alias, we still need an index to satisfy unique constraint.