### PR TITLE
fix bindings/wasm wal file creation by implementing `generate_random_number`

### DIFF
--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -288,18 +288,14 @@ impl limbo_core::IO for PlatformIO {
     }
 
     fn generate_random_number(&self) -> i64 {
-        let random_f64 = Math_random();
-        (random_f64 * i64::MAX as f64) as i64
+        let mut buf = [0u8; 8];
+        getrandom::getrandom(&mut buf).unwrap();
+        i64::from_ne_bytes(buf)
     }
 
     fn get_memory_io(&self) -> Arc<limbo_core::MemoryIO> {
         Arc::new(limbo_core::MemoryIO::new())
     }
-}
-
-#[wasm_bindgen]
-extern "C" {
-    fn Math_random() -> f64;
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
In binding/wasm `generate_random_number`'s implementation depends on an external function `Math_random` which does not exist

A related error can be observed when viewing `limbo-opfs-test.html` without an existing database. (Note: it will execute successfully if the wal file already exists, so you may wish view the html in a private/incognito session to ensure an existing file from a previous run is not used)
![Screenshot 2025-05-22 at 22 48 52](https://github.com/user-attachments/assets/e315ae74-29d5-4bdd-84b2-4a9de2b4675a)

This error occurs upon wal file creation as it uses `generate_random_number` for `salt_1` and `slat_2` in the header
https://github.com/tursodatabase/limbo/blob/main/core/storage/wal.rs#L764-L773) 


This PR uses the same implementation as other platforms

`core/io/unix.rs`
https://github.com/tursodatabase/limbo/blob/main/core/io/unix.rs#L259-L263

`core/io/windows.rs`
https://github.com/tursodatabase/limbo/blob/main/core/io/windows.rs#L40-L44

The library `getrandom` [supports wasm](https://github.com/rust-random/getrandom?tab=readme-ov-file#webassembly-support) and uses [Crypto.getRandomValues](https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues) for the implementation in wasm.


