### PR TITLE
Add support for DISTINCT aggregate functions

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5068,9 +5068,12 @@ fn debug_validate_cells_core(page: &PageContent, usable_space: u16) {
             usable_space as usize,
         );
         let buf = &page.as_ptr()[offset..offset + size];
+        // E.g. the following table btree cell may just have two bytes:
+        // Payload size 0 (stored as SerialTypeKind::ConstInt0)
+        // Rowid 1 (stored as SerialTypeKind::ConstInt1)
         assert!(
-            size >= 4,
-            "cell size should be at least 4 bytes idx={}, cell={:?}, offset={}",
+            size >= 2,
+            "cell size should be at least 2 bytes idx={}, cell={:?}, offset={}",
             i,
             buf,
             offset

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -63,7 +63,7 @@ pub fn emit_ungrouped_aggregation<'a>(
 /// Emits the bytecode for handling duplicates in a distinct aggregate.
 /// This is used in both GROUP BY and non-GROUP BY aggregations to jump over
 /// the AggStep that would otherwise accumulate the same value multiple times.
-fn handle_distinct(program: &mut ProgramBuilder, agg: &Aggregate, agg_arg_reg: usize) {
+pub fn handle_distinct(program: &mut ProgramBuilder, agg: &Aggregate, agg_arg_reg: usize) {
     let AggDistinctness::Distinct { ctx } = &agg.distinctness else {
         return;
     };

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -2,14 +2,17 @@ use limbo_sqlite3_parser::ast;
 
 use crate::{
     function::AggFunc,
-    vdbe::{builder::ProgramBuilder, insn::Insn},
+    vdbe::{
+        builder::ProgramBuilder,
+        insn::{IdxInsertFlags, Insn},
+    },
     LimboError, Result,
 };
 
 use super::{
     emitter::{Resolver, TranslateCtx},
     expr::translate_expr,
-    plan::{Aggregate, SelectPlan, TableReference},
+    plan::{AggDistinctness, Aggregate, SelectPlan, TableReference},
     result_row::emit_select_result,
 };
 
@@ -57,6 +60,39 @@ pub fn emit_ungrouped_aggregation<'a>(
     Ok(())
 }
 
+/// Emits the bytecode for handling duplicates in a distinct aggregate.
+/// This is used in both GROUP BY and non-GROUP BY aggregations to jump over
+/// the AggStep that would otherwise accumulate the same value multiple times.
+fn handle_distinct(program: &mut ProgramBuilder, agg: &Aggregate, agg_arg_reg: usize) {
+    let AggDistinctness::Distinct { ctx } = &agg.distinctness else {
+        return;
+    };
+    let distinct_agg_ctx = ctx
+        .as_ref()
+        .expect("distinct aggregate context not populated");
+    let num_regs = 1;
+    program.emit_insn(Insn::Found {
+        cursor_id: distinct_agg_ctx.cursor_id,
+        target_pc: distinct_agg_ctx.label_on_conflict,
+        record_reg: agg_arg_reg,
+        num_regs,
+    });
+    let record_reg = program.alloc_register();
+    program.emit_insn(Insn::MakeRecord {
+        start_reg: agg_arg_reg,
+        count: num_regs,
+        dest_reg: record_reg,
+        index_name: Some(distinct_agg_ctx.ephemeral_index_name.to_string()),
+    });
+    program.emit_insn(Insn::IdxInsert {
+        cursor_id: distinct_agg_ctx.cursor_id,
+        record_reg: record_reg,
+        unpacked_start: None,
+        unpacked_count: None,
+        flags: IdxInsertFlags::new(),
+    });
+}
+
 /// Emits the bytecode for processing an aggregate step.
 /// E.g. in `SELECT SUM(price) FROM t`, 'price' is evaluated for every row, and the result is added to the accumulator.
 ///
@@ -77,6 +113,7 @@ pub fn translate_aggregation_step(
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
             let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
+            handle_distinct(program, agg, expr_reg);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -94,6 +131,7 @@ pub fn translate_aggregation_step(
                 let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
                 expr_reg
             };
+            handle_distinct(program, agg, expr_reg);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -132,6 +170,7 @@ pub fn translate_aggregation_step(
             }
 
             translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
+            handle_distinct(program, agg, expr_reg);
             translate_expr(
                 program,
                 Some(referenced_tables),
@@ -156,6 +195,7 @@ pub fn translate_aggregation_step(
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
             let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
+            handle_distinct(program, agg, expr_reg);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -171,6 +211,7 @@ pub fn translate_aggregation_step(
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
             let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
+            handle_distinct(program, agg, expr_reg);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -190,6 +231,7 @@ pub fn translate_aggregation_step(
             let value_reg = program.alloc_register();
 
             let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
+            handle_distinct(program, agg, expr_reg);
             let _ = translate_expr(
                 program,
                 Some(referenced_tables),
@@ -214,6 +256,7 @@ pub fn translate_aggregation_step(
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
             let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
+            handle_distinct(program, agg, expr_reg);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -264,6 +307,7 @@ pub fn translate_aggregation_step(
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
             let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
+            handle_distinct(program, agg, expr_reg);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -279,6 +323,7 @@ pub fn translate_aggregation_step(
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
             let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
+            handle_distinct(program, agg, expr_reg);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -310,6 +355,10 @@ pub fn translate_aggregation_step(
                     expr_reg + i,
                     resolver,
                 )?;
+                // invariant: distinct aggregates are only supported for single-argument functions
+                if argc == 1 {
+                    handle_distinct(program, agg, expr_reg + i);
+                }
             }
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -288,6 +288,7 @@ pub fn emit_query<'a>(
         t_ctx,
         &plan.table_references,
         &mut plan.aggregates,
+        plan.group_by.as_ref(),
         OperationMode::SELECT,
     )?;
 
@@ -398,6 +399,7 @@ fn emit_program_for_delete(
         &mut t_ctx,
         &plan.table_references,
         &mut [],
+        None,
         OperationMode::DELETE,
     )?;
 
@@ -591,6 +593,7 @@ fn emit_program_for_update(
         &mut t_ctx,
         &plan.table_references,
         &mut [],
+        None,
         OperationMode::UPDATE,
     )?;
     // Open indexes for update.

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -287,6 +287,7 @@ pub fn emit_query<'a>(
         program,
         t_ctx,
         &plan.table_references,
+        &mut plan.aggregates,
         OperationMode::SELECT,
     )?;
 
@@ -396,6 +397,7 @@ fn emit_program_for_delete(
         program,
         &mut t_ctx,
         &plan.table_references,
+        &mut [],
         OperationMode::DELETE,
     )?;
 
@@ -588,6 +590,7 @@ fn emit_program_for_update(
         program,
         &mut t_ctx,
         &plan.table_references,
+        &mut [],
         OperationMode::UPDATE,
     )?;
     // Open indexes for update.

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -764,6 +764,12 @@ fn emit_loop_source<'a>(
                     reg,
                     &t_ctx.resolver,
                 )?;
+                if let AggDistinctness::Distinct { ctx } = &agg.distinctness {
+                    let ctx = ctx
+                        .as_ref()
+                        .expect("distinct aggregate context not populated");
+                    program.preassign_label_to_next_insn(ctx.label_on_conflict);
+                }
             }
 
             let label_emit_nonagg_only_once = if let Some(flag) = t_ctx.reg_nonagg_emit_once_flag {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -569,6 +569,12 @@ impl ProgramBuilder {
                 Insn::NoConflict { target_pc, .. } => {
                     resolve(target_pc, "NoConflict");
                 }
+                Insn::Found { target_pc, .. } => {
+                    resolve(target_pc, "Found");
+                }
+                Insn::NotFound { target_pc, .. } => {
+                    resolve(target_pc, "NotFound");
+                }
                 _ => {}
             }
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4641,22 +4641,30 @@ pub fn op_once(
     Ok(InsnFunctionStepResult::Step)
 }
 
-pub fn op_not_found(
+pub fn op_found(
     program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Rc<Pager>,
     mv_store: Option<&Rc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
-    let Insn::NotFound {
-        cursor_id,
-        target_pc,
-        record_reg,
-        num_regs,
-    } = insn
-    else {
-        unreachable!("unexpected Insn {:?}", insn)
+    let (cursor_id, target_pc, record_reg, num_regs) = match insn {
+        Insn::NotFound {
+            cursor_id,
+            target_pc,
+            record_reg,
+            num_regs,
+        } => (cursor_id, target_pc, record_reg, num_regs),
+        Insn::Found {
+            cursor_id,
+            target_pc,
+            record_reg,
+            num_regs,
+        } => (cursor_id, target_pc, record_reg, num_regs),
+        _ => unreachable!("unexpected Insn {:?}", insn),
     };
+
+    let not = matches!(insn, Insn::NotFound { .. });
 
     let found = {
         let mut cursor = state.get_cursor(*cursor_id);
@@ -4679,10 +4687,11 @@ pub fn op_not_found(
         }
     };
 
-    if found {
-        state.pc += 1;
-    } else {
+    let do_jump = (!found && not) || (found && !not);
+    if do_jump {
         state.pc = target_pc.to_offset_int();
+    } else {
+        state.pc += 1;
     }
 
     Ok(InsnFunctionStepResult::Step)

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1418,16 +1418,30 @@ pub fn insn_to_str(
                 target_pc,
                 record_reg,
                 ..
+            }
+            | Insn::Found {
+                cursor_id,
+                target_pc,
+                record_reg,
+                ..
             } => (
-                "NotFound",
+                if matches!(insn, Insn::NotFound { .. }) {
+                    "NotFound"
+                } else {
+                    "Found"
+                },
                 *cursor_id as i32,
                 target_pc.to_debug_int(),
                 *record_reg as i32,
                 Value::build_text(""),
                 0,
                 format!(
-                    "if (r[{}] != NULL) goto {}",
-                    record_reg,
+                    "if {}found goto {}",
+                    if matches!(insn, Insn::NotFound { .. }) {
+                        "not "
+                    } else {
+                        ""
+                    },
                     target_pc.to_debug_int()
                 ),
             ),

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -849,6 +849,15 @@ pub enum Insn {
     Once {
         target_pc_when_reentered: BranchOffset,
     },
+    /// Search for a record in the index cursor.
+    /// If any entry for which the key is a prefix exists, jump to target_pc.
+    /// Otherwise, continue to the next instruction.
+    Found {
+        cursor_id: CursorID,
+        target_pc: BranchOffset,
+        record_reg: usize,
+        num_regs: usize,
+    },
     /// Search for record in the index cusor, if any entry for which the key is a prefix exists
     /// is a no-op, otherwise go to target_pc
     /// Example =>
@@ -995,7 +1004,7 @@ impl Insn {
             Insn::ReadCookie { .. } => execute::op_read_cookie,
             Insn::OpenEphemeral { .. } | Insn::OpenAutoindex { .. } => execute::op_open_ephemeral,
             Insn::Once { .. } => execute::op_once,
-            Insn::NotFound { .. } => execute::op_not_found,
+            Insn::Found { .. } | Insn::NotFound { .. } => execute::op_found,
             Insn::Affinity { .. } => execute::op_affinity,
             Insn::IdxDelete { .. } => execute::op_idx_delete,
             Insn::Count { .. } => execute::op_count,

--- a/testing/agg-functions.test
+++ b/testing/agg-functions.test
@@ -127,3 +127,7 @@ do_execsql_test select-agg-json-array {
 do_execsql_test select-agg-json-array-object {
   SELECT json_group_array(json_object('name', name)) FROM products;
 } {[{"name":"hat"},{"name":"cap"},{"name":"shirt"},{"name":"sweater"},{"name":"sweatshirt"},{"name":"shorts"},{"name":"jeans"},{"name":"sneakers"},{"name":"boots"},{"name":"coat"},{"name":"accessories"}]}
+
+do_execsql_test select-distinct-agg-functions {
+  SELECT sum(distinct age), count(distinct age), avg(distinct age) FROM users;
+} {5050|100|50.5}

--- a/testing/groupby.test
+++ b/testing/groupby.test
@@ -198,3 +198,12 @@ do_execsql_test group_by_no_sorting_required {
 } {1|112
 2|113
 3|97}
+
+do_execsql_test distinct_agg_functions {
+  select first_name, sum(distinct age), count(distinct age), avg(distinct age) 
+  from users 
+  group by 1 
+  limit 3;
+} {Aaron|1769|33|53.6060606060606
+Abigail|833|15|55.5333333333333
+Adam|1517|30|50.5666666666667}


### PR DESCRIPTION
Reviewable commit by commit. CI failures are not related.

Adds support for e.g. `select first_name, sum(distinct age), count(distinct age), avg(distinct age) from users group by 1`

Implementation details:

- Creates an ephemeral index per distinct aggregate, and jumps over the accumulation step if a duplicate is found