### PR TITLE
btree: fix infinite looping in backwards iteration of btree table

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -576,6 +576,7 @@ impl BTreeCursor {
             } else {
                 cell_idx
             };
+
             let cell = contents.cell_get(
                 cell_idx,
                 payload_overflow_threshold_max(contents.page_type(), self.usable_space() as u16),
@@ -589,6 +590,7 @@ impl BTreeCursor {
                     _rowid,
                 }) => {
                     let mem_page = self.read_page(_left_child_page as usize)?;
+                    self.stack.retreat();
                     self.stack.push_backwards(mem_page);
                     continue;
                 }

--- a/testing/orderby.test
+++ b/testing/orderby.test
@@ -202,6 +202,12 @@ do_execsql_test orderby_desc_with_filter_id_le {
 6662}
 
 # regression test where backwards iteration used to hang indefinitely
-do_execsql_test orderby_desc_subquery_count_regression {
+do_execsql_test orderby_desc_regression {
     select count(1) from (select * from users where id < 100 order by id desc)
 } {99}
+
+do_execsql_test orderby_desc_regression_verify_order {
+    select id from users where id < 100 order by id desc limit 3;
+} {99
+98
+97}

--- a/testing/orderby.test
+++ b/testing/orderby.test
@@ -200,3 +200,8 @@ do_execsql_test orderby_desc_with_filter_id_le {
 6664
 6663
 6662}
+
+# regression test where backwards iteration used to hang indefinitely
+do_execsql_test orderby_desc_subquery_count_regression {
+    select count(1) from (select * from users where id < 100 order by id desc)
+} {99}

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -51,7 +51,7 @@ mod tests {
 
         let insert = format!(
             "INSERT INTO t VALUES {}",
-            (1..10000)
+            (1..2000)
                 .map(|x| format!("({})", x))
                 .collect::<Vec<_>>()
                 .join(", ")
@@ -71,9 +71,9 @@ mod tests {
 
         for comp in COMPARISONS.iter() {
             for order_by in ORDER_BY.iter() {
-                for max in 0..=10000 {
+                for max in 0..=2000 {
                     let query = format!(
-                        "SELECT * FROM t WHERE x {} {} {} LIMIT 3",
+                        "SELECT * FROM t WHERE x {} {} {}",
                         comp,
                         max,
                         order_by.unwrap_or("")


### PR DESCRIPTION
Closes #1562 

Existing "fuzz test" (not really fuzz, but kinda) didn't catch this due to `LIMIT 3` clause