### PR TITLE
Improve debug build validation speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,7 @@ dependencies = [
  "rusqlite",
  "rustix 1.0.7",
  "ryu",
+ "sorted-vec",
  "strum",
  "tempfile",
  "test-log",
@@ -3300,6 +3301,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "sorted-vec"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d372029cb5195f9ab4e4b9aef550787dce78b124fcaee8d82519925defcd6f0d"
 
 [[package]]
 name = "sqlparser_bench"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,7 @@ io-uring = { version = "0.7.5", optional = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 polling = "3.7.4"
-rustix = { version = "1.0.5", features = ["fs"]}
+rustix = { version = "1.0.5", features = ["fs"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 mimalloc = { version = "0.1.46", default-features = false }
@@ -99,6 +99,7 @@ rand_chacha = "0.9.0"
 env_logger = "0.11.6"
 test-log = { version = "0.2.17", features = ["trace"] }
 lru = "0.14.0"
+sorted-vec = "0.8.6"
 
 [[bench]]
 name = "benchmark"

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6224,6 +6224,7 @@ mod tests {
         inserts: usize,
         size: impl Fn(&mut ChaCha8Rng) -> usize,
     ) {
+        const VALIDATE_INTERVAL: usize = 1000;
         let do_validate_btree = std::env::var("VALIDATE_BTREE")
             .map_or(false, |v| v.parse().expect("validate should be bool"));
         let (mut rng, seed) = rng_from_time_or_env();
@@ -6235,7 +6236,7 @@ mod tests {
             let mut keys = SortedVec::new();
             tracing::info!("seed: {}", seed);
             for insert_id in 0..inserts {
-                let do_validate = do_validate_btree || (insert_id % 1000 == 0);
+                let do_validate = do_validate_btree || (insert_id % VALIDATE_INTERVAL == 0);
                 let size = size(&mut rng);
                 let key = {
                     let result;
@@ -6268,7 +6269,7 @@ mod tests {
                 .unwrap();
                 let value =
                     ImmutableRecord::from_registers(&[Register::Value(Value::Blob(vec![0; size]))]);
-                let btree_before = if do_validate_btree {
+                let btree_before = if do_validate {
                     format_btree(pager.clone(), root_page, 0)
                 } else {
                     "".to_string()


### PR DESCRIPTION
Various things to improve speed of long fuzz test execution time:
* remove unnecessary debug_validate_cell calls
* Add SortedVec for keys in fuzz tests
* Validate btree's depth in fuzz test every 1K inserts to not overload test with validations. We add `VALIDATE_BTREE`  env variable to enable validation on every insert in case it is needed.