### PR TITLE
long fuzz tests ci on btree changes

### DIFF
--- a/.github/workflows/long_fuzz_tests_btree.yml
+++ b/.github/workflows/long_fuzz_tests_btree.yml
@@ -1,0 +1,44 @@
+name: Run long fuzz tests on Btree
+
+on:
+  push:
+    paths:
+      - 'core/storage/btree.rs'
+  pull_request:
+    paths:
+      - 'core/storage/btree.rs'
+
+jobs:
+  run-long-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 0 
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 
+      
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      
+      - name: Run ignored long tests
+        run: cargo test -- --ignored fuzz_long
+        env:
+          RUST_BACKTRACE: 1  

--- a/.github/workflows/long_fuzz_tests_btree.yml
+++ b/.github/workflows/long_fuzz_tests_btree.yml
@@ -14,32 +14,17 @@ jobs:
     timeout-minutes: 0 
     
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 
-      
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-      
-      - uses: "./.github/shared/install_sqlite"
-      - name: Run ignored long tests
-        run: cargo test -- --ignored fuzz_long
-        env:
-          RUST_BACKTRACE: 1  
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: "v1-rust" # can be updated if we need to reset caches due to non-trivial change in the dependencies (for example, custom env var were set for single workspace project)
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Build
+      run: cargo build --verbose
+    - name: Run ignored long tests
+      run: cargo test -- --ignored fuzz_long
+      env:
+        RUST_BACKTRACE: 1  

--- a/.github/workflows/long_fuzz_tests_btree.yml
+++ b/.github/workflows/long_fuzz_tests_btree.yml
@@ -38,6 +38,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       
+      - uses: "./.github/shared/install_sqlite"
       - name: Run ignored long tests
         run: cargo test -- --ignored fuzz_long
         env:

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6121,6 +6121,47 @@ mod tests {
         btree_insert_fuzz_run(64, 32, |rng| (rng.next_u32() % 32 * 1024) as usize);
     }
 
+    #[test]
+    #[ignore]
+    pub fn fuzz_long_btree_insert_fuzz_run_equal_size() {
+        for size in 1..8 {
+            tracing::info!("======= size:{} =======", size);
+            btree_insert_fuzz_run(2, 10_000, |_| size);
+        }
+    }
+
+    #[test]
+    #[ignore]
+    pub fn fuzz_long_btree_index_insert_fuzz_run_equal_size() {
+        btree_index_insert_fuzz_run(2, 10_000);
+    }
+
+    #[test]
+    #[ignore]
+    pub fn fuzz_long_btree_insert_fuzz_run_random() {
+        btree_insert_fuzz_run(128, 10_000, |rng| (rng.next_u32() % 4096) as usize);
+    }
+
+    #[test]
+    #[ignore]
+    pub fn fuzz_long_btree_insert_fuzz_run_small() {
+        btree_insert_fuzz_run(1, 10_000, |rng| (rng.next_u32() % 128) as usize);
+    }
+
+    #[test]
+    #[ignore]
+    pub fn fuzz_long_btree_insert_fuzz_run_big() {
+        btree_insert_fuzz_run(64, 10_000, |rng| {
+            3 * 1024 + (rng.next_u32() % 1024) as usize
+        });
+    }
+
+    #[test]
+    #[ignore]
+    pub fn fuzz_long_btree_insert_fuzz_run_overflow() {
+        btree_insert_fuzz_run(64, 10_000, |rng| (rng.next_u32() % 32 * 1024) as usize);
+    }
+
     #[allow(clippy::arc_with_non_send_sync)]
     fn setup_test_env(database_size: u32) -> (Rc<Pager>, Arc<SpinLock<DatabaseHeader>>) {
         let page_size = 512;


### PR DESCRIPTION
The idea is simple, if you modify the btree, we should verify fuzz tests with long number of iterations to decrease the chance of a regression