### PR TITLE
Reset idx delete state after successful finish

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3931,6 +3931,7 @@ pub fn op_idx_delete(
                 let n_change = program.n_change.get();
                 program.n_change.set(n_change + 1);
                 state.pc += 1;
+                state.op_idx_delete_state = None;
                 return Ok(InsnFunctionStepResult::Step);
             }
             None => {


### PR DESCRIPTION
If we don't reset the state of `IdxDelete`, next `IdxDelete` will start in `Deleting` state which is completely wrong since it should seek from the start.