### PR TITLE
Small cleanups to pager/wal/vdbe - mostly naming

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6308,7 +6308,7 @@ mod tests {
         let page_cache = Arc::new(parking_lot::RwLock::new(DumbLruPageCache::new(2000)));
         let pager = {
             let db_header = Arc::new(SpinLock::new(db_header.clone()));
-            Pager::finish_open(db_header, db_file, Some(wal), io, page_cache, buffer_pool).unwrap()
+            Pager::finish_open(db_header, db_file, wal, io, page_cache, buffer_pool).unwrap()
         };
         let pager = Rc::new(pager);
         // FIXME: handle page cache is full
@@ -6486,8 +6486,8 @@ mod tests {
                 .unwrap();
                 loop {
                     match pager.end_tx().unwrap() {
-                        crate::CheckpointStatus::Done(_) => break,
-                        crate::CheckpointStatus::IO => {
+                        crate::PagerCacheflushStatus::Done(_) => break,
+                        crate::PagerCacheflushStatus::IO => {
                             pager.io.run_once().unwrap();
                         }
                     }
@@ -6600,8 +6600,8 @@ mod tests {
                 cursor.move_to_root();
                 loop {
                     match pager.end_tx().unwrap() {
-                        crate::CheckpointStatus::Done(_) => break,
-                        crate::CheckpointStatus::IO => {
+                        crate::PagerCacheflushStatus::Done(_) => break,
+                        crate::PagerCacheflushStatus::IO => {
                             pager.io.run_once().unwrap();
                         }
                     }
@@ -6790,7 +6790,7 @@ mod tests {
             Pager::finish_open(
                 db_header.clone(),
                 db_file,
-                Some(wal),
+                wal,
                 io,
                 Arc::new(parking_lot::RwLock::new(DumbLruPageCache::new(10))),
                 buffer_pool,

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4,7 +4,7 @@ use crate::storage::btree::BTreePageInner;
 use crate::storage::buffer_pool::BufferPool;
 use crate::storage::database::DatabaseStorage;
 use crate::storage::sqlite3_ondisk::{self, DatabaseHeader, PageContent, PageType};
-use crate::storage::wal::{CheckpointResult, Wal};
+use crate::storage::wal::{CheckpointResult, Wal, WalFsyncStatus};
 use crate::{Buffer, LimboError, Result};
 use parking_lot::RwLock;
 use std::cell::{RefCell, UnsafeCell};
@@ -136,12 +136,19 @@ impl Page {
 }
 
 #[derive(Clone, Copy, Debug)]
+/// The state of the current pager cache flush.
 enum FlushState {
+    /// Idle.
     Start,
+    /// Waiting for all in-flight writes to the on-disk WAL to complete.
     WaitAppendFrames,
+    /// Fsync the on-disk WAL.
     SyncWal,
+    /// Checkpoint the WAL to the database file (if needed).
     Checkpoint,
+    /// Fsync the database file.
     SyncDbFile,
+    /// Waiting for the database file to be fsynced.
     WaitSyncDbFile,
 }
 
@@ -167,7 +174,7 @@ pub struct Pager {
     /// Source of the database pages.
     pub db_file: Arc<dyn DatabaseStorage>,
     /// The write-ahead log (WAL) for the database.
-    wal: Option<Rc<RefCell<dyn Wal>>>,
+    wal: Rc<RefCell<dyn Wal>>,
     /// A page cache for the database.
     page_cache: Arc<RwLock<DumbLruPageCache>>,
     /// Buffer pool for temporary data storage.
@@ -183,6 +190,24 @@ pub struct Pager {
     syncing: Rc<RefCell<bool>>,
 }
 
+#[derive(Debug, Copy, Clone)]
+/// The status of the current cache flush.
+/// A Done state means that the WAL was committed to disk and fsynced,
+/// plus potentially checkpointed to the DB (and the DB then fsynced).
+pub enum PagerCacheflushStatus {
+    Done(PagerCacheflushResult),
+    IO,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum PagerCacheflushResult {
+    /// The WAL was written to disk and fsynced.
+    WalWritten,
+    /// The WAL was written, fsynced, and a checkpoint was performed.
+    /// The database file was then also fsynced.
+    Checkpointed(CheckpointResult),
+}
+
 impl Pager {
     /// Begins opening a database by reading the database header.
     pub fn begin_open(db_file: Arc<dyn DatabaseStorage>) -> Result<Arc<SpinLock<DatabaseHeader>>> {
@@ -193,7 +218,7 @@ impl Pager {
     pub fn finish_open(
         db_header_ref: Arc<SpinLock<DatabaseHeader>>,
         db_file: Arc<dyn DatabaseStorage>,
-        wal: Option<Rc<RefCell<dyn Wal>>>,
+        wal: Rc<RefCell<dyn Wal>>,
         io: Arc<dyn crate::io::IO>,
         page_cache: Arc<RwLock<DumbLruPageCache>>,
         buffer_pool: Rc<BufferPool>,
@@ -271,42 +296,28 @@ impl Pager {
 
     #[inline(always)]
     pub fn begin_read_tx(&self) -> Result<LimboResult> {
-        if let Some(wal) = &self.wal {
-            return wal.borrow_mut().begin_read_tx();
-        }
-
-        Ok(LimboResult::Ok)
+        self.wal.borrow_mut().begin_read_tx()
     }
 
     #[inline(always)]
     pub fn begin_write_tx(&self) -> Result<LimboResult> {
-        if let Some(wal) = &self.wal {
-            return wal.borrow_mut().begin_write_tx();
-        }
-
-        Ok(LimboResult::Ok)
+        self.wal.borrow_mut().begin_write_tx()
     }
 
-    pub fn end_tx(&self) -> Result<CheckpointStatus> {
-        if let Some(wal) = &self.wal {
-            let checkpoint_status = self.cacheflush()?;
-            return match checkpoint_status {
-                CheckpointStatus::IO => Ok(checkpoint_status),
-                CheckpointStatus::Done(_) => {
-                    wal.borrow().end_write_tx()?;
-                    wal.borrow().end_read_tx()?;
-                    Ok(checkpoint_status)
-                }
-            };
-        }
-
-        Ok(CheckpointStatus::Done(CheckpointResult::default()))
+    pub fn end_tx(&self) -> Result<PagerCacheflushStatus> {
+        let cacheflush_status = self.cacheflush()?;
+        return match cacheflush_status {
+            PagerCacheflushStatus::IO => Ok(PagerCacheflushStatus::IO),
+            PagerCacheflushStatus::Done(_) => {
+                self.wal.borrow().end_write_tx()?;
+                self.wal.borrow().end_read_tx()?;
+                Ok(cacheflush_status)
+            }
+        };
     }
 
     pub fn end_read_tx(&self) -> Result<()> {
-        if let Some(wal) = &self.wal {
-            wal.borrow().end_read_tx()?;
-        }
+        self.wal.borrow().end_read_tx()?;
         Ok(())
     }
 
@@ -314,10 +325,7 @@ impl Pager {
     pub fn read_page(&self, page_idx: usize) -> Result<PageRef, LimboError> {
         tracing::trace!("read_page(page_idx = {})", page_idx);
         let mut page_cache = self.page_cache.write();
-        let max_frame = match &self.wal {
-            Some(wal) => wal.borrow().get_max_frame(),
-            None => 0,
-        };
+        let max_frame = self.wal.borrow().get_max_frame();
         let page_key = PageCacheKey::new(page_idx, Some(max_frame));
         if let Some(page) = page_cache.get(&page_key) {
             tracing::trace!("read_page(page_idx = {}) = cached", page_idx);
@@ -326,31 +334,31 @@ impl Pager {
         let page = Arc::new(Page::new(page_idx));
         page.set_locked();
 
-        if let Some(wal) = &self.wal {
-            if let Some(frame_id) = wal.borrow().find_frame(page_idx as u64)? {
-                wal.borrow()
-                    .read_frame(frame_id, page.clone(), self.buffer_pool.clone())?;
-                {
-                    page.set_uptodate();
-                }
-                // TODO(pere) should probably first insert to page cache, and if successful,
-                // read frame or page
-                match page_cache.insert(page_key, page.clone()) {
-                    Ok(_) => {}
-                    Err(CacheError::Full) => return Err(LimboError::CacheFull),
-                    Err(CacheError::KeyExists) => {
-                        unreachable!("Page should not exist in cache after get() miss")
-                    }
-                    Err(e) => {
-                        return Err(LimboError::InternalError(format!(
-                            "Failed to insert page into cache: {:?}",
-                            e
-                        )))
-                    }
-                }
-                return Ok(page);
+        if let Some(frame_id) = self.wal.borrow().find_frame(page_idx as u64)? {
+            self.wal
+                .borrow()
+                .read_frame(frame_id, page.clone(), self.buffer_pool.clone())?;
+            {
+                page.set_uptodate();
             }
+            // TODO(pere) should probably first insert to page cache, and if successful,
+            // read frame or page
+            match page_cache.insert(page_key, page.clone()) {
+                Ok(_) => {}
+                Err(CacheError::Full) => return Err(LimboError::CacheFull),
+                Err(CacheError::KeyExists) => {
+                    unreachable!("Page should not exist in cache after get() miss")
+                }
+                Err(e) => {
+                    return Err(LimboError::InternalError(format!(
+                        "Failed to insert page into cache: {:?}",
+                        e
+                    )))
+                }
+            }
+            return Ok(page);
         }
+
         sqlite3_ondisk::begin_read_page(
             self.db_file.clone(),
             self.buffer_pool.clone(),
@@ -391,15 +399,14 @@ impl Pager {
     }
 
     pub fn wal_frame_count(&self) -> Result<u64> {
-        let mut frame_count = 0;
-        let wal = self.wal.clone();
-        if let Some(wal) = &wal {
-            frame_count = wal.borrow().get_max_frame_in_wal();
-        }
-        Ok(frame_count)
+        Ok(self.wal.borrow().get_max_frame_in_wal())
     }
 
-    pub fn cacheflush(&self) -> Result<CheckpointStatus> {
+    /// Flush dirty pages to disk.
+    /// In the base case, it will write the dirty pages to the WAL and then fsync the WAL.
+    /// If the WAL size is over the checkpoint threshold, it will checkpoint the WAL to
+    /// the database file and then fsync the database file.
+    pub fn cacheflush(&self) -> Result<PagerCacheflushStatus> {
         let mut checkpoint_result = CheckpointResult::default();
         loop {
             let state = self.flush_info.borrow().state;
@@ -407,23 +414,18 @@ impl Pager {
             match state {
                 FlushState::Start => {
                     let db_size = self.db_header.lock().database_size;
-                    let max_frame = match &self.wal {
-                        Some(wal) => wal.borrow().get_max_frame(),
-                        None => 0,
-                    };
+                    let max_frame = self.wal.borrow().get_max_frame();
                     for page_id in self.dirty_pages.borrow().iter() {
                         let mut cache = self.page_cache.write();
                         let page_key = PageCacheKey::new(*page_id, Some(max_frame));
                         let page = cache.get(&page_key).expect("we somehow added a page to dirty list but we didn't mark it as dirty, causing cache to drop it.");
-                        if let Some(wal) = &self.wal {
-                            let page_type = page.get().contents.as_ref().unwrap().maybe_page_type();
-                            trace!("cacheflush(page={}, page_type={:?}", page_id, page_type);
-                            wal.borrow_mut().append_frame(
-                                page.clone(),
-                                db_size,
-                                self.flush_info.borrow().in_flight_writes.clone(),
-                            )?;
-                        }
+                        let page_type = page.get().contents.as_ref().unwrap().maybe_page_type();
+                        trace!("cacheflush(page={}, page_type={:?}", page_id, page_type);
+                        self.wal.borrow_mut().append_frame(
+                            page.clone(),
+                            db_size,
+                            self.flush_info.borrow().in_flight_writes.clone(),
+                        )?;
                         page.clear_dirty();
                     }
                     // This is okay assuming we use shared cache by default.
@@ -433,33 +435,28 @@ impl Pager {
                     }
                     self.dirty_pages.borrow_mut().clear();
                     self.flush_info.borrow_mut().state = FlushState::WaitAppendFrames;
-                    return Ok(CheckpointStatus::IO);
+                    return Ok(PagerCacheflushStatus::IO);
                 }
                 FlushState::WaitAppendFrames => {
                     let in_flight = *self.flush_info.borrow().in_flight_writes.borrow();
                     if in_flight == 0 {
                         self.flush_info.borrow_mut().state = FlushState::SyncWal;
                     } else {
-                        return Ok(CheckpointStatus::IO);
+                        return Ok(PagerCacheflushStatus::IO);
                     }
                 }
                 FlushState::SyncWal => {
-                    let wal = self.wal.clone().ok_or(LimboError::InternalError(
-                        "SyncWal was called without a existing wal".to_string(),
-                    ))?;
-                    match wal.borrow_mut().sync() {
-                        Ok(CheckpointStatus::IO) => return Ok(CheckpointStatus::IO),
-                        Ok(CheckpointStatus::Done(res)) => checkpoint_result = res,
-                        Err(e) => return Err(e),
+                    if WalFsyncStatus::IO == self.wal.borrow_mut().sync()? {
+                        return Ok(PagerCacheflushStatus::IO);
                     }
 
-                    let should_checkpoint = wal.borrow().should_checkpoint();
-                    if should_checkpoint {
-                        self.flush_info.borrow_mut().state = FlushState::Checkpoint;
-                    } else {
+                    if !self.wal.borrow().should_checkpoint() {
                         self.flush_info.borrow_mut().state = FlushState::Start;
-                        break;
+                        return Ok(PagerCacheflushStatus::Done(
+                            PagerCacheflushResult::WalWritten,
+                        ));
                     }
+                    self.flush_info.borrow_mut().state = FlushState::Checkpoint;
                 }
                 FlushState::Checkpoint => {
                     match self.checkpoint()? {
@@ -467,7 +464,7 @@ impl Pager {
                             checkpoint_result = res;
                             self.flush_info.borrow_mut().state = FlushState::SyncDbFile;
                         }
-                        CheckpointStatus::IO => return Ok(CheckpointStatus::IO),
+                        CheckpointStatus::IO => return Ok(PagerCacheflushStatus::IO),
                     };
                 }
                 FlushState::SyncDbFile => {
@@ -476,7 +473,7 @@ impl Pager {
                 }
                 FlushState::WaitSyncDbFile => {
                     if *self.syncing.borrow() {
-                        return Ok(CheckpointStatus::IO);
+                        return Ok(PagerCacheflushStatus::IO);
                     } else {
                         self.flush_info.borrow_mut().state = FlushState::Start;
                         break;
@@ -484,7 +481,9 @@ impl Pager {
                 }
             }
         }
-        Ok(CheckpointStatus::Done(checkpoint_result))
+        Ok(PagerCacheflushStatus::Done(
+            PagerCacheflushResult::Checkpointed(checkpoint_result),
+        ))
     }
 
     pub fn checkpoint(&self) -> Result<CheckpointStatus> {
@@ -495,13 +494,11 @@ impl Pager {
             match state {
                 CheckpointState::Checkpoint => {
                     let in_flight = self.checkpoint_inflight.clone();
-                    let wal = self.wal.clone().ok_or(LimboError::InternalError(
-                        "Checkpoint was called without a existing wal".to_string(),
-                    ))?;
-                    match wal
-                        .borrow_mut()
-                        .checkpoint(self, in_flight, CheckpointMode::Passive)?
-                    {
+                    match self.wal.borrow_mut().checkpoint(
+                        self,
+                        in_flight,
+                        CheckpointMode::Passive,
+                    )? {
                         CheckpointStatus::IO => return Ok(CheckpointStatus::IO),
                         CheckpointStatus::Done(res) => {
                             checkpoint_result = res;
@@ -538,7 +535,7 @@ impl Pager {
     pub fn clear_page_cache(&self) -> CheckpointResult {
         let checkpoint_result: CheckpointResult;
         loop {
-            match self.wal.clone().unwrap().borrow_mut().checkpoint(
+            match self.wal.borrow_mut().checkpoint(
                 self,
                 Rc::new(RefCell::new(0)),
                 CheckpointMode::Passive,
@@ -667,10 +664,7 @@ impl Pager {
             // setup page and add to cache
             page.set_dirty();
             self.add_dirty(page.get().id);
-            let max_frame = match &self.wal {
-                Some(wal) => wal.borrow().get_max_frame(),
-                None => 0,
-            };
+            let max_frame = self.wal.borrow().get_max_frame();
 
             let page_key = PageCacheKey::new(page.get().id, Some(max_frame));
             let mut cache = self.page_cache.write();
@@ -692,10 +686,7 @@ impl Pager {
         page: PageRef,
     ) -> Result<(), LimboError> {
         let mut cache = self.page_cache.write();
-        let max_frame = match &self.wal {
-            Some(wal) => wal.borrow().get_max_frame(),
-            None => 0,
-        };
+        let max_frame = self.wal.borrow().get_max_frame();
         let page_key = PageCacheKey::new(id, Some(max_frame));
 
         // FIXME: use specific page key for writer instead of max frame, this will make readers not conflict

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -1,4 +1,4 @@
-use limbo_core::{CheckpointStatus, Connection, Database, IO};
+use limbo_core::{Connection, Database, PagerCacheflushStatus, IO};
 use rand::{rng, RngCore};
 use rusqlite::params;
 use std::path::{Path, PathBuf};
@@ -86,10 +86,10 @@ impl TempDatabase {
 pub(crate) fn do_flush(conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
     loop {
         match conn.cacheflush()? {
-            CheckpointStatus::Done(_) => {
+            PagerCacheflushStatus::Done(_) => {
                 break;
             }
-            CheckpointStatus::IO => {
+            PagerCacheflushStatus::IO => {
                 tmp_db.io.run_once()?;
             }
         }


### PR DESCRIPTION
- Instead of using a confusing `CheckpointStatus` for many different things, introduce the following statuses:
    * `PagerCacheflushStatus` - cacheflush can result in either:
       - the WAL being written to disk and fsynced
       - but also a checkpoint to the main DB file, and fsyncing the main DB file
      Reflect this in the type.
    * `WalFsyncStatus`
      - previously `CheckpointStatus` was also used for this, even though fsyncing the WAL doesn't checkpoint.
    * `CheckpointStatus`/`CheckpointResult` is now used only for actual checkpointing.

- Rename `HaltState` to `CommitState` (program.halt_state -> program.commit_state)
   * `HaltState`'s only variant was `HaltState::Checkpointing` but it wasn't necessarily reflective of checkpoint being in progress.
   * Now the variants are `CommitState::Ready` and `CommitState::Committing` and `commit_state` is
      non-optional in `ProgramState`
- Make `wal` a non-optional property in `Pager`
  * This gets rid of a lot of `if let Some(...)` boilerplate
  * For ephemeral indexes, provide a `DummyWAL` implementation that does nothing.
- Rename `program.halt()` to `program.commit_txn()`
- Add some documentation comments to structs and functions