### PR TITLE
bindings/rust: Add pragma methods

### DIFF
--- a/bindings/rust/examples/example.rs
+++ b/bindings/rust/examples/example.rs
@@ -12,8 +12,8 @@ async fn main() {
         .await
         .unwrap();
 
-    conn.pragma_query("journal_mode", |&mut row| {
-        println!("{:?}", row);
+    conn.pragma_query("journal_mode", |row| {
+        println!("{}", row.get_value(0));
         Ok(())
     })
     .unwrap();

--- a/bindings/rust/examples/example.rs
+++ b/bindings/rust/examples/example.rs
@@ -12,6 +12,12 @@ async fn main() {
         .await
         .unwrap();
 
+    conn.pragma_query("journal_mode", |&mut row| {
+        println!("{:?}", row);
+        Ok(())
+    })
+    .unwrap();
+
     let mut stmt = conn
         .prepare("INSERT INTO users (email) VALUES (?1)")
         .await

--- a/bindings/rust/examples/example.rs
+++ b/bindings/rust/examples/example.rs
@@ -13,7 +13,7 @@ async fn main() {
         .unwrap();
 
     conn.pragma_query("journal_mode", |row| {
-        println!("{}", row.get_value(0));
+        println!("{:?}", row.get_value(0));
         Ok(())
     })
     .unwrap();

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -124,17 +124,28 @@ impl Connection {
         Ok(statement)
     }
 
-    pub fn pragma_query<F>(&self, pragma_name: &str, f: F) -> Result<()>
+    pub fn pragma_query<F>(&self, pragma_name: &str, mut f: F) -> Result<()>
     where
-        F: FnMut(&limbo_core::Row) -> limbo_core::Result<()>,
+        F: FnMut(&Row) -> limbo_core::Result<()>,
     {
         let conn = self
             .inner
             .lock()
             .map_err(|e| Error::MutexError(e.to_string()))?;
 
-        conn.pragma_query(pragma_name, f)
-            .map_err(|e| Error::SqlExecutionFailure(e.to_string()))
+        let rows: Vec<Row> = conn
+            .pragma_query(pragma_name)
+            .map_err(|e| Error::SqlExecutionFailure(e.to_string()))?
+            .iter()
+            .map(|row| row.iter().collect::<Row>())
+            .collect();
+
+        rows.iter().try_for_each(|row| {
+            f(row).map_err(|e| {
+                Error::SqlExecutionFailure(format!("Error executing user defined function: {}", e))
+            })
+        })?;
+        Ok(())
     }
 }
 
@@ -318,5 +329,22 @@ impl Row {
 
     pub fn column_count(&self) -> usize {
         self.values.len()
+    }
+}
+
+impl<'a> FromIterator<&'a limbo_core::Value> for Row {
+    fn from_iter<T: IntoIterator<Item = &'a limbo_core::Value>>(iter: T) -> Self {
+        let values = iter
+            .into_iter()
+            .map(|v| match v {
+                limbo_core::Value::Integer(i) => limbo_core::Value::Integer(*i),
+                limbo_core::Value::Null => limbo_core::Value::Null,
+                limbo_core::Value::Float(f) => limbo_core::Value::Float(*f),
+                limbo_core::Value::Text(s) => limbo_core::Value::Text(s.clone()),
+                limbo_core::Value::Blob(b) => limbo_core::Value::Blob(b.clone()),
+            })
+            .collect();
+
+        Row { values }
     }
 }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -124,9 +124,9 @@ impl Connection {
         Ok(statement)
     }
 
-    pub fn pragma_query<F>(&self, pragma_name: &str, mut f: F) -> Result<()>
+    pub fn pragma_query<F>(&self, pragma_name: &str, f: F) -> Result<()>
     where
-        F: FnMut(&) -> Result<()>,
+        F: FnMut(&limbo_core::Row) -> limbo_core::Result<()>,
     {
         let conn = self
             .inner

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -123,6 +123,19 @@ impl Connection {
         };
         Ok(statement)
     }
+
+    pub fn pragma_query<F>(&self, pragma_name: &str, mut f: F) -> Result<()>
+    where
+        F: FnMut(&) -> Result<()>,
+    {
+        let conn = self
+            .inner
+            .lock()
+            .map_err(|e| Error::MutexError(e.to_string()))?;
+
+        conn.pragma_query(pragma_name, f)
+            .map_err(|e| Error::SqlExecutionFailure(e.to_string()))
+    }
 }
 
 pub struct Statement {

--- a/core/error.rs
+++ b/core/error.rs
@@ -53,6 +53,8 @@ pub enum LimboError {
     SchemaLocked,
     #[error("Database Connection is read-only")]
     ReadOnly,
+    #[error("Database is busy")]
+    Busy,
 }
 
 #[macro_export]


### PR DESCRIPTION
I tried to be the most similar to rusqlite as possible. The only thing that's bothering me is `Vec<Vec<Value>>` which I think can be improved but not so sure how, any inputs on this are welcomed.