### PR TITLE
clear page cache on transaction failure

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -531,7 +531,7 @@ impl Connection {
     }
 
     pub fn checkpoint(&self) -> Result<CheckpointResult> {
-        let checkpoint_result = self.pager.clear_page_cache();
+        let checkpoint_result = self.pager.wal_checkpoint();
         Ok(checkpoint_result)
     }
 

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -474,8 +474,6 @@ impl DumbLruPageCache {
         );
     }
 
-    #[cfg(test)]
-    /// For testing purposes, in case we use cursor api directly, we might want to unmark pages as dirty because we bypass the WAL transaction layer
     pub fn unset_dirty_all_pages(&mut self) {
         for node in self.map.borrow_mut().iter_mut() {
             unsafe {
@@ -572,7 +570,6 @@ impl PageHashMap {
         self.buckets.iter().flat_map(|bucket| bucket.iter())
     }
 
-    #[cfg(test)]
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut HashMapNode> {
         self.buckets.iter_mut().flat_map(|bucket| bucket.iter_mut())
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1641,6 +1641,10 @@ pub fn op_halt(
     else {
         unreachable!("unexpected Insn {:?}", insn)
     };
+    if *err_code > 0 {
+        // invalidate page cache in case of error
+        pager.clear_page_cache();
+    }
     match *err_code {
         0 => {}
         SQLITE_CONSTRAINT_PRIMARYKEY => {

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -269,7 +269,6 @@ fn test_wal_checkpoint() -> anyhow::Result<()> {
     }
 
     do_flush(&conn, &tmp_db)?;
-    conn.clear_page_cache()?;
     let list_query = "SELECT * FROM test LIMIT 1";
     let mut current_index = 0;
     run_query_on_row(&tmp_db, &conn, list_query, |row: &Row| {


### PR DESCRIPTION
This is the first step towards rollback, since we still don't spill pages with WAL, we can simply invalidate page cache in case of failure.