### PR TITLE
refactor: introduce walk_expr() and walk_expr_mut() to reduce repetitive pattern matching

### DIFF
--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -365,6 +365,7 @@ pub fn open_loop(
                                     .filter_map(|(i, p)| {
                                         // Build ConstraintInfo from the predicates
                                         convert_where_to_vtab_constraint(p, table_index, i)
+                                            .unwrap_or(None)
                                     })
                                     .collect::<Vec<_>>();
                                 // TODO: get proper order_by information to pass to the vtab.


### PR DESCRIPTION
We do a lot of 

```rust
match expr {
  ...
}
```

just to find some specific case like `Expr::Column` deep inside an expression tree. This PR introduces new helpers `walk_expr()` and `walk_expr_mut()` that handle the tree-walking part, and the business logic functions where this tree traversal is used can focus on the exact enum variants of `Expr` that they are interested in.