### PR TITLE
Refactor: add stable internal_id property to TableReference

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -77,6 +77,7 @@ use translate::select::prepare_select_plan;
 pub use types::RefValue;
 pub use types::Value;
 use util::{columns_from_create_table_body, parse_schema_rows};
+use vdbe::builder::TableRefIdCounter;
 use vdbe::{builder::QueryMode, VTabOpaqueCursor};
 pub type Result<T, E = LimboError> = std::result::Result<T, E>;
 pub static DATABASE_VERSION: OnceLock<String> = OnceLock::new();
@@ -407,6 +408,7 @@ impl Connection {
                 Ok(Some(stmt))
             }
             Cmd::ExplainQueryPlan(stmt) => {
+                let mut table_ref_counter = TableRefIdCounter::new();
                 match stmt {
                     ast::Stmt::Select(select) => {
                         let mut plan = prepare_select_plan(
@@ -417,6 +419,7 @@ impl Connection {
                             *select,
                             &syms,
                             None,
+                            &mut table_ref_counter,
                         )?;
                         optimize_plan(
                             &mut plan,

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1790,7 +1790,12 @@ pub fn translate_expr(
             column,
             is_rowid_alias,
         } => {
-            let table_reference = referenced_tables.as_ref().unwrap().get(*table).unwrap();
+            let table_reference = referenced_tables
+                .as_ref()
+                .unwrap()
+                .iter()
+                .find(|t| t.internal_id == *table)
+                .unwrap();
             let index = table_reference.op.index();
             let use_covering_index = table_reference.utilizes_covering_index();
 
@@ -1883,7 +1888,12 @@ pub fn translate_expr(
             }
         }
         ast::Expr::RowId { database: _, table } => {
-            let table_reference = referenced_tables.as_ref().unwrap().get(*table).unwrap();
+            let table_reference = referenced_tables
+                .as_ref()
+                .unwrap()
+                .iter()
+                .find(|t| t.internal_id == *table)
+                .unwrap();
             let index = table_reference.op.index();
             let use_covering_index = table_reference.utilizes_covering_index();
             if use_covering_index {

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -135,7 +135,11 @@ pub fn init_group_by(
                     CollationSeq::new(collation_name).map(Some)
                 }
                 ast::Expr::Column { table, column, .. } => {
-                    let table_reference = plan.table_references.get(*table).unwrap();
+                    let table_reference = plan
+                        .table_references
+                        .iter()
+                        .find(|t| t.internal_id == *table)
+                        .unwrap();
 
                     let Some(table_column) = table_reference.table.get_column_at(*column) else {
                         crate::bail_parse_error!("column index out of bounds");

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -298,7 +298,7 @@ pub fn open_loop(
     predicates: &mut [WhereTerm],
 ) -> Result<()> {
     for (join_index, join) in join_order.iter().enumerate() {
-        let table_index = join.table_no;
+        let table_index = join.original_idx;
         let table = &tables[table_index];
         let LoopLabels {
             loop_start,
@@ -345,110 +345,112 @@ pub fn open_loop(
                         program.preassign_label_to_next_insn(loop_start);
                     }
                     Table::Virtual(vtab) => {
-                        let (start_reg, count, maybe_idx_str, maybe_idx_int) =
-                            if vtab.kind.eq(&VTabKind::VirtualTable) {
-                                // Virtual‑table (non‑TVF) modules can receive constraints via xBestIndex.
-                                // They return information with which to pass to VFilter operation.
-                                // We forward every predicate that touches vtab columns.
-                                //
-                                // vtab.col = literal             (always usable)
-                                // vtab.col = outer_table.col     (usable, because outer_table is already positioned)
-                                // vtab.col = later_table.col     (forwarded with usable = false)
-                                //
-                                // xBestIndex decides which ones it wants by setting argvIndex and whether the
-                                // core layer may omit them (omit = true).
-                                // We then materialise the RHS/LHS into registers before issuing VFilter.
-                                let converted_constraints = predicates
-                                    .iter()
-                                    .filter(|p| p.should_eval_at_loop(join_index, join_order))
-                                    .enumerate()
-                                    .filter_map(|(i, p)| {
-                                        // Build ConstraintInfo from the predicates
-                                        convert_where_to_vtab_constraint(p, table_index, i)
-                                            .unwrap_or(None)
-                                    })
-                                    .collect::<Vec<_>>();
-                                // TODO: get proper order_by information to pass to the vtab.
-                                // maybe encode more info on t_ctx? we need: [col_idx, is_descending]
-                                let index_info = vtab.best_index(&converted_constraints, &[]);
+                        let (start_reg, count, maybe_idx_str, maybe_idx_int) = if vtab
+                            .kind
+                            .eq(&VTabKind::VirtualTable)
+                        {
+                            // Virtual‑table (non‑TVF) modules can receive constraints via xBestIndex.
+                            // They return information with which to pass to VFilter operation.
+                            // We forward every predicate that touches vtab columns.
+                            //
+                            // vtab.col = literal             (always usable)
+                            // vtab.col = outer_table.col     (usable, because outer_table is already positioned)
+                            // vtab.col = later_table.col     (forwarded with usable = false)
+                            //
+                            // xBestIndex decides which ones it wants by setting argvIndex and whether the
+                            // core layer may omit them (omit = true).
+                            // We then materialise the RHS/LHS into registers before issuing VFilter.
+                            let converted_constraints = predicates
+                                .iter()
+                                .filter(|p| p.should_eval_at_loop(join_index, join_order))
+                                .enumerate()
+                                .filter_map(|(i, p)| {
+                                    // Build ConstraintInfo from the predicates
+                                    convert_where_to_vtab_constraint(p, table_index, i, join_order)
+                                        .unwrap_or(None)
+                                })
+                                .collect::<Vec<_>>();
+                            // TODO: get proper order_by information to pass to the vtab.
+                            // maybe encode more info on t_ctx? we need: [col_idx, is_descending]
+                            let index_info = vtab.best_index(&converted_constraints, &[]);
 
-                                // Determine the number of VFilter arguments (constraints with an argv_index).
-                                let args_needed = index_info
-                                    .constraint_usages
-                                    .iter()
-                                    .filter(|u| u.argv_index.is_some())
-                                    .count();
-                                let start_reg = program.alloc_registers(args_needed);
+                            // Determine the number of VFilter arguments (constraints with an argv_index).
+                            let args_needed = index_info
+                                .constraint_usages
+                                .iter()
+                                .filter(|u| u.argv_index.is_some())
+                                .count();
+                            let start_reg = program.alloc_registers(args_needed);
 
-                                // For each constraint used by best_index, translate the opposite side.
-                                for (i, usage) in index_info.constraint_usages.iter().enumerate() {
-                                    if let Some(argv_index) = usage.argv_index {
-                                        if let Some(cinfo) = converted_constraints.get(i) {
-                                            let (pred_idx, is_rhs) = cinfo.unpack_plan_info();
-                                            if let ast::Expr::Binary(lhs, _, rhs) =
-                                                &predicates[pred_idx].expr
-                                            {
-                                                // translate the opposite side of the referenced vtab column
-                                                let expr = if is_rhs { lhs } else { rhs };
-                                                // argv_index is 1-based; adjust to get the proper register offset.
-                                                if argv_index == 0 {
-                                                    // invalid since argv_index is 1-based
-                                                    continue;
-                                                }
-                                                let target_reg =
-                                                    start_reg + (argv_index - 1) as usize;
-                                                translate_expr(
-                                                    program,
-                                                    Some(tables),
-                                                    expr,
-                                                    target_reg,
-                                                    &t_ctx.resolver,
-                                                )?;
-                                                if cinfo.usable && usage.omit {
-                                                    predicates[pred_idx].consumed = true;
-                                                }
+                            // For each constraint used by best_index, translate the opposite side.
+                            for (i, usage) in index_info.constraint_usages.iter().enumerate() {
+                                if let Some(argv_index) = usage.argv_index {
+                                    if let Some(cinfo) = converted_constraints.get(i) {
+                                        let (pred_idx, is_rhs) = cinfo.unpack_plan_info();
+                                        if let ast::Expr::Binary(lhs, _, rhs) =
+                                            &predicates[pred_idx].expr
+                                        {
+                                            // translate the opposite side of the referenced vtab column
+                                            let expr = if is_rhs { lhs } else { rhs };
+                                            // argv_index is 1-based; adjust to get the proper register offset.
+                                            if argv_index == 0 {
+                                                // invalid since argv_index is 1-based
+                                                continue;
+                                            }
+                                            let target_reg = start_reg + (argv_index - 1) as usize;
+                                            translate_expr(
+                                                program,
+                                                Some(tables),
+                                                expr,
+                                                target_reg,
+                                                &t_ctx.resolver,
+                                            )?;
+                                            if cinfo.usable && usage.omit {
+                                                predicates[pred_idx].consumed = true;
                                             }
                                         }
                                     }
                                 }
-                                // If best_index provided an idx_str, translate it.
-                                let maybe_idx_str = if let Some(idx_str) = index_info.idx_str {
-                                    let reg = program.alloc_register();
-                                    program.emit_insn(Insn::String8 {
-                                        dest: reg,
-                                        value: idx_str,
-                                    });
-                                    Some(reg)
-                                } else {
-                                    None
-                                };
-                                (
-                                    start_reg,
-                                    args_needed,
-                                    maybe_idx_str,
-                                    Some(index_info.idx_num),
-                                )
+                            }
+
+                            // If best_index provided an idx_str, translate it.
+                            let maybe_idx_str = if let Some(idx_str) = index_info.idx_str {
+                                let reg = program.alloc_register();
+                                program.emit_insn(Insn::String8 {
+                                    dest: reg,
+                                    value: idx_str,
+                                });
+                                Some(reg)
                             } else {
-                                // For table-valued functions: translate the table args.
-                                let args = match vtab.args.as_ref() {
-                                    Some(args) => args,
-                                    None => &vec![],
-                                };
-                                let start_reg = program.alloc_registers(args.len());
-                                let mut cur_reg = start_reg;
-                                for arg in args {
-                                    let reg = cur_reg;
-                                    cur_reg += 1;
-                                    let _ = translate_expr(
-                                        program,
-                                        Some(tables),
-                                        arg,
-                                        reg,
-                                        &t_ctx.resolver,
-                                    )?;
-                                }
-                                (start_reg, args.len(), None, None)
+                                None
                             };
+                            (
+                                start_reg,
+                                args_needed,
+                                maybe_idx_str,
+                                Some(index_info.idx_num),
+                            )
+                        } else {
+                            // For table-valued functions: translate the table args.
+                            let args = match vtab.args.as_ref() {
+                                Some(args) => args,
+                                None => &vec![],
+                            };
+                            let start_reg = program.alloc_registers(args.len());
+                            let mut cur_reg = start_reg;
+                            for arg in args {
+                                let reg = cur_reg;
+                                cur_reg += 1;
+                                let _ = translate_expr(
+                                    program,
+                                    Some(tables),
+                                    arg,
+                                    reg,
+                                    &t_ctx.resolver,
+                                )?;
+                            }
+                            (start_reg, args.len(), None, None)
+                        };
 
                         // Emit VFilter with the computed arguments.
                         program.emit_insn(Insn::VFilter {
@@ -919,7 +921,7 @@ pub fn close_loop(
     //   CLOSE t2
     // CLOSE t1
     for join in join_order.iter().rev() {
-        let table_index = join.table_no;
+        let table_index = join.original_idx;
         let table = &tables[table_index];
         let loop_labels = *t_ctx
             .labels_main_loop

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -54,7 +54,7 @@ pub fn find_best_access_method_for_join_order<'a>(
     maybe_order_target: Option<&OrderTarget>,
     input_cardinality: f64,
 ) -> Result<AccessMethod<'a>> {
-    let table_no = join_order.last().unwrap().table_no;
+    let table_no = join_order.last().unwrap().table_id;
     let mut best_access_method =
         AccessMethod::new_table_scan(input_cardinality, IterationDirection::Forwards);
     let rowid_column_idx = rhs_table.columns().iter().position(|c| c.is_rowid_alias);
@@ -93,7 +93,7 @@ pub fn find_best_access_method_for_join_order<'a>(
             let mut all_same_direction = true;
             let mut all_opposite_direction = true;
             for i in 0..order_target.0.len().min(index_info.column_count) {
-                let correct_table = order_target.0[i].table_no == table_no;
+                let correct_table = order_target.0[i].table_id == table_no;
                 let correct_column = {
                     match &candidate.index {
                         Some(index) => index.columns[i].pos_in_table == order_target.0[i].column_no,

--- a/core/translate/optimizer/lift_common_subexpressions.rs
+++ b/core/translate/optimizer/lift_common_subexpressions.rs
@@ -188,7 +188,7 @@ fn rebuild_or_expr_from_list(mut operands: Vec<Expr>) -> Expr {
 mod tests {
     use super::*;
     use crate::translate::plan::WhereTerm;
-    use limbo_sqlite3_parser::ast::{self, Expr, Literal, Operator};
+    use limbo_sqlite3_parser::ast::{self, Expr, Literal, Operator, TableInternalId};
 
     #[test]
     fn test_lift_common_subexpressions() -> Result<()> {
@@ -200,7 +200,7 @@ mod tests {
         let a_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 0,
                 is_rowid_alias: false,
             }),
@@ -211,7 +211,7 @@ mod tests {
         let b_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 1,
                 is_rowid_alias: false,
             }),
@@ -222,7 +222,7 @@ mod tests {
         let x_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 2,
                 is_rowid_alias: false,
             }),
@@ -233,7 +233,7 @@ mod tests {
         let y_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 3,
                 is_rowid_alias: false,
             }),
@@ -293,7 +293,7 @@ mod tests {
         let a_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 0,
                 is_rowid_alias: false,
             }),
@@ -304,7 +304,7 @@ mod tests {
         let x_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 1,
                 is_rowid_alias: false,
             }),
@@ -315,7 +315,7 @@ mod tests {
         let y_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 2,
                 is_rowid_alias: false,
             }),
@@ -326,7 +326,7 @@ mod tests {
         let z_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 3,
                 is_rowid_alias: false,
             }),
@@ -393,7 +393,7 @@ mod tests {
         let x_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 0,
                 is_rowid_alias: false,
             }),
@@ -404,7 +404,7 @@ mod tests {
         let y_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 1,
                 is_rowid_alias: false,
             }),
@@ -445,7 +445,7 @@ mod tests {
         let a_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 0,
                 is_rowid_alias: false,
             }),
@@ -456,7 +456,7 @@ mod tests {
         let x_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 1,
                 is_rowid_alias: false,
             }),
@@ -467,7 +467,7 @@ mod tests {
         let y_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 2,
                 is_rowid_alias: false,
             }),
@@ -487,7 +487,7 @@ mod tests {
 
         let mut where_clause = vec![WhereTerm {
             expr: or_expr,
-            from_outer_join: Some(0), // Set from_outer_join
+            from_outer_join: Some(TableInternalId::default()), // Set from_outer_join
             consumed: false,
         }];
 
@@ -507,9 +507,15 @@ mod tests {
                 Box::new(ast::Expr::Parenthesized(vec![y_expr]))
             )
         );
-        assert_eq!(nonconsumed_terms[0].from_outer_join, Some(0));
+        assert_eq!(
+            nonconsumed_terms[0].from_outer_join,
+            Some(TableInternalId::default())
+        );
         assert_eq!(nonconsumed_terms[1].expr, a_expr);
-        assert_eq!(nonconsumed_terms[1].from_outer_join, Some(0));
+        assert_eq!(
+            nonconsumed_terms[1].from_outer_join,
+            Some(TableInternalId::default())
+        );
 
         Ok(())
     }
@@ -523,7 +529,7 @@ mod tests {
         let single_expr = Expr::Binary(
             Box::new(Expr::Column {
                 database: None,
-                table: 0,
+                table: TableInternalId::default(),
                 column: 0,
                 is_rowid_alias: false,
             }),
@@ -559,7 +565,7 @@ mod tests {
                 Expr::Binary(
                     Box::new(Expr::Column {
                         database: None,
-                        table: 0,
+                        table: TableInternalId::default(),
                         column: i,
                         is_rowid_alias: false,
                     }),

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use limbo_sqlite3_parser::ast::{self, SortOrder};
+use limbo_sqlite3_parser::ast::{self, SortOrder, TableInternalId};
 
 use crate::{
     translate::plan::{GroupBy, IterationDirection, TableReference},
@@ -12,7 +12,7 @@ use super::{access_method::AccessMethod, join::JoinN};
 #[derive(Debug, PartialEq, Clone)]
 /// A convenience struct for representing a (table_no, column_no, [SortOrder]) tuple.
 pub struct ColumnOrder {
-    pub table_no: usize,
+    pub table_id: TableInternalId,
     pub column_no: usize,
     pub order: SortOrder,
 }
@@ -51,7 +51,7 @@ impl OrderTarget {
                     unreachable!();
                 };
                 ColumnOrder {
-                    table_no: *table,
+                    table_id: *table,
                     column_no: *column,
                     order,
                 }
@@ -162,10 +162,10 @@ pub fn plan_satisfies_order_target(
 ) -> bool {
     let mut target_col_idx = 0;
     let num_cols_in_order_target = order_target.0.len();
-    for (table_no, access_method_index) in plan.data.iter() {
+    for (table_index, access_method_index) in plan.data.iter() {
         let target_col = &order_target.0[target_col_idx];
-        let table_ref = &table_references[*table_no];
-        let correct_table = target_col.table_no == *table_no;
+        let table_ref = &table_references[*table_index];
+        let correct_table = target_col.table_id == table_ref.internal_id;
         if !correct_table {
             return false;
         }

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -54,7 +54,10 @@ pub fn init_order_by(
         .map(|(expr, _)| match expr {
             ast::Expr::Collate(_, collation_name) => CollationSeq::new(collation_name).map(Some),
             ast::Expr::Column { table, column, .. } => {
-                let table_reference = referenced_tables.get(*table).unwrap();
+                let table_reference = referenced_tables
+                    .iter()
+                    .find(|t| t.internal_id == *table)
+                    .unwrap();
 
                 let Some(table_column) = table_reference.table.get_column_at(*column) else {
                     crate::bail_parse_error!("column index out of bounds");

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -13,11 +13,11 @@ use crate::{
     schema::{Schema, Table},
     translate::expr::walk_expr_mut,
     util::{exprs_are_equivalent, normalize_ident, vtable_args},
-    vdbe::BranchOffset,
+    vdbe::{builder::TableRefIdCounter, BranchOffset},
     Result,
 };
 use limbo_sqlite3_parser::ast::{
-    self, Expr, FromClause, JoinType, Limit, Materialized, UnaryOperator, With,
+    self, Expr, FromClause, JoinType, Limit, Materialized, TableInternalId, UnaryOperator, With,
 };
 
 pub const ROWID: &str = "rowid";
@@ -110,7 +110,9 @@ pub fn bind_column_references(
 
                 if !referenced_tables.is_empty() {
                     if let Some(row_id_expr) =
-                        parse_row_id(&normalized_id, 0, || referenced_tables.len() != 1)?
+                        parse_row_id(&normalized_id, referenced_tables[0].internal_id, || {
+                            referenced_tables.len() != 1
+                        })?
                     {
                         *expr = row_id_expr;
 
@@ -135,7 +137,7 @@ pub fn bind_column_references(
                 if let Some((tbl_idx, col_idx, is_rowid_alias)) = match_result {
                     *expr = Expr::Column {
                         database: None, // TODO: support different databases
-                        table: tbl_idx,
+                        table: referenced_tables[tbl_idx].internal_id,
                         column: col_idx,
                         is_rowid_alias,
                     };
@@ -167,7 +169,11 @@ pub fn bind_column_references(
                 let tbl_idx = matching_tbl_idx.unwrap();
                 let normalized_id = normalize_ident(id.0.as_str());
 
-                if let Some(row_id_expr) = parse_row_id(&normalized_id, tbl_idx, || false)? {
+                if let Some(row_id_expr) = parse_row_id(
+                    &normalized_id,
+                    referenced_tables[tbl_idx].internal_id,
+                    || false,
+                )? {
                     *expr = row_id_expr;
 
                     return Ok(());
@@ -186,7 +192,7 @@ pub fn bind_column_references(
                     .unwrap();
                 *expr = Expr::Column {
                     database: None, // TODO: support different databases
-                    table: tbl_idx,
+                    table: referenced_tables[tbl_idx].internal_id,
                     column: col_idx.unwrap(),
                     is_rowid_alias: col.is_rowid_alias,
                 };
@@ -203,6 +209,7 @@ fn parse_from_clause_table<'a>(
     table: ast::SelectTable,
     scope: &mut Scope<'a>,
     syms: &SymbolTable,
+    table_ref_counter: &mut TableRefIdCounter,
 ) -> Result<()> {
     match table {
         ast::SelectTable::Table(qualified_name, maybe_alias, _) => {
@@ -215,8 +222,12 @@ fn parse_from_clause_table<'a>(
             {
                 // CTE can be rewritten as a subquery.
                 // TODO: find a way not to clone the CTE plan here.
-                let cte_table =
-                    TableReference::new_subquery(cte.name.clone(), cte.plan.clone(), None);
+                let cte_table = TableReference::new_subquery(
+                    cte.name.clone(),
+                    cte.plan.clone(),
+                    None,
+                    table_ref_counter.next(),
+                );
                 scope.tables.push(cte_table);
                 return Ok(());
             };
@@ -244,6 +255,7 @@ fn parse_from_clause_table<'a>(
                     },
                     table: tbl_ref,
                     identifier: alias.unwrap_or(normalized_qualified_name),
+                    internal_id: table_ref_counter.next(),
                     join_info: None,
                     col_used_mask: ColumnUsedMask::new(),
                 });
@@ -267,8 +279,12 @@ fn parse_from_clause_table<'a>(
                     .find(|cte| cte.name == normalized_qualified_name)
                 {
                     // TODO: avoid cloning the CTE plan here.
-                    let cte_table =
-                        TableReference::new_subquery(cte.name.clone(), cte.plan.clone(), None);
+                    let cte_table = TableReference::new_subquery(
+                        cte.name.clone(),
+                        cte.plan.clone(),
+                        None,
+                        table_ref_counter.next(),
+                    );
                     scope.tables.push(cte_table);
                     return Ok(());
                 }
@@ -278,7 +294,7 @@ fn parse_from_clause_table<'a>(
         }
         ast::SelectTable::Select(subselect, maybe_alias) => {
             let Plan::Select(mut subplan) =
-                prepare_select_plan(schema, *subselect, syms, Some(scope))?
+                prepare_select_plan(schema, *subselect, syms, Some(scope), table_ref_counter)?
             else {
                 crate::bail_parse_error!("Only non-compound SELECT queries are currently supported in FROM clause subqueries");
             };
@@ -293,9 +309,12 @@ fn parse_from_clause_table<'a>(
                     ast::As::Elided(id) => id.0.clone(),
                 })
                 .unwrap_or(format!("subquery_{}", cur_table_index));
-            scope
-                .tables
-                .push(TableReference::new_subquery(identifier, subplan, None));
+            scope.tables.push(TableReference::new_subquery(
+                identifier,
+                subplan,
+                None,
+                table_ref_counter.next(),
+            ));
             Ok(())
         }
         ast::SelectTable::TableCall(qualified_name, maybe_args, maybe_alias) => {
@@ -328,6 +347,7 @@ fn parse_from_clause_table<'a>(
                 join_info: None,
                 table: Table::Virtual(vtab),
                 identifier: alias,
+                internal_id: table_ref_counter.next(),
                 col_used_mask: ColumnUsedMask::new(),
             });
 
@@ -384,6 +404,7 @@ pub fn parse_from<'a>(
     with: Option<With>,
     out_where_clause: &mut Vec<WhereTerm>,
     outer_scope: Option<&'a Scope<'a>>,
+    table_ref_counter: &mut TableRefIdCounter,
 ) -> Result<Vec<TableReference>> {
     if from.as_ref().and_then(|f| f.select.as_ref()).is_none() {
         return Ok(vec![]);
@@ -429,7 +450,8 @@ pub fn parse_from<'a>(
             }
 
             // CTE can refer to other CTEs that came before it, plus any schema tables or tables in the outer scope.
-            let cte_plan = prepare_select_plan(schema, *cte.select, syms, Some(&scope))?;
+            let cte_plan =
+                prepare_select_plan(schema, *cte.select, syms, Some(&scope), table_ref_counter)?;
             let Plan::Select(mut cte_plan) = cte_plan else {
                 crate::bail_parse_error!("Only SELECT queries are currently supported in CTEs");
             };
@@ -448,10 +470,17 @@ pub fn parse_from<'a>(
     let mut from_owned = std::mem::take(&mut from).unwrap();
     let select_owned = *std::mem::take(&mut from_owned.select).unwrap();
     let joins_owned = std::mem::take(&mut from_owned.joins).unwrap_or_default();
-    parse_from_clause_table(schema, select_owned, &mut scope, syms)?;
+    parse_from_clause_table(schema, select_owned, &mut scope, syms, table_ref_counter)?;
 
     for join in joins_owned.into_iter() {
-        parse_join(schema, join, syms, &mut scope, out_where_clause)?;
+        parse_join(
+            schema,
+            join,
+            syms,
+            &mut scope,
+            out_where_clause,
+            table_ref_counter,
+        )?;
     }
 
     Ok(scope.tables)
@@ -493,11 +522,11 @@ pub fn determine_where_to_eval_term(
     term: &WhereTerm,
     join_order: &[JoinOrderMember],
 ) -> Result<EvalAt> {
-    if let Some(table_no) = term.from_outer_join {
+    if let Some(table_id) = term.from_outer_join {
         return Ok(EvalAt::Loop(
             join_order
                 .iter()
-                .position(|t| t.table_no == table_no)
+                .position(|t| t.table_id == table_id)
                 .unwrap_or(usize::MAX),
         ));
     }
@@ -523,6 +552,11 @@ pub fn determine_where_to_eval_term(
 /// [TableMask] helps determine:
 /// - Which tables are referenced in a constraint
 /// - When a constraint can be applied as a join condition (all referenced tables must be on the left side of the table being joined)
+///
+/// Note that although [TableReference]s contain an internal ID as well, in join order optimization
+/// the [TableMask] refers to the index of the table in the original join order, not the internal ID.
+/// This is simply because we want to represent the tables as a contiguous set of bits, and the internal ID
+/// might not be contiguous after e.g. subquery unnesting or other transformations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TableMask(pub u128);
 
@@ -597,12 +631,19 @@ impl TableMask {
 
 /// Returns a [TableMask] representing the tables referenced in the given expression.
 /// Used in the optimizer for constraint analysis.
-pub fn table_mask_from_expr(top_level_expr: &Expr) -> Result<TableMask> {
+pub fn table_mask_from_expr(
+    top_level_expr: &Expr,
+    table_references: &[TableReference],
+) -> Result<TableMask> {
     let mut mask = TableMask::new();
     walk_expr(top_level_expr, &mut |expr: &Expr| -> Result<()> {
         match expr {
             Expr::Column { table, .. } | Expr::RowId { table, .. } => {
-                mask.add_table(*table);
+                let table_idx = table_references
+                    .iter()
+                    .position(|t| t.internal_id == *table)
+                    .expect("table not found in table_references");
+                mask.add_table(table_idx);
             }
             _ => {}
         }
@@ -622,7 +663,7 @@ pub fn determine_where_to_eval_expr<'a>(
             Expr::Column { table, .. } | Expr::RowId { table, .. } => {
                 let join_idx = join_order
                     .iter()
-                    .position(|t| t.table_no == *table)
+                    .position(|t| t.table_id == *table)
                     .unwrap_or(usize::MAX);
                 eval_at = eval_at.max(EvalAt::Loop(join_idx));
             }
@@ -640,6 +681,7 @@ fn parse_join<'a>(
     syms: &SymbolTable,
     scope: &mut Scope<'a>,
     out_where_clause: &mut Vec<WhereTerm>,
+    table_ref_counter: &mut TableRefIdCounter,
 ) -> Result<()> {
     let ast::JoinedSelectTable {
         operator: join_operator,
@@ -647,7 +689,7 @@ fn parse_join<'a>(
         constraint,
     } = join;
 
-    parse_from_clause_table(schema, table, scope, syms)?;
+    parse_from_clause_table(schema, table, scope, syms, table_ref_counter)?;
 
     let (outer, natural) = match join_operator {
         ast::JoinOperator::TypedJoin(Some(join_type)) => {
@@ -717,7 +759,7 @@ fn parse_join<'a>(
                     out_where_clause.push(WhereTerm {
                         expr: pred,
                         from_outer_join: if outer {
-                            Some(scope.tables.len() - 1)
+                            Some(scope.tables.last().unwrap().internal_id)
                         } else {
                             None
                         },
@@ -744,7 +786,7 @@ fn parse_join<'a>(
                                     .as_ref()
                                     .map_or(false, |name| *name == name_normalized)
                             })
-                            .map(|(idx, col)| (left_table_idx, idx, col));
+                            .map(|(idx, col)| (left_table_idx, left_table.internal_id, idx, col));
                         if left_col.is_some() {
                             break;
                         }
@@ -766,19 +808,19 @@ fn parse_join<'a>(
                             distinct_name.0
                         );
                     }
-                    let (left_table_idx, left_col_idx, left_col) = left_col.unwrap();
+                    let (left_table_idx, left_table_id, left_col_idx, left_col) = left_col.unwrap();
                     let (right_col_idx, right_col) = right_col.unwrap();
                     let expr = Expr::Binary(
                         Box::new(Expr::Column {
                             database: None,
-                            table: left_table_idx,
+                            table: left_table_id,
                             column: left_col_idx,
                             is_rowid_alias: left_col.is_rowid_alias,
                         }),
                         ast::Operator::Equals,
                         Box::new(Expr::Column {
                             database: None,
-                            table: cur_table_idx,
+                            table: right_table.internal_id,
                             column: right_col_idx,
                             is_rowid_alias: right_col.is_rowid_alias,
                         }),
@@ -790,7 +832,11 @@ fn parse_join<'a>(
                     right_table.mark_column_used(right_col_idx);
                     out_where_clause.push(WhereTerm {
                         expr,
-                        from_outer_join: if outer { Some(cur_table_idx) } else { None },
+                        from_outer_join: if outer {
+                            Some(right_table.internal_id)
+                        } else {
+                            None
+                        },
                         consumed: false,
                     });
                 }
@@ -858,7 +904,11 @@ pub fn break_predicate_at_and_boundaries(predicate: Expr, out_predicates: &mut V
     }
 }
 
-fn parse_row_id<F>(column_name: &str, table_id: usize, fn_check: F) -> Result<Option<Expr>>
+fn parse_row_id<F>(
+    column_name: &str,
+    table_id: TableInternalId,
+    fn_check: F,
+) -> Result<Option<Expr>>
 where
     F: FnOnce() -> bool,
 {

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -288,6 +288,43 @@ pub struct Delete {
     pub limit: Option<Box<Limit>>,
 }
 
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Internal ID of a table.
+///
+/// Used by [Expr::Column] and [Expr::RowId] to refer to a table.
+pub struct TableInternalId(usize);
+
+impl Default for TableInternalId {
+    fn default() -> Self {
+        Self(1)
+    }
+}
+
+impl From<usize> for TableInternalId {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+impl std::ops::AddAssign<usize> for TableInternalId {
+    fn add_assign(&mut self, rhs: usize) {
+        self.0 += rhs;
+    }
+}
+
+impl From<TableInternalId> for usize {
+    fn from(value: TableInternalId) -> Self {
+        value.0
+    }
+}
+
+impl std::fmt::Display for TableInternalId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "t{}", self.0)
+    }
+}
+
 /// SQL expression
 // https://sqlite.org/syntax/expr.html
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -354,7 +391,7 @@ pub enum Expr {
         /// the x in `x.y.z`. index of the db in catalog.
         database: Option<usize>,
         /// the y in `x.y.z`. index of the table in catalog.
-        table: usize,
+        table: TableInternalId,
         /// the z in `x.y.z`. index of the column in the table.
         column: usize,
         /// is the column a rowid alias
@@ -365,7 +402,7 @@ pub enum Expr {
         /// the x in `x.y.z`. index of the db in catalog.
         database: Option<usize>,
         /// the y in `x.y.z`. index of the table in catalog.
-        table: usize,
+        table: TableInternalId,
     },
     /// `IN`
     InList {


### PR DESCRIPTION
Closes #1557 

Currently our "table id"/"table no"/"table idx" references always use the direct index of the `TableReference` in the plan, e.g. in `SelectPlan::table_references`. For example:

```rust
Expr::Column { table: 0, column: 3, .. }
```

refers to the 0'th table in the `table_references` list.

This is a fragile approach because it assumes the table_references list is stable for the lifetime of the query processing. This has so far been the case, but there exist certain query transformations, e.g. subquery unnesting, that may fold new table references from a subquery (which has its own table ref list) into the table reference list of the parent.

If such a transformation is made, then potentially all of the Expr::Column references to tables will become invalid. Consider this example:

```sql
-- Assume tables: users(id, age), orders(user_id, amount)

-- Get total amount spent per user on orders over $100
SELECT u.id, sub.total
FROM users u JOIN
     (SELECT user_id, SUM(amount) as total
      FROM orders o
      WHERE o.amount > 100
      GROUP BY o.user_id) sub
WHERE u.id = sub.user_id

-- Before subquery unnesting:
-- Main query table_references: [users, sub]
-- u.id refers to table 0, column 0
-- sub.total refers to table 1, column 1
--
-- Subquery table_references: [orders]
-- o.user_id refers to table 0, column 0
-- o.amount refers to table 0, column 1
--
-- After unnesting and folding subquery tables into main query,
-- the query might look like this:

SELECT u.id, SUM(o.amount) as total
FROM users u JOIN orders o ON u.id = o.user_id
WHERE o.amount > 100
GROUP BY u.id;

-- Main query table_references: [users, orders]
-- u.id refers to table index 0 (correct)
-- o.amount refers to table index 0 (incorrect, should be 1)
-- o.user_id refers to table index 0 (incorrect, should be 1)
```

We could ofc traverse every expression in the subquery and rewrite the table indexes to be correct, but if we instead use stable identifiers for each table reference, then all the column references will continue to be correct.

Hence, this PR introduces a `TableInternalId` used in `TableReference` as well as `Expr::Column` and `Expr::Rowid` so that this kind of query transformations can happen with less pain. I used a separate newtype struct for `TableInternalId` because it made the refactor a lot easier due to not having to spend time thinking which `usize` is what.

---

Potential follow-up: `join_order` can be removed from `SelectPlan` because the `table_references` vec can simply be sorted after join reordering, because the `Expr::Column` references will continue to be valid.