### PR TITLE
Initial Support for Nested Translation

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -932,7 +932,7 @@ impl VirtualTable {
     }
 }
 
-pub(crate) struct SymbolTable {
+pub struct SymbolTable {
     pub functions: HashMap<String, Rc<function::ExternalFunc>>,
     pub vtabs: HashMap<String, Rc<VirtualTable>>,
     pub vtab_modules: HashMap<String, Rc<crate::ext::VTabImpl>>,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -355,6 +355,7 @@ impl Connection {
                     Rc::downgrade(self),
                     &syms,
                     QueryMode::Normal,
+                    None,
                 )?);
                 Ok(Statement::new(
                     program,
@@ -393,6 +394,7 @@ impl Connection {
                     Rc::downgrade(self),
                     &syms,
                     cmd.into(),
+                    None,
                 )?;
                 let stmt = Statement::new(
                     program.into(),
@@ -454,6 +456,7 @@ impl Connection {
                         Rc::downgrade(self),
                         &syms,
                         QueryMode::Explain,
+                        None,
                     )?;
                     let _ = std::io::stdout().write_all(program.explain().as_bytes());
                 }
@@ -470,6 +473,7 @@ impl Connection {
                         Rc::downgrade(self),
                         &syms,
                         QueryMode::Normal,
+                        None,
                     )?;
 
                     let mut state =

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -355,7 +355,6 @@ impl Connection {
                     Rc::downgrade(self),
                     &syms,
                     QueryMode::Normal,
-                    None,
                 )?);
                 Ok(Statement::new(
                     program,
@@ -394,7 +393,6 @@ impl Connection {
                     Rc::downgrade(self),
                     &syms,
                     cmd.into(),
-                    None,
                 )?;
                 let stmt = Statement::new(
                     program.into(),
@@ -456,7 +454,6 @@ impl Connection {
                         Rc::downgrade(self),
                         &syms,
                         QueryMode::Explain,
-                        None,
                     )?;
                     let _ = std::io::stdout().write_all(program.explain().as_bytes());
                 }
@@ -473,7 +470,6 @@ impl Connection {
                         Rc::downgrade(self),
                         &syms,
                         QueryMode::Normal,
-                        None,
                     )?;
 
                     let mut state =

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -16,7 +16,7 @@ pub fn translate_delete(
     where_clause: Option<Box<Expr>>,
     limit: Option<Box<Limit>>,
     syms: &SymbolTable,
-    program: Option<ProgramBuilder>,
+    mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     let mut delete_plan = prepare_delete_plan(schema, tbl_name, where_clause, limit)?;
     optimize_plan(&mut delete_plan, schema)?;
@@ -29,12 +29,7 @@ pub fn translate_delete(
         approx_num_insns: estimate_num_instructions(delete),
         approx_num_labels: 0,
     };
-    let mut program = if let Some(mut program) = program {
-        program.extend(&opts);
-        program
-    } else {
-        ProgramBuilder::new(opts)
-    };
+    program.extend(&opts);
     emit_program(&mut program, delete_plan, syms)?;
     Ok(program)
 }

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -158,8 +158,6 @@ fn emit_program_for_select(
     mut plan: SelectPlan,
     syms: &SymbolTable,
 ) -> Result<()> {
-    let (init_label, start_offset) = program.prologue();
-
     let mut t_ctx = TranslateCtx::new(
         program,
         syms,
@@ -170,7 +168,7 @@ fn emit_program_for_select(
     // Trivial exit on LIMIT 0
     if let Some(limit) = plan.limit {
         if limit == 0 {
-            program.epilogue(init_label, start_offset, TransactionMode::Read);
+            program.epilogue(TransactionMode::Read);
             program.result_columns = plan.result_columns;
             program.table_references = plan.table_references;
             return Ok(());
@@ -181,9 +179,9 @@ fn emit_program_for_select(
 
     // Finalize program
     if plan.table_references.is_empty() {
-        program.epilogue(init_label, start_offset, TransactionMode::None);
+        program.epilogue(TransactionMode::None);
     } else {
-        program.epilogue(init_label, start_offset, TransactionMode::Read);
+        program.epilogue(TransactionMode::Read);
     }
 
     program.result_columns = plan.result_columns;
@@ -331,8 +329,6 @@ fn emit_program_for_delete(
     mut plan: DeletePlan,
     syms: &SymbolTable,
 ) -> Result<()> {
-    let (init_label, start_offset) = program.prologue();
-
     let mut t_ctx = TranslateCtx::new(
         program,
         syms,
@@ -342,7 +338,7 @@ fn emit_program_for_delete(
 
     // exit early if LIMIT 0
     if let Some(0) = plan.limit {
-        program.epilogue(init_label, start_offset, TransactionMode::Write);
+        program.epilogue(TransactionMode::Write);
         program.result_columns = plan.result_columns;
         program.table_references = plan.table_references;
         return Ok(());
@@ -393,7 +389,7 @@ fn emit_program_for_delete(
     program.preassign_label_to_next_insn(after_main_loop_label);
 
     // Finalize program
-    program.epilogue(init_label, start_offset, TransactionMode::Write);
+    program.epilogue(TransactionMode::Write);
     program.result_columns = plan.result_columns;
     program.table_references = plan.table_references;
     Ok(())
@@ -504,8 +500,6 @@ fn emit_program_for_update(
     mut plan: UpdatePlan,
     syms: &SymbolTable,
 ) -> Result<()> {
-    let (init_label, start_offset) = program.prologue();
-
     let mut t_ctx = TranslateCtx::new(
         program,
         syms,
@@ -515,7 +509,7 @@ fn emit_program_for_update(
 
     // Exit on LIMIT 0
     if let Some(0) = plan.limit {
-        program.epilogue(init_label, start_offset, TransactionMode::None);
+        program.epilogue(TransactionMode::None);
         program.result_columns = plan.returning.unwrap_or_default();
         program.table_references = plan.table_references;
         return Ok(());
@@ -607,7 +601,7 @@ fn emit_program_for_update(
     program.preassign_label_to_next_insn(after_main_loop_label);
 
     // Finalize program
-    program.epilogue(init_label, start_offset, TransactionMode::Write);
+    program.epilogue(TransactionMode::Write);
     program.result_columns = plan.returning.unwrap_or_default();
     program.table_references = plan.table_references;
     Ok(())

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -110,75 +110,11 @@ pub enum OperationMode {
     DELETE,
 }
 
-/// Initialize the program with basic setup and return initial metadata and labels
-fn prologue<'a>(
-    program: &mut ProgramBuilder,
-    syms: &'a SymbolTable,
-    table_count: usize,
-    result_column_count: usize,
-) -> Result<(TranslateCtx<'a>, BranchOffset, BranchOffset)> {
-    let init_label = program.allocate_label();
-
-    program.emit_insn(Insn::Init {
-        target_pc: init_label,
-    });
-
-    let start_offset = program.offset();
-
-    let t_ctx = TranslateCtx {
-        labels_main_loop: (0..table_count).map(|_| LoopLabels::new(program)).collect(),
-        label_main_loop_end: None,
-        reg_agg_start: None,
-        reg_nonagg_emit_once_flag: None,
-        reg_limit: None,
-        reg_offset: None,
-        reg_limit_offset_sum: None,
-        reg_result_cols_start: None,
-        meta_group_by: None,
-        meta_left_joins: (0..table_count).map(|_| None).collect(),
-        meta_sort: None,
-        result_column_indexes_in_orderby_sorter: (0..result_column_count).collect(),
-        result_columns_to_skip_in_orderby_sorter: None,
-        resolver: Resolver::new(syms),
-    };
-
-    Ok((t_ctx, init_label, start_offset))
-}
-
 #[derive(Clone, Copy, Debug)]
 pub enum TransactionMode {
     None,
     Read,
     Write,
-}
-
-/// Clean up and finalize the program, resolving any remaining labels
-/// Note that although these are the final instructions, typically an SQLite
-/// query will jump to the Transaction instruction via init_label.
-fn epilogue(
-    program: &mut ProgramBuilder,
-    init_label: BranchOffset,
-    start_offset: BranchOffset,
-    txn_mode: TransactionMode,
-) -> Result<()> {
-    program.emit_insn(Insn::Halt {
-        err_code: 0,
-        description: String::new(),
-    });
-    program.preassign_label_to_next_insn(init_label);
-
-    match txn_mode {
-        TransactionMode::Read => program.emit_insn(Insn::Transaction { write: false }),
-        TransactionMode::Write => program.emit_insn(Insn::Transaction { write: true }),
-        TransactionMode::None => {}
-    }
-
-    program.emit_constant_insns();
-    program.emit_insn(Insn::Goto {
-        target_pc: start_offset,
-    });
-
-    Ok(())
 }
 
 /// Main entry point for emitting bytecode for a SQL query
@@ -196,17 +132,13 @@ fn emit_program_for_select(
     mut plan: SelectPlan,
     syms: &SymbolTable,
 ) -> Result<()> {
-    let (mut t_ctx, init_label, start_offset) = prologue(
-        program,
-        syms,
-        plan.table_references.len(),
-        plan.result_columns.len(),
-    )?;
+    let (mut t_ctx, init_label, start_offset) =
+        program.prologue(syms, plan.table_references.len(), plan.result_columns.len());
 
     // Trivial exit on LIMIT 0
     if let Some(limit) = plan.limit {
         if limit == 0 {
-            epilogue(program, init_label, start_offset, TransactionMode::Read)?;
+            program.epilogue(init_label, start_offset, TransactionMode::Read);
             program.result_columns = plan.result_columns;
             program.table_references = plan.table_references;
             return Ok(());
@@ -217,9 +149,9 @@ fn emit_program_for_select(
 
     // Finalize program
     if plan.table_references.is_empty() {
-        epilogue(program, init_label, start_offset, TransactionMode::None)?;
+        program.epilogue(init_label, start_offset, TransactionMode::None);
     } else {
-        epilogue(program, init_label, start_offset, TransactionMode::Read)?;
+        program.epilogue(init_label, start_offset, TransactionMode::Read);
     }
 
     program.result_columns = plan.result_columns;
@@ -367,16 +299,12 @@ fn emit_program_for_delete(
     mut plan: DeletePlan,
     syms: &SymbolTable,
 ) -> Result<()> {
-    let (mut t_ctx, init_label, start_offset) = prologue(
-        program,
-        syms,
-        plan.table_references.len(),
-        plan.result_columns.len(),
-    )?;
+    let (mut t_ctx, init_label, start_offset) =
+        program.prologue(syms, plan.table_references.len(), plan.result_columns.len());
 
     // exit early if LIMIT 0
     if let Some(0) = plan.limit {
-        epilogue(program, init_label, start_offset, TransactionMode::Write)?;
+        program.epilogue(init_label, start_offset, TransactionMode::Write);
         program.result_columns = plan.result_columns;
         program.table_references = plan.table_references;
         return Ok(());
@@ -427,7 +355,7 @@ fn emit_program_for_delete(
     program.preassign_label_to_next_insn(after_main_loop_label);
 
     // Finalize program
-    epilogue(program, init_label, start_offset, TransactionMode::Write)?;
+    program.epilogue(init_label, start_offset, TransactionMode::Write);
     program.result_columns = plan.result_columns;
     program.table_references = plan.table_references;
     Ok(())
@@ -538,16 +466,15 @@ fn emit_program_for_update(
     mut plan: UpdatePlan,
     syms: &SymbolTable,
 ) -> Result<()> {
-    let (mut t_ctx, init_label, start_offset) = prologue(
-        program,
+    let (mut t_ctx, init_label, start_offset) = program.prologue(
         syms,
         plan.table_references.len(),
         plan.returning.as_ref().map_or(0, |r| r.len()),
-    )?;
+    );
 
     // Exit on LIMIT 0
     if let Some(0) = plan.limit {
-        epilogue(program, init_label, start_offset, TransactionMode::None)?;
+        program.epilogue(init_label, start_offset, TransactionMode::None);
         program.result_columns = plan.returning.unwrap_or_default();
         program.table_references = plan.table_references;
         return Ok(());
@@ -639,7 +566,7 @@ fn emit_program_for_update(
     program.preassign_label_to_next_insn(after_main_loop_label);
 
     // Finalize program
-    epilogue(program, init_label, start_offset, TransactionMode::Write)?;
+    program.epilogue(init_label, start_offset, TransactionMode::Write);
     program.result_columns = plan.returning.unwrap_or_default();
     program.table_references = plan.table_references;
     Ok(())

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -21,15 +21,22 @@ pub fn translate_create_index(
     tbl_name: &str,
     columns: &[SortedColumn],
     schema: &Schema,
+    program: Option<ProgramBuilder>,
 ) -> crate::Result<ProgramBuilder> {
     let idx_name = normalize_ident(idx_name);
     let tbl_name = normalize_ident(tbl_name);
-    let mut program = ProgramBuilder::new(crate::vdbe::builder::ProgramBuilderOpts {
+    let opts = crate::vdbe::builder::ProgramBuilderOpts {
         query_mode: mode,
         num_cursors: 5,
         approx_num_insns: 40,
         approx_num_labels: 5,
-    });
+    };
+    let mut program = if let Some(mut program) = program {
+        program.extend(&opts);
+        program
+    } else {
+        ProgramBuilder::new(opts)
+    };
 
     // Check if the index is being created on a valid btree table and
     // the name is globally unique in the schema.
@@ -311,14 +318,21 @@ pub fn translate_drop_index(
     idx_name: &str,
     if_exists: bool,
     schema: &Schema,
+    program: Option<ProgramBuilder>,
 ) -> crate::Result<ProgramBuilder> {
     let idx_name = normalize_ident(idx_name);
-    let mut program = ProgramBuilder::new(crate::vdbe::builder::ProgramBuilderOpts {
+    let opts = crate::vdbe::builder::ProgramBuilderOpts {
         query_mode: mode,
         num_cursors: 5,
         approx_num_insns: 40,
         approx_num_labels: 5,
-    });
+    };
+    let mut program = if let Some(mut program) = program {
+        program.extend(&opts);
+        program
+    } else {
+        ProgramBuilder::new(opts)
+    };
 
     // Find the index in Schema
     let mut maybe_index = None;

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -60,7 +60,6 @@ pub fn translate_insert(
         Some(table) => table,
         None => crate::bail_corrupt_error!("Parse error: no such table: {}", table_name),
     };
-    let (init_label, start_offset) = program.prologue();
 
     let resolver = Resolver::new(syms);
 
@@ -73,11 +72,7 @@ pub fn translate_insert(
             on_conflict,
             &resolver,
         )?;
-        program.epilogue(
-            init_label,
-            start_offset,
-            super::emitter::TransactionMode::Write,
-        );
+        program.epilogue(super::emitter::TransactionMode::Write);
         return Ok(program);
     }
 
@@ -417,11 +412,7 @@ pub fn translate_insert(
     }
 
     program.resolve_label(halt_label, program.offset());
-    program.epilogue(
-        init_label,
-        start_offset,
-        super::emitter::TransactionMode::Write,
-    );
+    program.epilogue(super::emitter::TransactionMode::Write);
 
     Ok(program)
 }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -34,7 +34,7 @@ pub fn translate_insert(
     body: &mut InsertBody,
     _returning: &Option<Vec<ResultColumn>>,
     syms: &SymbolTable,
-    program: Option<ProgramBuilder>,
+    mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     let opts = ProgramBuilderOpts {
         query_mode,
@@ -42,12 +42,7 @@ pub fn translate_insert(
         approx_num_insns: 30,
         approx_num_labels: 5,
     };
-    let mut program = if let Some(mut program) = program {
-        program.extend(&opts);
-        program
-    } else {
-        ProgramBuilder::new(opts)
-    };
+    program.extend(&opts);
     if with.is_some() {
         crate::bail_parse_error!("WITH clause is not supported");
     }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -34,13 +34,20 @@ pub fn translate_insert(
     body: &mut InsertBody,
     _returning: &Option<Vec<ResultColumn>>,
     syms: &SymbolTable,
+    program: Option<ProgramBuilder>,
 ) -> Result<ProgramBuilder> {
-    let mut program = ProgramBuilder::new(ProgramBuilderOpts {
+    let opts = ProgramBuilderOpts {
         query_mode,
         num_cursors: 1,
         approx_num_insns: 30,
         approx_num_labels: 5,
-    });
+    };
+    let mut program = if let Some(mut program) = program {
+        program.extend(&opts);
+        program
+    } else {
+        ProgramBuilder::new(opts)
+    };
     if with.is_some() {
         crate::bail_parse_error!("WITH clause is not supported");
     }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -84,9 +84,9 @@ pub fn translate(
             body.map(|b| *b),
             database_header.clone(),
             pager,
-            Some(program),
+            program,
         )?,
-        stmt => translate_inner(schema, stmt, syms, query_mode, Some(program))?,
+        stmt => translate_inner(schema, stmt, syms, query_mode, program)?,
     };
 
     // TODO: bring epilogue here when I can sort out what instructions correspond to a Write or a Read transaction
@@ -102,7 +102,7 @@ pub fn translate_inner(
     stmt: ast::Stmt,
     syms: &SymbolTable,
     query_mode: QueryMode,
-    program: Option<ProgramBuilder>,
+    program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     let program = match stmt {
         ast::Stmt::AlterTable(a) => {
@@ -159,8 +159,8 @@ pub fn translate_inner(
         }
         ast::Stmt::Analyze(_) => bail_parse_error!("ANALYZE not supported yet"),
         ast::Stmt::Attach { .. } => bail_parse_error!("ATTACH not supported yet"),
-        ast::Stmt::Begin(tx_type, tx_name) => translate_tx_begin(tx_type, tx_name)?,
-        ast::Stmt::Commit(tx_name) => translate_tx_commit(tx_name)?,
+        ast::Stmt::Begin(tx_type, tx_name) => translate_tx_begin(tx_type, tx_name, program)?,
+        ast::Stmt::Commit(tx_name) => translate_tx_commit(tx_name, program)?,
         ast::Stmt::CreateIndex {
             unique,
             if_not_exists,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -41,13 +41,20 @@ pub fn translate_pragma(
     body: Option<ast::PragmaBody>,
     database_header: Arc<SpinLock<DatabaseHeader>>,
     pager: Rc<Pager>,
+    program: Option<ProgramBuilder>,
 ) -> crate::Result<ProgramBuilder> {
-    let mut program = ProgramBuilder::new(ProgramBuilderOpts {
+    let opts = ProgramBuilderOpts {
         query_mode,
         num_cursors: 0,
         approx_num_insns: 20,
         approx_num_labels: 0,
-    });
+    };
+    let mut program = if let Some(mut program) = program {
+        program.extend(&opts);
+        program
+    } else {
+        ProgramBuilder::new(opts)
+    };
     let init_label = program.emit_init();
     let start_offset = program.offset();
     let mut write = false;

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -13,25 +13,17 @@ use crate::storage::wal::CheckpointMode;
 use crate::util::normalize_ident;
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts, QueryMode};
 use crate::vdbe::insn::{Cookie, Insn};
-use crate::vdbe::BranchOffset;
 use crate::{bail_parse_error, Pager};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
-fn list_pragmas(
-    program: &mut ProgramBuilder,
-    init_label: BranchOffset,
-    start_offset: BranchOffset,
-) {
+fn list_pragmas(program: &mut ProgramBuilder) {
     for x in PragmaName::iter() {
         let register = program.emit_string8_new_reg(x.to_string());
         program.emit_result_row(register, 1);
     }
 
-    program.emit_halt();
-    program.preassign_label_to_next_insn(init_label);
-    program.emit_constant_insns();
-    program.emit_goto(start_offset);
+    program.epilogue(crate::translate::emitter::TransactionMode::None);
 }
 
 pub fn translate_pragma(
@@ -41,7 +33,7 @@ pub fn translate_pragma(
     body: Option<ast::PragmaBody>,
     database_header: Arc<SpinLock<DatabaseHeader>>,
     pager: Rc<Pager>,
-    program: Option<ProgramBuilder>,
+    mut program: ProgramBuilder,
 ) -> crate::Result<ProgramBuilder> {
     let opts = ProgramBuilderOpts {
         query_mode,
@@ -49,18 +41,11 @@ pub fn translate_pragma(
         approx_num_insns: 20,
         approx_num_labels: 0,
     };
-    let mut program = if let Some(mut program) = program {
-        program.extend(&opts);
-        program
-    } else {
-        ProgramBuilder::new(opts)
-    };
-    let init_label = program.emit_init();
-    let start_offset = program.offset();
+    program.extend(&opts);
     let mut write = false;
 
     if name.name.0.to_lowercase() == "pragma_list" {
-        list_pragmas(&mut program, init_label, start_offset);
+        list_pragmas(&mut program);
         return Ok(program);
     }
 
@@ -110,11 +95,10 @@ pub fn translate_pragma(
             }
         },
     };
-    program.emit_halt();
-    program.preassign_label_to_next_insn(init_label);
-    program.emit_transaction(write);
-    program.emit_constant_insns();
-    program.emit_goto(start_offset);
+    program.epilogue(match write {
+        false => super::emitter::TransactionMode::Read,
+        true => super::emitter::TransactionMode::Write,
+    });
 
     Ok(program)
 }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -24,6 +24,7 @@ pub fn translate_select(
     schema: &Schema,
     select: ast::Select,
     syms: &SymbolTable,
+    program: Option<ProgramBuilder>,
 ) -> Result<ProgramBuilder> {
     let mut select_plan = prepare_select_plan(schema, select, syms, None)?;
     optimize_plan(&mut select_plan, schema)?;
@@ -31,12 +32,18 @@ pub fn translate_select(
         panic!("select_plan is not a SelectPlan");
     };
 
-    let mut program = ProgramBuilder::new(ProgramBuilderOpts {
+    let opts = ProgramBuilderOpts {
         query_mode,
         num_cursors: count_plan_required_cursors(select),
         approx_num_insns: estimate_num_instructions(select),
         approx_num_labels: estimate_num_labels(select),
-    });
+    };
+    let mut program = if let Some(mut program) = program {
+        program.extend(&opts);
+        program
+    } else {
+        ProgramBuilder::new(opts)
+    };
     emit_program(&mut program, select_plan, syms)?;
     Ok(program)
 }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -24,7 +24,7 @@ pub fn translate_select(
     schema: &Schema,
     select: ast::Select,
     syms: &SymbolTable,
-    program: Option<ProgramBuilder>,
+    mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     let mut select_plan = prepare_select_plan(schema, select, syms, None)?;
     optimize_plan(&mut select_plan, schema)?;
@@ -38,12 +38,7 @@ pub fn translate_select(
         approx_num_insns: estimate_num_instructions(select),
         approx_num_labels: estimate_num_labels(select),
     };
-    let mut program = if let Some(mut program) = program {
-        program.extend(&opts);
-        program
-    } else {
-        ProgramBuilder::new(opts)
-    };
+    program.extend(&opts);
     emit_program(&mut program, select_plan, syms)?;
     Ok(program)
 }

--- a/core/translate/transaction.rs
+++ b/core/translate/transaction.rs
@@ -6,15 +6,14 @@ use limbo_sqlite3_parser::ast::{Name, TransactionType};
 pub fn translate_tx_begin(
     tx_type: Option<TransactionType>,
     _tx_name: Option<Name>,
+    mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
-    let mut program = ProgramBuilder::new(ProgramBuilderOpts {
+    program.extend(&ProgramBuilderOpts {
         query_mode: QueryMode::Normal,
         num_cursors: 0,
         approx_num_insns: 0,
         approx_num_labels: 0,
     });
-    let init_label = program.emit_init();
-    let start_offset = program.offset();
     let tx_type = tx_type.unwrap_or(TransactionType::Deferred);
     match tx_type {
         TransactionType::Deferred => {
@@ -32,27 +31,24 @@ pub fn translate_tx_begin(
             });
         }
     }
-    program.emit_halt();
-    program.preassign_label_to_next_insn(init_label);
-    program.emit_goto(start_offset);
+    program.epilogue(super::emitter::TransactionMode::None);
     Ok(program)
 }
 
-pub fn translate_tx_commit(_tx_name: Option<Name>) -> Result<ProgramBuilder> {
-    let mut program = ProgramBuilder::new(ProgramBuilderOpts {
+pub fn translate_tx_commit(
+    _tx_name: Option<Name>,
+    mut program: ProgramBuilder,
+) -> Result<ProgramBuilder> {
+    program.extend(&ProgramBuilderOpts {
         query_mode: QueryMode::Normal,
         num_cursors: 0,
         approx_num_insns: 0,
         approx_num_labels: 0,
     });
-    let init_label = program.emit_init();
-    let start_offset = program.offset();
     program.emit_insn(Insn::AutoCommit {
         auto_commit: true,
         rollback: false,
     });
-    program.emit_halt();
-    program.preassign_label_to_next_insn(init_label);
-    program.emit_goto(start_offset);
+    program.epilogue(super::emitter::TransactionMode::None);
     Ok(program)
 }

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -52,16 +52,23 @@ pub fn translate_update(
     body: &mut Update,
     syms: &SymbolTable,
     parse_schema: ParseSchema,
+    program: Option<ProgramBuilder>,
 ) -> crate::Result<ProgramBuilder> {
     let mut plan = prepare_update_plan(schema, body, parse_schema)?;
     optimize_plan(&mut plan, schema)?;
     // TODO: freestyling these numbers
-    let mut program = ProgramBuilder::new(ProgramBuilderOpts {
+    let opts = ProgramBuilderOpts {
         query_mode,
         num_cursors: 1,
         approx_num_insns: 20,
         approx_num_labels: 4,
-    });
+    };
+    let mut program = if let Some(mut program) = program {
+        program.extend(&opts);
+        program
+    } else {
+        ProgramBuilder::new(opts)
+    };
     emit_program(&mut program, plan, syms)?;
     Ok(program)
 }

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -52,7 +52,7 @@ pub fn translate_update(
     body: &mut Update,
     syms: &SymbolTable,
     parse_schema: ParseSchema,
-    program: Option<ProgramBuilder>,
+    mut program: ProgramBuilder,
 ) -> crate::Result<ProgramBuilder> {
     let mut plan = prepare_update_plan(schema, body, parse_schema)?;
     optimize_plan(&mut plan, schema)?;
@@ -63,12 +63,7 @@ pub fn translate_update(
         approx_num_insns: 20,
         approx_num_labels: 4,
     };
-    let mut program = if let Some(mut program) = program {
-        program.extend(&opts);
-        program
-    } else {
-        ProgramBuilder::new(opts)
-    };
+    program.extend(&opts);
     emit_program(&mut program, plan, syms)?;
     Ok(program)
 }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -104,6 +104,13 @@ impl ProgramBuilder {
         }
     }
 
+    pub fn extend(&mut self, opts: &ProgramBuilderOpts) {
+        self.insns.reserve(opts.approx_num_insns);
+        self.cursor_ref.reserve(opts.num_cursors);
+        self.label_to_resolved_offset
+            .reserve(opts.approx_num_labels);
+    }
+
     /// Start a new constant span. The next instruction to be emitted will be the first
     /// instruction in the span.
     pub fn constant_span_start(&mut self) -> usize {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -234,7 +234,7 @@ impl ProgramBuilder {
         self.emit_insn(Insn::ResultRow { start_reg, count });
     }
 
-    pub fn emit_halt(&mut self) {
+    fn emit_halt(&mut self) {
         self.emit_insn(Insn::Halt {
             err_code: 0,
             description: String::new(),
@@ -250,20 +250,6 @@ impl ProgramBuilder {
             err_code,
             description,
         });
-    }
-
-    pub fn emit_init(&mut self) -> BranchOffset {
-        let target_pc = self.allocate_label();
-        self.emit_insn(Insn::Init { target_pc });
-        target_pc
-    }
-
-    pub fn emit_transaction(&mut self, write: bool) {
-        self.emit_insn(Insn::Transaction { write });
-    }
-
-    pub fn emit_goto(&mut self, target_pc: BranchOffset) {
-        self.emit_insn(Insn::Goto { target_pc });
     }
 
     pub fn add_comment(&mut self, insn_index: BranchOffset, comment: &'static str) {
@@ -282,7 +268,7 @@ impl ProgramBuilder {
         self.constant_spans.push((prev, prev));
     }
 
-    pub fn emit_constant_insns(&mut self) {
+    fn emit_constant_insns(&mut self) {
         // move compile-time constant instructions to the end of the program, where they are executed once after Init jumps to it.
         // any label_to_resolved_offset that points to an instruction within any moved constant span should be updated to point to the new location.
 
@@ -661,10 +647,7 @@ impl ProgramBuilder {
     /// query will jump to the Transaction instruction via init_label.
     pub fn epilogue(&mut self, txn_mode: TransactionMode) {
         if self.nested_level == 0 {
-            self.emit_insn(Insn::Halt {
-                err_code: 0,
-                description: String::new(),
-            });
+            self.emit_halt();
             self.preassign_label_to_next_insn(self.init_label);
 
             match txn_mode {


### PR DESCRIPTION
This PR introduces some modifications to the Program Builder to allow us to use nested parsing. By focusing the emission of Init and the last Goto (prologue and epilogue), inside the ProgramBuilder, we can just not emit them if we are parsing/translating in a nested context. For this PR, I only migrated insert to use these functions as I need them to support Insert statements that use `SELECT FROM` syntax. Nested parsing overall enables code reuse for us and arguably is one of the only ways to parse deeply nested queries without a lot of code duplication. 

#1528 