### PR TITLE
Make WhereTerm::consumed a Cell<bool>

### DIFF
--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -295,7 +295,7 @@ pub fn open_loop(
     t_ctx: &mut TranslateCtx,
     tables: &[TableReference],
     join_order: &[JoinOrderMember],
-    predicates: &mut [WhereTerm],
+    predicates: &[WhereTerm],
 ) -> Result<()> {
     for (join_index, join) in join_order.iter().enumerate() {
         let table_index = join.original_idx;
@@ -406,7 +406,7 @@ pub fn open_loop(
                                                 &t_ctx.resolver,
                                             )?;
                                             if cinfo.usable && usage.omit {
-                                                predicates[pred_idx].consumed = true;
+                                                predicates[pred_idx].consumed.set(true);
                                             }
                                         }
                                     }

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -494,7 +494,7 @@ fn generate_join_bitmasks(table_number_max_exclusive: usize, how_many: usize) ->
 
 #[cfg(test)]
 mod tests {
-    use std::{rc::Rc, sync::Arc};
+    use std::{cell::Cell, rc::Rc, sync::Arc};
 
     use limbo_sqlite3_parser::ast::{self, Expr, Operator, SortOrder, TableInternalId};
 
@@ -1332,7 +1332,7 @@ mod tests {
         WhereTerm {
             expr: Expr::Binary(Box::new(lhs), op, Box::new(rhs)),
             from_outer_join: None,
-            consumed: false,
+            consumed: Cell::new(false),
         }
     }
 

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+
 use super::{
     expr::walk_expr,
     plan::{
@@ -514,7 +516,7 @@ pub fn parse_where(
             out_where_clause.push(WhereTerm {
                 expr,
                 from_outer_join: None,
-                consumed: false,
+                consumed: Cell::new(false),
             });
         }
         Ok(())
@@ -775,7 +777,7 @@ fn parse_join<'a>(
                         } else {
                             None
                         },
-                        consumed: false,
+                        consumed: Cell::new(false),
                     });
                 }
             }
@@ -849,7 +851,7 @@ fn parse_join<'a>(
                         } else {
                             None
                         },
-                        consumed: false,
+                        consumed: Cell::new(false),
                     });
                 }
                 using = Some(distinct_names);


### PR DESCRIPTION
Currently in the main translation logic after planning and optimization, we don't _really_ need to pass a `&mut Vec<WhereTerm>` around anymore, except for the fact that virtual table constraint resolution is done ad-hoc in `init_loop()`. 

Even there, the only thing we mutate is `WhereTerm::consumed` which is a boolean indicating that the term has been "used up" by the optimizer and shouldn't be evaluated as a normal where clause condition anymore.

In the upcoming branch for WHERE clause subqueries, I want to store immutable references to WHERE clause expressions in `Resolver`, but this is unfortunately not possible if we still use the aforementioned mutable references.

Hence, we can temporarily make `WhereTerm::consumed` a `Cell<bool>` which allows us to pass an immutable reference to `init_loop()`, and the `Cell` can be removed once the virtual table constraint resolution is moved to an earlier part of the query processing pipeline.