### PR TITLE
Add support for SELECT DISTINCT

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{
     emitter::{Resolver, TranslateCtx},
     expr::translate_expr,
-    plan::{AggDistinctness, Aggregate, SelectPlan, TableReference},
+    plan::{Aggregate, Distinctness, SelectPlan, TableReference},
     result_row::emit_select_result,
 };
 
@@ -64,7 +64,7 @@ pub fn emit_ungrouped_aggregation<'a>(
 /// This is used in both GROUP BY and non-GROUP BY aggregations to jump over
 /// the AggStep that would otherwise accumulate the same value multiple times.
 pub fn handle_distinct(program: &mut ProgramBuilder, agg: &Aggregate, agg_arg_reg: usize) {
-    let AggDistinctness::Distinct { ctx } = &agg.distinctness else {
+    let Distinctness::Distinct { ctx } = &agg.distinctness else {
         return;
     };
     let distinct_agg_ctx = ctx

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -67,13 +67,13 @@ pub fn handle_distinct(program: &mut ProgramBuilder, agg: &Aggregate, agg_arg_re
     let Distinctness::Distinct { ctx } = &agg.distinctness else {
         return;
     };
-    let distinct_agg_ctx = ctx
+    let distinct_ctx = ctx
         .as_ref()
         .expect("distinct aggregate context not populated");
     let num_regs = 1;
     program.emit_insn(Insn::Found {
-        cursor_id: distinct_agg_ctx.cursor_id,
-        target_pc: distinct_agg_ctx.label_on_conflict,
+        cursor_id: distinct_ctx.cursor_id,
+        target_pc: distinct_ctx.label_on_conflict,
         record_reg: agg_arg_reg,
         num_regs,
     });
@@ -82,10 +82,10 @@ pub fn handle_distinct(program: &mut ProgramBuilder, agg: &Aggregate, agg_arg_re
         start_reg: agg_arg_reg,
         count: num_regs,
         dest_reg: record_reg,
-        index_name: Some(distinct_agg_ctx.ephemeral_index_name.to_string()),
+        index_name: Some(distinct_ctx.ephemeral_index_name.to_string()),
     });
     program.emit_insn(Insn::IdxInsert {
-        cursor_id: distinct_agg_ctx.cursor_id,
+        cursor_id: distinct_ctx.cursor_id,
         record_reg: record_reg,
         unpacked_start: None,
         unpacked_count: None,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -21,7 +21,9 @@ use super::expr::{translate_condition_expr, translate_expr, ConditionMetadata};
 use super::group_by::{
     group_by_agg_phase, group_by_emit_row_phase, init_group_by, GroupByMetadata, GroupByRowSource,
 };
-use super::main_loop::{close_loop, emit_loop, init_loop, open_loop, LeftJoinMetadata, LoopLabels};
+use super::main_loop::{
+    close_loop, emit_loop, init_distinct, init_loop, open_loop, LeftJoinMetadata, LoopLabels,
+};
 use super::order_by::{emit_order_by, init_order_by, SortMetadata};
 use super::plan::{JoinOrderMember, Operation, SelectPlan, TableReference, UpdatePlan};
 use super::schema::ParseSchema;
@@ -243,6 +245,8 @@ pub fn emit_query<'a>(
     if let Some(ref group_by) = plan.group_by {
         init_group_by(program, t_ctx, group_by, &plan)?;
     }
+
+    init_distinct(program, plan);
     init_loop(
         program,
         t_ctx,

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -20,7 +20,7 @@ use super::{
     emitter::{Resolver, TranslateCtx},
     expr::{translate_condition_expr, translate_expr, ConditionMetadata},
     order_by::order_by_sorter_insert,
-    plan::{AggDistinctness, Aggregate, GroupBy, SelectPlan, TableReference},
+    plan::{Aggregate, Distinctness, GroupBy, SelectPlan, TableReference},
     result_row::emit_select_result,
 };
 
@@ -576,7 +576,7 @@ pub fn group_by_process_single_group(
             agg_result_reg,
             &t_ctx.resolver,
         )?;
-        if let AggDistinctness::Distinct { ctx } = &agg.distinctness {
+        if let Distinctness::Distinct { ctx } = &agg.distinctness {
             let ctx = ctx
                 .as_ref()
                 .expect("distinct aggregate context not populated");
@@ -924,7 +924,7 @@ pub fn group_by_emit_row_phase<'a>(
     plan.aggregates
         .iter()
         .filter_map(|agg| {
-            if let AggDistinctness::Distinct { ctx } = &agg.distinctness {
+            if let Distinctness::Distinct { ctx } = &agg.distinctness {
                 Some(ctx)
             } else {
                 None

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -773,6 +773,11 @@ pub fn group_by_emit_row_phase<'a>(
         labels.label_group_by_end_without_emitting_row,
         program.offset(),
     );
+    // SELECT DISTINCT also jumps here if there is a duplicate.
+    if let Distinctness::Distinct { ctx } = &plan.distinctness {
+        let distinct_agg_ctx = ctx.as_ref().expect("distinct context must exist");
+        program.resolve_label(distinct_agg_ctx.label_on_conflict, program.offset());
+    }
     program.emit_insn(Insn::Return {
         return_reg: registers.reg_subrtn_acc_output_return_offset,
     });

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -775,8 +775,8 @@ pub fn group_by_emit_row_phase<'a>(
     );
     // SELECT DISTINCT also jumps here if there is a duplicate.
     if let Distinctness::Distinct { ctx } = &plan.distinctness {
-        let distinct_agg_ctx = ctx.as_ref().expect("distinct context must exist");
-        program.resolve_label(distinct_agg_ctx.label_on_conflict, program.offset());
+        let distinct_ctx = ctx.as_ref().expect("distinct context must exist");
+        program.resolve_label(distinct_ctx.label_on_conflict, program.offset());
     }
     program.emit_insn(Insn::Return {
         return_reg: registers.reg_subrtn_acc_output_return_offset,

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -86,7 +86,7 @@ pub fn init_distinct(program: &mut ProgramBuilder, plan: &mut SelectPlan) {
                     name: col.expr.to_string(),
                     order: SortOrder::Asc,
                     pos_in_table: i,
-                    collation: None, // FIXME: this should be inferred from the expression
+                    collation: None, // FIXME: this should be determined based on the result column expression!
                 })
                 .collect(),
             unique: false,

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -791,8 +791,8 @@ fn emit_loop_source<'a>(
             )?;
 
             if let Distinctness::Distinct { ctx } = &plan.distinctness {
-                let distinct_agg_ctx = ctx.as_ref().expect("distinct context must exist");
-                program.preassign_label_to_next_insn(distinct_agg_ctx.label_on_conflict);
+                let distinct_ctx = ctx.as_ref().expect("distinct context must exist");
+                program.preassign_label_to_next_insn(distinct_ctx.label_on_conflict);
             }
 
             Ok(())
@@ -887,8 +887,8 @@ fn emit_loop_source<'a>(
             )?;
 
             if let Distinctness::Distinct { ctx } = &plan.distinctness {
-                let distinct_agg_ctx = ctx.as_ref().expect("distinct context must exist");
-                program.preassign_label_to_next_insn(distinct_agg_ctx.label_on_conflict);
+                let distinct_ctx = ctx.as_ref().expect("distinct context must exist");
+                program.preassign_label_to_next_insn(distinct_ctx.label_on_conflict);
             }
 
             Ok(())

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use crate::{
     schema::{Index, IndexColumn, Table},
     translate::{
-        plan::{AggDistinctness, DistinctAggCtx},
+        plan::{DistinctCtx, Distinctness},
         result_row::emit_select_result,
     },
     types::SeekOp,
@@ -116,8 +116,8 @@ pub fn init_loop(
                 is_table: false,
             });
         }
-        agg.distinctness = AggDistinctness::Distinct {
-            ctx: Some(DistinctAggCtx {
+        agg.distinctness = Distinctness::Distinct {
+            ctx: Some(DistinctCtx {
                 cursor_id,
                 ephemeral_index_name: index_name,
                 label_on_conflict: program.allocate_label(),
@@ -763,7 +763,7 @@ fn emit_loop_source<'a>(
                     reg,
                     &t_ctx.resolver,
                 )?;
-                if let AggDistinctness::Distinct { ctx } = &agg.distinctness {
+                if let Distinctness::Distinct { ctx } = &agg.distinctness {
                     let ctx = ctx
                         .as_ref()
                         .expect("distinct aggregate context not populated");

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -252,9 +252,9 @@ pub fn order_by_sorter_insert(
 
     // Handle SELECT DISTINCT deduplication
     if let Distinctness::Distinct { ctx } = &plan.distinctness {
-        let distinct_agg_ctx = ctx.as_ref().expect("distinct context must exist");
+        let distinct_ctx = ctx.as_ref().expect("distinct context must exist");
         let num_regs = order_by_len + translated_result_col_count;
-        distinct_agg_ctx.emit_deduplication_insns(program, num_regs, start_reg);
+        distinct_ctx.emit_deduplication_insns(program, num_regs, start_reg);
     }
 
     let SortMetadata {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1,6 +1,6 @@
 use super::{
     plan::{
-        AggDistinctness, Aggregate, ColumnUsedMask, EvalAt, IterationDirection, JoinInfo,
+        Aggregate, ColumnUsedMask, Distinctness, EvalAt, IterationDirection, JoinInfo,
         JoinOrderMember, Operation, Plan, ResultSetColumn, SelectPlan, SelectQueryType,
         TableReference, WhereTerm,
     },
@@ -41,7 +41,7 @@ pub fn resolve_aggregates(expr: &Expr, aggs: &mut Vec<Aggregate>) -> Result<bool
             };
             match Func::resolve_function(normalize_ident(name.0.as_str()).as_str(), args_count) {
                 Ok(Func::Agg(f)) => {
-                    let distinctness = AggDistinctness::from_ast(distinctness.as_ref());
+                    let distinctness = Distinctness::from_ast(distinctness.as_ref());
                     let num_args = args.as_ref().map_or(0, |args| args.len());
                     if distinctness.is_distinct() && num_args != 1 {
                         crate::bail_parse_error!(
@@ -75,7 +75,7 @@ pub fn resolve_aggregates(expr: &Expr, aggs: &mut Vec<Aggregate>) -> Result<bool
                     func: f,
                     args: vec![],
                     original_expr: expr.clone(),
-                    distinctness: AggDistinctness::NonDistinct,
+                    distinctness: Distinctness::NonDistinct,
                 });
                 Ok(true)
             } else {

--- a/core/translate/result_row.rs
+++ b/core/translate/result_row.rs
@@ -52,9 +52,9 @@ pub fn emit_select_result(
 
     // Handle SELECT DISTINCT deduplication
     if let Distinctness::Distinct { ctx } = &plan.distinctness {
-        let distinct_agg_ctx = ctx.as_ref().expect("distinct context must exist");
+        let distinct_ctx = ctx.as_ref().expect("distinct context must exist");
         let num_regs = plan.result_columns.len();
-        distinct_agg_ctx.emit_deduplication_insns(program, num_regs, start_reg);
+        distinct_ctx.emit_deduplication_insns(program, num_regs, start_reg);
     }
 
     emit_result_row_and_limit(

--- a/testing/subquery.test
+++ b/testing/subquery.test
@@ -411,3 +411,25 @@ do_execsql_test subquery-ignore-unused-cte {
     sub as (select first_name from users where first_name = 'Jamie' limit 1) 
     select * from sub;
 } {Jamie}
+
+# Test verifying that select distinct works (distinct ages are 1-100)
+do_execsql_test subquery-count-distinct-age {
+    select count(1) from (select distinct age from users);
+} {100}
+
+# Test verifying that select distinct works for multiple columns, and across joins
+do_execsql_test subquery-count-distinct {
+    select count(1) from (
+        select distinct first_name, name 
+        from users u join products p 
+        where u.id < 100
+    );
+} {902}
+
+do_execsql_test subquery-count-all {
+    select count(1) from (
+        select first_name, name 
+        from users u join products p 
+        where u.id < 100
+    );
+} {1089}


### PR DESCRIPTION
```sql
# Test verifying that select distinct works (distinct ages are 1-100)
do_execsql_test subquery-count-distinct-age {
    select count(1) from (select distinct age from users);
} {100}

# Test verifying that select distinct works for multiple columns, and across joins
do_execsql_test subquery-count-distinct {
    select count(1) from (
        select distinct first_name, name 
        from users u join products p 
        where u.id < 100
    );
} {902}

do_execsql_test subquery-count-all {
    select count(1) from (
        select first_name, name 
        from users u join products p 
        where u.id < 100
    );
} {1089}
```