### PR TITLE
sqlite3-parser: Remove scanner trace-logging

### DIFF
--- a/vendored/sqlite3-parser/src/lexer/scan.rs
+++ b/vendored/sqlite3-parser/src/lexer/scan.rs
@@ -1,7 +1,5 @@
 //! Adaptation/port of [Go scanner](http://tip.golang.org/pkg/bufio/#Scanner).
 
-use log::trace;
-
 use std::error::Error;
 use std::fmt;
 use std::io;
@@ -118,7 +116,6 @@ impl<S: Splitter> Scanner<S> {
         &mut self,
         input: &'input [u8],
     ) -> ScanResult<'input, S::TokenType, S::Error> {
-        trace!(target: "scanner", "scan(line: {}, column: {})", self.line, self.column);
         // Loop until we have a token.
         loop {
             // See if we can get a token with what we already have.
@@ -152,7 +149,6 @@ impl<S: Splitter> Scanner<S> {
 
     /// Consume `amt` bytes of the buffer.
     fn consume(&mut self, data: &[u8], amt: usize) {
-        trace!(target: "scanner", "consume({})", amt);
         debug_assert!(amt <= data.len());
         for byte in &data[..amt] {
             if *byte == b'\n' {


### PR DESCRIPTION
It spams the logs like no tomorrow, and is mostly useless.