### PR TITLE
Document how to run `cargo test` on Ubuntu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,33 @@ cargo run --package limbo_cli --bin limbo database.db
 ```
 
 Run tests:
+```console
+cargo test
+```
 
+### Running Tests On Linux
+> [!NOTE]
+> These steps have been tested on Ubuntu Noble 24.04.2 LTS
+
+Running tests on Linux and getting them pass requires a few additional steps
+
+1. Install [SQLite](https://www.sqlite.org/index.html)
+```console
+sudo apt install sqlite3 libsqlite3-dev
+```
+2. Build Cargo 
+```console
+cargo build -p limbo_sqlite3 --features capi
+```
+3. Install Python3
+```console
+sudo apt install python3.12 python3.12-dev
+```
+4. Set env var for Maturin
+```console
+export PYO3_PYTHON=$(which python3)
+```
+5. Run tests
 ```console
 cargo test
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,21 +38,21 @@ cargo test
 
 Running tests on Linux and getting them pass requires a few additional steps
 
-1. Install [SQLite](https://www.sqlite.org/index.html)
+1. Install [SQLite](https://www.sqlite.org/index.html) headers
 ```console
 sudo apt install sqlite3 libsqlite3-dev
 ```
-2. Build Cargo 
-```console
-cargo build -p limbo_sqlite3 --features capi
-```
-3. Install Python3
+2. Install Python3 dev files
 ```console
 sudo apt install python3.12 python3.12-dev
 ```
-4. Set env var for Maturin
+3. Set env var for Maturin
 ```console
 export PYO3_PYTHON=$(which python3)
+```
+4. Build Cargo 
+```console
+cargo build -p limbo_sqlite3 --features capi
 ```
 5. Run tests
 ```console


### PR DESCRIPTION
This PR adds documentation on how to get tests to successfully pass on Linux (Ubuntu 24.04.2 LTS)

Without these additional steps `cargo test` complains about missing missing dev files and can't complete the compatibility tests.