### PR TITLE
Autoindex fix

### DIFF
--- a/testing/all.test
+++ b/testing/all.test
@@ -33,3 +33,4 @@ source $testdir/default_value.test
 source $testdir/boolean.test
 source $testdir/literal.test
 source $testdir/null.test
+source $testdir/create_table.test

--- a/testing/create_table.test
+++ b/testing/create_table.test
@@ -1,0 +1,16 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test_in_memory_any_error create_table_one_unique_set {
+    CREATE TABLE t4(a, unique(b));
+}
+
+do_execsql_test_on_specific_db {:memory:} create_table_same_uniques_and_primary_keys {
+    CREATE TABLE t2(a,b, unique(a,b), primary key(a,b));
+} {}
+
+do_execsql_test_on_specific_db {:memory:} create_table_unique_contained_in_primary_keys {
+    CREATE TABLE t4(a,b, primary key(a,b), unique(a));
+} {}

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1034,7 +1034,6 @@ pub struct GroupBy {
 
 /// identifier or one of several keywords or `INDEXED`
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[repr(transparent)] // Repr transparent needed as we do transmute between Name and Id
 pub struct Id(pub String);
 
 impl Id {
@@ -1048,7 +1047,6 @@ impl Id {
 
 /// identifier or string or `CROSS` or `FULL` or `INNER` or `LEFT` or `NATURAL` or `OUTER` or `RIGHT`.
 #[derive(Clone, Debug, Eq)]
-#[repr(transparent)] // Repr transparent needed as we do transmute between Name and Id
 pub struct Name(pub String); // TODO distinction between Name and "Name"/[Name]/`Name`
 
 impl Name {

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1034,6 +1034,7 @@ pub struct GroupBy {
 
 /// identifier or one of several keywords or `INDEXED`
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)] // Repr transparent needed as we do transmute between Name and Id
 pub struct Id(pub String);
 
 impl Id {
@@ -1047,6 +1048,7 @@ impl Id {
 
 /// identifier or string or `CROSS` or `FULL` or `INNER` or `LEFT` or `NATURAL` or `OUTER` or `RIGHT`.
 #[derive(Clone, Debug, Eq)]
+#[repr(transparent)] // Repr transparent needed as we do transmute between Name and Id
 pub struct Name(pub String); // TODO distinction between Name and "Name"/[Name]/`Name`
 
 impl Name {


### PR DESCRIPTION
Closes #1508 . There were two small issues to fix:

1. We were not checking in the IndexMap of columns, if the unique column name is declared in the composite declaration exists in the IndexMap. This solved the first this statement `create table t4(a, unique(b));`.
2. The second thing was that we forgot to add the column_name to the HashSet of columns. 
```rust
Some(PrimaryKeyDefinitionType::Simple { column, .. }) => {
      let mut columns = HashSet::new();
      columns.insert(std::mem::take(column));
      // Have to also insert the current column_name we are iterating over in primary_key_column_results
      columns.insert(column_name.clone()); <-- Fix here
      primary_key_definition =
           Some(PrimaryKeyDefinitionType::Composite { columns });
      }
```
The rest of the modifications are just some small simplifications for readability and avoiding some clones
