### PR TITLE
Clear test db's WAL too in clone_test_db.sh

### DIFF
--- a/scripts/clone_test_db.sh
+++ b/scripts/clone_test_db.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-rm -f testing/testing_clone.db
+rm -f testing/testing_clone.db*
 sqlite3 testing/testing/db '.clone testing/testing_clone.db' > /dev/null


### PR DESCRIPTION
Before #1570 , we never read anything from the on-disk WAL in a newly-instantiated DB, so the `test_wal_frame_count()` test would always pass

Now that the actual bug is fixed, the current test isn't idempotent because the `clone_test_db.sh` command does not clear the wal, just the db file