### PR TITLE
pager: bump default page cache size from 10 to 2000 pages

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -78,6 +78,8 @@ use vdbe::{builder::QueryMode, VTabOpaqueCursor};
 pub type Result<T, E = LimboError> = std::result::Result<T, E>;
 pub static DATABASE_VERSION: OnceLock<String> = OnceLock::new();
 
+const DEFAULT_PAGE_CACHE_SIZE_IN_PAGES: usize = 2000;
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum TransactionState {
     Write,
@@ -166,7 +168,9 @@ impl Database {
             None
         };
 
-        let shared_page_cache = Arc::new(RwLock::new(DumbLruPageCache::new(1000)));
+        let shared_page_cache = Arc::new(RwLock::new(DumbLruPageCache::new(
+            DEFAULT_PAGE_CACHE_SIZE_IN_PAGES,
+        )));
         let schema = Arc::new(RwLock::new(Schema::new()));
         let db = Database {
             mv_store,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -166,7 +166,7 @@ impl Database {
             None
         };
 
-        let shared_page_cache = Arc::new(RwLock::new(DumbLruPageCache::new(10)));
+        let shared_page_cache = Arc::new(RwLock::new(DumbLruPageCache::new(1000)));
         let schema = Arc::new(RwLock::new(Schema::new()));
         let db = Database {
             mv_store,


### PR DESCRIPTION
```
Execute `SELECT count() FROM users`/limbo_execute_select_count
                        time:   [12.867 µs 12.958 µs 13.104 µs]
                        change: [-91.233% -91.178% -91.120%] (p = 0.00 < 0.05)
                        Performance has improved.
```

also extracted it to a constant