### PR TITLE
use temporary db in sqlite3 wal tests to fix later tests failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,13 @@ test-time:
 	SQLITE_EXEC=$(SQLITE_EXEC) ./testing/time.test
 .PHONY: test-time
 
-test-sqlite3:
+reset-db:
+	./scripts/clone_test_db.sh
+.PHONY: reset-db
+
+test-sqlite3: reset-db
 	cargo test -p limbo_sqlite3 --test compat
+	./scripts/clone_test_db.sh
 	cargo test -p limbo_sqlite3 --test compat --features sqlite3
 .PHONY: test-sqlite3
 

--- a/scripts/clone_test_db.sh
+++ b/scripts/clone_test_db.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+rm -f testing/testing_clone.db
+sqlite3 testing/testing/db '.clone testing/testing_clone.db' > /dev/null

--- a/sqlite3/tests/compat/mod.rs
+++ b/sqlite3/tests/compat/mod.rs
@@ -74,7 +74,7 @@ mod tests {
         unsafe {
             let mut db = ptr::null_mut();
             assert_eq!(
-                sqlite3_open(b"not-found/local.db\0".as_ptr() as *const i8, &mut db),
+                sqlite3_open(c"not-found/local.db".as_ptr(), &mut db),
                 SQLITE_CANTOPEN
             );
         }
@@ -85,7 +85,7 @@ mod tests {
         unsafe {
             let mut db = ptr::null_mut();
             assert_eq!(
-                sqlite3_open(b"../testing/testing.db\0".as_ptr() as *const i8, &mut db),
+                sqlite3_open(c"../testing/testing_clone.db".as_ptr(), &mut db),
                 SQLITE_OK
             );
             assert_eq!(sqlite3_close(db), SQLITE_OK);
@@ -104,19 +104,13 @@ mod tests {
         unsafe {
             let mut db = ptr::null_mut();
             assert_eq!(
-                sqlite3_open(b"../testing/testing.db\0".as_ptr() as *const i8, &mut db),
+                sqlite3_open(c"../testing/testing_clone.db".as_ptr(), &mut db),
                 SQLITE_OK
             );
 
             let mut stmt = ptr::null_mut();
             assert_eq!(
-                sqlite3_prepare_v2(
-                    db,
-                    b"SELECT 1\0".as_ptr() as *const i8,
-                    -1,
-                    &mut stmt,
-                    ptr::null_mut()
-                ),
+                sqlite3_prepare_v2(db, c"SELECT 1".as_ptr(), -1, &mut stmt, ptr::null_mut()),
                 SQLITE_OK
             );
 
@@ -131,7 +125,7 @@ mod tests {
             // Test with valid db
             let mut db = ptr::null_mut();
             assert_eq!(
-                sqlite3_open(b"../testing/testing.db\0".as_ptr() as *const i8, &mut db),
+                sqlite3_open(c"../testing/testing_clone.db".as_ptr(), &mut db),
                 SQLITE_OK
             );
             assert_eq!(sqlite3_wal_checkpoint(db, ptr::null()), SQLITE_OK);
@@ -145,7 +139,7 @@ mod tests {
             // Test with valid db
             let mut db = ptr::null_mut();
             assert_eq!(
-                sqlite3_open(b"../testing/testing.db\0".as_ptr() as *const i8, &mut db),
+                sqlite3_open(c"../testing/testing_clone.db".as_ptr(), &mut db),
                 SQLITE_OK
             );
 
@@ -210,7 +204,7 @@ mod tests {
             unsafe {
                 let mut db = ptr::null_mut();
                 assert_eq!(
-                    sqlite3_open(b"../testing/testing.db\0".as_ptr() as *const i8, &mut db),
+                    sqlite3_open(c"../testing/testing_clone.db".as_ptr(), &mut db),
                     SQLITE_OK
                 );
                 // Ensure that WAL is initially empty.
@@ -222,7 +216,7 @@ mod tests {
                 assert_eq!(
                     sqlite3_prepare_v2(
                         db,
-                        b"CREATE TABLE test (id INTEGER PRIMARY KEY)\0".as_ptr() as *const i8,
+                        c"CREATE TABLE test (id INTEGER PRIMARY KEY)".as_ptr(),
                         -1,
                         &mut stmt,
                         ptr::null_mut()
@@ -235,7 +229,7 @@ mod tests {
                 assert_eq!(
                     sqlite3_prepare_v2(
                         db,
-                        b"INSERT INTO test (id) VALUES (1)\0".as_ptr() as *const i8,
+                        c"INSERT INTO test (id) VALUES (1)".as_ptr(),
                         -1,
                         &mut stmt,
                         ptr::null_mut()


### PR DESCRIPTION
This prevents the new wal checkpoint tests in `sqlite3/tests/compat` from writing/creating `test` table to `testing/testing.db`, which is queried in later tests which fail for having an extra table.

There is another issue with failing tests related to the new `count` impl that I am in the process of fixing as well, but that will be a separate PR.