### PR TITLE
remove detection of comments in the middle of query in cli

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -537,13 +537,6 @@ impl Limbo {
             }
             return Ok(());
         }
-
-        if let Some(comment_pos) = line.find("--") {
-            let before_comment = line[..comment_pos].trim();
-            if !before_comment.is_empty() {
-                return self.handle_input_line(before_comment);
-            }
-        }
         if line.ends_with(';') {
             self.buffer_input(line);
             let buff = self.input_buff.clone();


### PR DESCRIPTION
I was trying to run the TPC-H 9.sql in the CLI, but it kept truncating my input due to a comment that is present in the query. After removing it, I can just copy and paste the query and it works. @PThorpe92 is it safe to remove this? Or is there a particular reason that was included that I am not aware of?