### PR TITLE
Fix updating single value

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3589,15 +3589,12 @@ impl BTreeCursor {
                             Some(rowid) => rowid,
                             None => {
                                 self.state = CursorState::None;
-                                // I don't think its necessary to invalidate here, but its safer to do so if I'm wrong
-                                self.invalidate_record();
                                 return Ok(CursorResult::Ok(()));
                             }
                         };
                     } else {
                         if self.reusable_immutable_record.borrow().is_none() {
                             self.state = CursorState::None;
-                            // Record is None here so no need to invalidate
                             return Ok(CursorResult::Ok(()));
                         }
                     }
@@ -3781,7 +3778,6 @@ impl BTreeCursor {
                     } else {
                         self.stack.retreat();
                         self.state = CursorState::None;
-                        self.invalidate_record();
                         return Ok(CursorResult::Ok(()));
                     }
                     // Only reaches this function call if state = DeleteState::WaitForBalancingToComplete
@@ -3838,16 +3834,10 @@ impl BTreeCursor {
                     return_if_io!(self.seek(key, SeekOp::EQ));
 
                     self.state = CursorState::None;
-                    self.invalidate_record();
                     return Ok(CursorResult::Ok(()));
                 }
             }
         }
-    }
-
-    fn invalidate_record(&mut self) {
-        let mut record = self.get_immutable_record();
-        record.as_mut().map(|record| record.invalidate());
     }
 
     /// In outer joins, whenever the right-side table has no matching row, the query must still return a row

--- a/testing/cli_tests/constraint.py
+++ b/testing/cli_tests/constraint.py
@@ -347,6 +347,15 @@ def custom_test_2(limbo: TestLimboShell):
     )
 
 
+# Issue #1482
+def regression_test_update_single_key(limbo: TestLimboShell):
+    create = "CREATE TABLE t(a unique);"
+    first_insert = "INSERT INTO t VALUES (1);"
+    limbo.run_test("Create simple table with 1 unique value", create + first_insert, "")
+    update_single = "UPDATE t SET a=1 WHERE a=1;"
+    limbo.run_test("Update one single key to the same value", update_single, "")
+
+
 def all_tests() -> list[ConstraintTest]:
     tests: list[ConstraintTest] = []
     max_cols = 10
@@ -390,15 +399,17 @@ def main():
         cleanup(db_path)
 
     db_path = "testing/constraint.db"
-    try:
-        with TestLimboShell("") as limbo:
-            limbo.execute_dot(f".open {db_path}")
-            custom_test_2(limbo)
-    except Exception as e:
-        console.error(f"Test FAILED: {e}")
+    tests = [custom_test_2, regression_test_update_single_key]
+    for test in tests:
+        try:
+            with TestLimboShell("") as limbo:
+                limbo.execute_dot(f".open {db_path}")
+                test(limbo)
+        except Exception as e:
+            console.error(f"Test FAILED: {e}")
+            cleanup(db_path)
+            exit(1)
         cleanup(db_path)
-        exit(1)
-    cleanup(db_path)
     console.info("All tests passed successfully.")
 
 


### PR DESCRIPTION
Closes #1482. I needed to change the `key_exists_in_index` function because it zips the values from the records it is comparing, but if one of the records is empty or not of the same length, the `all` function could return true incorrectly. 