### PR TITLE
Reverse Parse Limbo `ast` and Plans

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -39,10 +39,10 @@ pub fn optimize_plan(plan: &mut Plan, schema: &Schema) -> Result<()> {
     match plan {
         Plan::Select(plan) => {
             optimize_select_plan(plan, schema)?;
+            // Context for everything is created inside the plan
             tracing::debug!(
                 target = "optimized_plan",
-                plan = plan
-                    .to_sql_string(&crate::translate::plan::PlanContext(&plan.table_references))
+                plan = plan.to_sql_string(&crate::translate::plan::PlanContext(&[]))
             );
         }
         Plan::Delete(plan) => optimize_delete_plan(plan, schema)?,

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -37,14 +37,7 @@ pub(crate) mod order;
 
 pub fn optimize_plan(plan: &mut Plan, schema: &Schema) -> Result<()> {
     match plan {
-        Plan::Select(plan) => {
-            optimize_select_plan(plan, schema)?;
-            // Context for everything is created inside the plan
-            tracing::debug!(
-                target = "optimized_plan",
-                plan = plan.to_sql_string(&crate::translate::plan::PlanContext(&[]))
-            );
-        }
+        Plan::Select(plan) => optimize_select_plan(plan, schema)?,
         Plan::Delete(plan) => optimize_delete_plan(plan, schema)?,
         Plan::Update(plan) => optimize_update_plan(plan, schema)?,
         Plan::CompoundSelect { first, rest, .. } => {
@@ -54,6 +47,11 @@ pub fn optimize_plan(plan: &mut Plan, schema: &Schema) -> Result<()> {
             }
         }
     }
+    // Context for everything is created inside the plan
+    tracing::debug!(
+        target = "optimized_plan",
+        plan = plan.to_sql_string(&crate::translate::plan::PlanContext(&[]))
+    );
     Ok(())
 }
 

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -6,7 +6,10 @@ use constraints::{
 use cost::Cost;
 use join::{compute_best_join_order, BestJoinOrderResult};
 use lift_common_subexpressions::lift_common_subexpressions_from_binary_or_terms;
-use limbo_sqlite3_parser::ast::{self, Expr, SortOrder};
+use limbo_sqlite3_parser::{
+    ast::{self, Expr, SortOrder},
+    to_sql_string::ToSqlString,
+};
 use order::{compute_order_target, plan_satisfies_order_target, EliminatesSort};
 
 use crate::{
@@ -34,17 +37,24 @@ pub(crate) mod order;
 
 pub fn optimize_plan(plan: &mut Plan, schema: &Schema) -> Result<()> {
     match plan {
-        Plan::Select(plan) => optimize_select_plan(plan, schema),
-        Plan::Delete(plan) => optimize_delete_plan(plan, schema),
-        Plan::Update(plan) => optimize_update_plan(plan, schema),
+        Plan::Select(plan) => {
+            optimize_select_plan(plan, schema)?;
+            tracing::debug!(
+                target = "optimized_plan",
+                plan = plan
+                    .to_sql_string(&crate::translate::plan::PlanContext(&plan.table_references))
+            );
+        }
+        Plan::Delete(plan) => optimize_delete_plan(plan, schema)?,
+        Plan::Update(plan) => optimize_update_plan(plan, schema)?,
         Plan::CompoundSelect { first, rest, .. } => {
             optimize_select_plan(first, schema)?;
             for (plan, _) in rest {
                 optimize_select_plan(plan, schema)?;
             }
-            Ok(())
         }
     }
+    Ok(())
 }
 
 /**

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -47,10 +47,10 @@ pub fn optimize_plan(plan: &mut Plan, schema: &Schema) -> Result<()> {
             }
         }
     }
-    // Context for everything is created inside the plan
+    // Context for everything is created with values inside the plan
     tracing::debug!(
         target = "optimized_plan",
-        plan = plan.to_sql_string(&crate::translate::plan::PlanContext(&[]))
+        plan_sql = plan.to_sql_string(&crate::translate::plan::PlanContext(&[]))
     );
     Ok(())
 }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -52,6 +52,11 @@ pub fn optimize_plan(plan: &mut Plan, schema: &Schema) -> Result<()> {
         target = "optimized_plan",
         plan_sql = plan.to_sql_string(&crate::translate::plan::PlanContext(&[]))
     );
+    dbg!(&plan);
+    println!(
+        "{}",
+        plan.to_sql_string(&crate::translate::plan::PlanContext(&[]))
+    );
     Ok(())
 }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1420,12 +1420,10 @@ impl ToSqlContext for PlanContext<'_> {
 }
 
 impl ToSqlString for Plan {
-    fn to_sql_string<C: ToSqlContext>(&self, _context: &C) -> String {
+    fn to_sql_string<C: ToSqlContext>(&self, context: &C) -> String {
         // Make the Plans pass their own context
         match self {
-            Self::Select(select) => select.to_sql_string(&PlanContext(
-                &select.table_references.iter().collect::<Vec<_>>(),
-            )),
+            Self::Select(select) => select.to_sql_string(context),
             Self::CompoundSelect {
                 first,
                 rest,
@@ -1473,6 +1471,7 @@ impl ToSqlString for Plan {
                 }
                 ret.join(" ")
             }
+            Self::Delete(delete) => delete.to_sql_string(context),
             _ => todo!(),
         }
     }
@@ -1514,12 +1513,15 @@ impl ToSqlString for TableReference {
     }
 }
 
-// TODO: currently cannot print the original CTE as it is
+// TODO: currently cannot print the original CTE as it is optimized into a subquery
 impl ToSqlString for SelectPlan {
     fn to_sql_string<C: limbo_sqlite3_parser::to_sql_string::ToSqlContext>(
         &self,
-        context: &C,
+        _context: &C,
     ) -> String {
+        let context = self.table_references.iter().collect::<Vec<_>>();
+        let context = &PlanContext(&context);
+
         let mut ret = Vec::new();
         // VALUES SELECT statement
         if !self.values.is_empty() {
@@ -1607,6 +1609,52 @@ impl ToSqlString for SelectPlan {
                     );
                 }
             }
+        }
+        if let Some(order_by) = &self.order_by {
+            ret.push(format!(
+                "ORDER BY {}",
+                order_by
+                    .iter()
+                    .map(|(expr, order)| format!(
+                        "{} {}",
+                        expr.to_sql_string(context),
+                        order.to_sql_string(context)
+                    ))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        if let Some(limit) = &self.limit {
+            ret.push(format!("LIMIT {}", limit));
+        }
+        if let Some(offset) = &self.offset {
+            ret.push(format!("OFFSET {}", offset));
+        }
+        ret.join(" ")
+    }
+}
+
+impl ToSqlString for DeletePlan {
+    fn to_sql_string<C: ToSqlContext>(&self, _context: &C) -> String {
+        let table_ref = self
+            .table_references
+            .first()
+            .expect("Delete Plan should have only one table reference");
+        let context = &[table_ref];
+        let context = &PlanContext(context);
+        let mut ret = Vec::new();
+
+        ret.push(format!("DELETE FROM {}", table_ref.table.get_name()));
+
+        if !self.where_clause.is_empty() {
+            ret.push("WHERE".to_string());
+            ret.push(
+                self.where_clause
+                    .iter()
+                    .map(|where_clause| where_clause.expr.to_sql_string(context))
+                    .collect::<Vec<_>>()
+                    .join(" AND "),
+            );
         }
         if let Some(order_by) = &self.order_by {
             ret.push(format!(

--- a/vendored/sqlite3-parser/src/lib.rs
+++ b/vendored/sqlite3-parser/src/lib.rs
@@ -6,3 +6,4 @@ pub mod dialect;
 pub mod lexer;
 mod parser;
 pub use parser::ast;
+pub mod to_sql_string;

--- a/vendored/sqlite3-parser/src/to_sql_string/expr.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/expr.rs
@@ -408,3 +408,6 @@ impl ToSqlString for ast::UnaryOperator {
         .to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {}

--- a/vendored/sqlite3-parser/src/to_sql_string/expr.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/expr.rs
@@ -1,0 +1,410 @@
+use crate::ast::{self, Expr};
+
+use super::ToSqlString;
+
+impl ToSqlString for Expr {
+    fn to_sql_string<C: super::ToSqlContext>(&self, context: &C) -> String {
+        let mut ret = String::new();
+        match self {
+            Expr::Between {
+                lhs,
+                not,
+                start,
+                end,
+            } => {
+                ret.push_str(&lhs.to_sql_string(context));
+                ret.push(' ');
+
+                if *not {
+                    ret.push_str("NOT ");
+                }
+
+                ret.push_str("BETWEEN ");
+
+                ret.push_str(&start.to_sql_string(context));
+
+                ret.push_str(" AND ");
+
+                ret.push_str(&end.to_sql_string(context));
+            }
+            Expr::Binary(lhs, op, rhs) => {
+                ret.push_str(&lhs.to_sql_string(context));
+                ret.push(' ');
+                ret.push_str(&op.to_sql_string(context));
+                ret.push(' ');
+                ret.push_str(&rhs.to_sql_string(context));
+            }
+            Expr::Case {
+                base,
+                when_then_pairs,
+                else_expr,
+            } => {
+                ret.push_str("CASE ");
+                if let Some(base) = base {
+                    ret.push_str(&base.to_sql_string(context));
+                }
+                for (when, then) in when_then_pairs {
+                    ret.push_str(" WHEN ");
+                    ret.push_str(&when.to_sql_string(context));
+                    ret.push_str(" THEN ");
+                    ret.push_str(&then.to_sql_string(context));
+                }
+                if let Some(else_expr) = else_expr {
+                    ret.push_str(" ELSE ");
+                    ret.push_str(&else_expr.to_sql_string(context));
+                }
+                ret.push_str(" END");
+            }
+            Expr::Cast { expr, type_name } => {
+                ret.push_str("CAST");
+                ret.push('(');
+                ret.push_str(&expr.to_sql_string(context));
+                if let Some(type_name) = type_name {
+                    ret.push_str(" AS ");
+                    ret.push_str(&type_name.to_sql_string(context));
+                }
+                ret.push(')');
+            }
+            Expr::Collate(expr, name) => {
+                ret.push_str(&expr.to_sql_string(context));
+                ret.push_str(" COLLATE ");
+                ret.push_str(&name);
+            }
+            Expr::DoublyQualified(name, name1, name2) => {
+                ret.push_str(&name.0);
+                ret.push('.');
+                ret.push_str(&name1.0);
+                ret.push('.');
+                ret.push_str(&name2.0);
+            }
+            Expr::Exists(select) => {
+                ret.push_str("EXISTS (");
+                ret.push_str(&select.to_sql_string(context));
+                ret.push(')');
+            }
+            Expr::FunctionCall {
+                name,
+                distinctness: _,
+                args,
+                order_by: _,
+                filter_over,
+            } => {
+                ret.push_str(&name.0);
+                // TODO: pretty sure there should be no ORDER_BY nor DISTINCT
+                ret.push('(');
+                if let Some(args) = args {
+                    let joined_args = args
+                        .iter()
+                        .map(|arg| arg.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    ret.push_str(&joined_args);
+                }
+                ret.push(')');
+                if let Some(filter_over) = filter_over {
+                    if let Some(filter) = &filter_over.filter_clause {
+                        ret.push_str(" FILTER (");
+                        ret.push_str("WHERE ");
+                        ret.push_str(&filter.to_sql_string(context));
+                        ret.push(')');
+                    }
+                    if let Some(_over) = &filter_over.over_clause {
+                        todo!()
+                    }
+                }
+            }
+            Expr::FunctionCallStar { name, filter_over } => {
+                ret.push_str(&name.0);
+                ret.push_str("(*)");
+                if let Some(filter_over) = filter_over {
+                    if let Some(filter) = &filter_over.filter_clause {
+                        ret.push_str(" FILTER (");
+                        ret.push_str("WHERE ");
+                        ret.push_str(&filter.to_sql_string(context));
+                        ret.push(')');
+                    }
+                    if let Some(_over) = &filter_over.over_clause {
+                        todo!()
+                    }
+                }
+            }
+            Expr::Id(id) => {
+                ret.push_str(&id.0);
+            }
+            Expr::Column {
+                database: _, // TODO: Ignore database for now
+                table,
+                column,
+                is_rowid_alias: _,
+            } => {
+                ret.push_str(context.get_table_name(*table));
+                ret.push('.');
+                ret.push_str(context.get_column_name(*table, *column));
+            }
+            // TODO: not sure how to rewrite this
+            Expr::RowId {
+                database: _,
+                table: _,
+            } => todo!(),
+            Expr::InList { lhs, not, rhs } => {
+                ret.push_str(&lhs.to_sql_string(context));
+                ret.push(' ');
+                if *not {
+                    ret.push_str("NOT ");
+                }
+                ret.push('(');
+                if let Some(rhs) = rhs {
+                    let joined_args = rhs
+                        .iter()
+                        .map(|expr| expr.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    ret.push_str(&joined_args);
+                }
+                ret.push(')');
+            }
+            Expr::InSelect { lhs, not, rhs } => {
+                ret.push_str(&lhs.to_sql_string(context));
+                ret.push(' ');
+                if *not {
+                    ret.push_str("NOT ");
+                }
+                ret.push('(');
+                ret.push_str(&rhs.to_sql_string(context));
+                ret.push(')');
+            }
+            Expr::InTable {
+                lhs,
+                not,
+                rhs,
+                args,
+            } => {
+                ret.push_str(&lhs.to_sql_string(context));
+                ret.push(' ');
+                if *not {
+                    ret.push_str("NOT ");
+                }
+                ret.push_str(&rhs.to_sql_string(context));
+
+                if let Some(args) = args {
+                    ret.push('(');
+                    let joined_args = args
+                        .iter()
+                        .map(|expr| expr.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    ret.push_str(&joined_args);
+                    ret.push(')');
+                }
+            }
+            Expr::IsNull(expr) => {
+                ret.push_str(&expr.to_sql_string(context));
+                ret.push_str(" ISNULL");
+            }
+            Expr::Like {
+                lhs,
+                not,
+                op,
+                rhs,
+                escape,
+            } => {
+                ret.push_str(&lhs.to_sql_string(context));
+                ret.push(' ');
+                if *not {
+                    ret.push_str("NOT ");
+                }
+                ret.push_str(&op.to_sql_string(context));
+                ret.push(' ');
+                ret.push_str(&rhs.to_sql_string(context));
+                if let Some(escape) = escape {
+                    ret.push_str(" ESCAPE ");
+                    ret.push_str(&escape.to_sql_string(context));
+                }
+            }
+            Expr::Literal(literal) => {
+                ret.push_str(&literal.to_sql_string(context));
+            }
+            Expr::Name(name) => {
+                ret.push_str(&name.0);
+            }
+            Expr::NotNull(expr) => {
+                ret.push_str(&expr.to_sql_string(context));
+                ret.push_str(" NOT NULL");
+            }
+            Expr::Parenthesized(exprs) => {
+                ret.push('(');
+                let joined_args = exprs
+                    .iter()
+                    .map(|expr| expr.to_sql_string(context))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                ret.push_str(&joined_args);
+                ret.push(')');
+            }
+            Expr::Qualified(name, name1) => {
+                ret.push_str(&name.0);
+                ret.push('.');
+                ret.push_str(&name1.0);
+            }
+            Expr::Raise(resolve_type, expr) => {
+                ret.push_str("RAISE (");
+                ret.push_str(&resolve_type.to_sql_string(context));
+                if let Some(expr) = expr {
+                    ret.push_str(", ");
+                    ret.push_str(&expr.to_sql_string(context));
+                }
+                ret.push(')');
+            }
+            Expr::Subquery(select) => {
+                ret.push('(');
+                ret.push_str(&select.to_sql_string(context));
+                ret.push(')');
+            }
+            Expr::Unary(unary_operator, expr) => {
+                ret.push_str(&unary_operator.to_sql_string(context));
+                ret.push(' ');
+                ret.push_str(&expr.to_sql_string(context));
+            }
+            Expr::Variable(variable) => {
+                ret.push_str(variable);
+            }
+        };
+        ret
+    }
+}
+
+impl ToSqlString for ast::Operator {
+    fn to_sql_string<C: super::ToSqlContext>(&self, _context: &C) -> String {
+        match self {
+            Self::Add => "+",
+            Self::And => "AND",
+            Self::ArrowRight => "->",
+            Self::ArrowRightShift => "->>",
+            Self::BitwiseAnd => "&",
+            Self::BitwiseNot => "~",
+            Self::BitwiseOr => "|",
+            Self::Concat => "||",
+            Self::Divide => "/",
+            Self::Equals => "==",
+            Self::Greater => ">",
+            Self::GreaterEquals => ">=",
+            Self::Is => "IS",
+            Self::IsNot => "IS NOT",
+            Self::LeftShift => "<<",
+            Self::Less => "<",
+            Self::LessEquals => "<=",
+            Self::Modulus => "%",
+            Self::Multiply => "*",
+            Self::NotEquals => "!=",
+            Self::Or => "OR",
+            Self::RightShift => ">>",
+            Self::Subtract => "-",
+        }
+        .to_string()
+    }
+}
+
+impl ToSqlString for ast::Type {
+    fn to_sql_string<C: super::ToSqlContext>(&self, context: &C) -> String {
+        let mut ret = self.name.clone();
+        ret.push(' ');
+        if let Some(size) = &self.size {
+            ret.push('(');
+            ret.push_str(&size.to_sql_string(context));
+            ret.push(')');
+        }
+        ret
+    }
+}
+
+impl ToSqlString for ast::TypeSize {
+    fn to_sql_string<C: super::ToSqlContext>(&self, context: &C) -> String {
+        let mut ret = String::new();
+        match self {
+            Self::MaxSize(e) => {
+                ret.push_str(&e.to_sql_string(context));
+            }
+            Self::TypeSize(lhs, rhs) => {
+                ret.push_str(&lhs.to_sql_string(context));
+                ret.push_str(", ");
+                ret.push_str(&rhs.to_sql_string(context));
+            }
+        };
+        ret
+    }
+}
+
+impl ToSqlString for ast::Distinctness {
+    fn to_sql_string<C: super::ToSqlContext>(&self, _context: &C) -> String {
+        match self {
+            Self::All => "ALL",
+            Self::Distinct => "DISTINCT",
+        }
+        .to_string()
+    }
+}
+
+impl ToSqlString for ast::QualifiedName {
+    fn to_sql_string<C: super::ToSqlContext>(&self, _context: &C) -> String {
+        let mut ret = String::new();
+        // TODO: skip DB Name
+        if let Some(alias) = &self.alias {
+            ret.push_str(&alias.0);
+            ret.push('.');
+        }
+        ret.push_str(&self.name.0);
+        ret
+    }
+}
+
+impl ToSqlString for ast::LikeOperator {
+    fn to_sql_string<C: super::ToSqlContext>(&self, _context: &C) -> String {
+        match self {
+            Self::Glob => "GLOB",
+            Self::Like => "LIKE",
+            Self::Match => "MATCH",
+            Self::Regexp => "REGEXP",
+        }
+        .to_string()
+    }
+}
+
+impl ToSqlString for ast::Literal {
+    fn to_sql_string<C: super::ToSqlContext>(&self, _context: &C) -> String {
+        match self {
+            Self::Blob(b) => format!("Ox{b}"),
+            Self::CurrentDate => "CURRENT_DATE".to_string(),
+            Self::CurrentTime => "CURRENT_TIME".to_string(),
+            Self::CurrentTimestamp => "CURRENT_TIMESTAMP".to_string(),
+            Self::Keyword(keyword) => keyword.clone(),
+            Self::Null => "NULL".to_string(),
+            Self::Numeric(num) => num.clone(),
+            Self::String(s) => s.clone(),
+        }
+    }
+}
+
+impl ToSqlString for ast::ResolveType {
+    fn to_sql_string<C: super::ToSqlContext>(&self, _context: &C) -> String {
+        match self {
+            Self::Abort => "ABORT",
+            Self::Fail => "FAIL",
+            Self::Ignore => "IGNORE",
+            Self::Replace => "REPLACE",
+            Self::Rollback => "ROLLBACK",
+        }
+        .to_string()
+    }
+}
+
+impl ToSqlString for ast::UnaryOperator {
+    fn to_sql_string<C: super::ToSqlContext>(&self, _context: &C) -> String {
+        match self {
+            Self::BitwiseNot => "~",
+            Self::Negative => "-",
+            Self::Not => "NOT",
+            Self::Positive => "+",
+        }
+        .to_string()
+    }
+}

--- a/vendored/sqlite3-parser/src/to_sql_string/expr.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/expr.rs
@@ -285,7 +285,7 @@ impl ToSqlString for ast::Operator {
             Self::BitwiseOr => "|",
             Self::Concat => "||",
             Self::Divide => "/",
-            Self::Equals => "==",
+            Self::Equals => "=",
             Self::Greater => ">",
             Self::GreaterEquals => ">=",
             Self::Is => "IS",

--- a/vendored/sqlite3-parser/src/to_sql_string/expr.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/expr.rs
@@ -246,7 +246,7 @@ impl ToSqlString for Expr {
                 ret.push_str(&name1.0);
             }
             Expr::Raise(resolve_type, expr) => {
-                ret.push_str("RAISE (");
+                ret.push_str("RAISE(");
                 ret.push_str(&resolve_type.to_sql_string(context));
                 if let Some(expr) = expr {
                     ret.push_str(", ");

--- a/vendored/sqlite3-parser/src/to_sql_string/expr.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/expr.rs
@@ -306,8 +306,8 @@ impl ToSqlString for ast::Operator {
 impl ToSqlString for ast::Type {
     fn to_sql_string<C: super::ToSqlContext>(&self, context: &C) -> String {
         let mut ret = self.name.clone();
-        ret.push(' ');
         if let Some(size) = &self.size {
+            ret.push(' ');
             ret.push('(');
             ret.push_str(&size.to_sql_string(context));
             ret.push(')');
@@ -346,7 +346,10 @@ impl ToSqlString for ast::Distinctness {
 impl ToSqlString for ast::QualifiedName {
     fn to_sql_string<C: super::ToSqlContext>(&self, _context: &C) -> String {
         let mut ret = String::new();
-        // TODO: skip DB Name
+        if let Some(db_name) = &self.db_name {
+            ret.push_str(&db_name.0);
+            ret.push('.');
+        }
         if let Some(alias) = &self.alias {
             ret.push_str(&alias.0);
             ret.push('.');

--- a/vendored/sqlite3-parser/src/to_sql_string/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/mod.rs
@@ -26,3 +26,20 @@ impl<T: ToSqlString> ToSqlString for Box<T> {
         T::to_sql_string(&self, context)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToSqlContext;
+
+    struct TestContext;
+
+    impl ToSqlContext for TestContext {
+        fn get_column_name(&self, _table_id: crate::ast::TableInternalId, _col_idx: usize) -> &str {
+            "placeholder_column"
+        }
+
+        fn get_table_name(&self, _id: crate::ast::TableInternalId) -> &str {
+            "placeholder_table"
+        }
+    }
+}

--- a/vendored/sqlite3-parser/src/to_sql_string/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/mod.rs
@@ -1,16 +1,19 @@
 //! ToSqlString trait definition and implementations
 
+mod stmt;
+
 use crate::ast::TableInternalId;
 
 /// Context to be used in ToSqlString
 pub trait ToSqlContext {
     /// Given an id, get the table name
-    /// Currently not considering alias
+    ///
+    /// Currently not considering aliases
     fn get_table_name(&self, id: TableInternalId) -> &str;
 }
 
 /// Trait to convert an ast to a string
-pub trait ToSqlString<C: ToSqlContext> {
+pub trait ToSqlString {
     /// Convert the given value to String
-    fn to_sql_string(&self, context: &C) -> String;
+    fn to_sql_string<C: ToSqlContext>(&self, context: &C) -> String;
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/mod.rs
@@ -1,5 +1,6 @@
 //! ToSqlString trait definition and implementations
 
+mod expr;
 mod stmt;
 
 use crate::ast::TableInternalId;
@@ -10,10 +11,18 @@ pub trait ToSqlContext {
     ///
     /// Currently not considering aliases
     fn get_table_name(&self, id: TableInternalId) -> &str;
+    /// Given a table id and a column index, get the column name
+    fn get_column_name(&self, table_id: TableInternalId, col_idx: usize) -> &str;
 }
 
 /// Trait to convert an ast to a string
 pub trait ToSqlString {
     /// Convert the given value to String
     fn to_sql_string<C: ToSqlContext>(&self, context: &C) -> String;
+}
+
+impl<T: ToSqlString> ToSqlString for Box<T> {
+    fn to_sql_string<C: ToSqlContext>(&self, context: &C) -> String {
+        T::to_sql_string(&self, context)
+    }
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/mod.rs
@@ -1,0 +1,16 @@
+//! ToSqlString trait definition and implementations
+
+use crate::ast::TableInternalId;
+
+/// Context to be used in ToSqlString
+pub trait ToSqlContext {
+    /// Given an id, get the table name
+    /// Currently not considering alias
+    fn get_table_name(&self, id: TableInternalId) -> &str;
+}
+
+/// Trait to convert an ast to a string
+pub trait ToSqlString<C: ToSqlContext> {
+    /// Convert the given value to String
+    fn to_sql_string(&self, context: &C) -> String;
+}

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
@@ -65,7 +65,7 @@ impl ToSqlString for ast::ColumnConstraint {
                 clause,
                 deref_clause,
             } => format!(
-                "FOREIGN KEY {}{}",
+                "{}{}",
                 clause.to_sql_string(context),
                 if let Some(deref) = deref_clause {
                     deref.to_sql_string(context)
@@ -214,71 +214,71 @@ mod tests {
 
     to_sql_string_test!(
         test_alter_table_rename,
-        "ALTER TABLE t RENAME TO new_table_name"
+        "ALTER TABLE t RENAME TO new_table_name;"
     );
 
     to_sql_string_test!(
         test_alter_table_add_column,
-        "ALTER TABLE t ADD COLUMN c INTEGER"
+        "ALTER TABLE t ADD COLUMN c INTEGER;"
     );
 
     to_sql_string_test!(
         test_alter_table_add_column_with_default,
-        "ALTER TABLE t ADD COLUMN c TEXT DEFAULT 'value'"
+        "ALTER TABLE t ADD COLUMN c TEXT DEFAULT 'value';"
     );
 
     to_sql_string_test!(
         test_alter_table_add_column_not_null_default,
-        "ALTER TABLE t ADD COLUMN c REAL NOT NULL DEFAULT 0.0"
+        "ALTER TABLE t ADD COLUMN c REAL NOT NULL DEFAULT 0.0;"
     );
 
     to_sql_string_test!(
         test_alter_table_add_column_unique,
         "ALTER TABLE t ADD COLUMN c TEXT UNIQUE",
-        ignore = "ParserError = Cannot add a UNIQUE column"
+        ignore = "ParserError = Cannot add a UNIQUE column;"
     );
 
     to_sql_string_test!(
         test_alter_table_rename_column,
-        "ALTER TABLE t RENAME COLUMN old_name TO new_name"
+        "ALTER TABLE t RENAME COLUMN old_name TO new_name;"
     );
 
-    to_sql_string_test!(test_alter_table_drop_column, "ALTER TABLE t DROP COLUMN c");
+    to_sql_string_test!(test_alter_table_drop_column, "ALTER TABLE t DROP COLUMN c;");
 
     to_sql_string_test!(
         test_alter_table_add_column_check,
-        "ALTER TABLE t ADD COLUMN c INTEGER CHECK (c > 0)"
+        "ALTER TABLE t ADD COLUMN c INTEGER CHECK (c > 0);"
     );
 
     to_sql_string_test!(
         test_alter_table_add_column_foreign_key,
-        "ALTER TABLE t ADD COLUMN c INTEGER REFERENCES t2(id) ON DELETE CASCADE"
+        "ALTER TABLE t ADD COLUMN c INTEGER REFERENCES t2(id) ON DELETE CASCADE;"
     );
 
     to_sql_string_test!(
         test_alter_table_add_column_collate,
-        "ALTER TABLE t ADD COLUMN c TEXT COLLATE NOCASE"
+        "ALTER TABLE t ADD COLUMN c TEXT COLLATE NOCASE;"
     );
 
     to_sql_string_test!(
         test_alter_table_add_column_primary_key,
-        "ALTER TABLE t ADD COLUMN c INTEGER PRIMARY KEY",
+        "ALTER TABLE t ADD COLUMN c INTEGER PRIMARY KEY;",
         ignore = "ParserError = Cannot add a PRIMARY KEY column"
     );
 
     to_sql_string_test!(
         test_alter_table_add_column_primary_key_autoincrement,
-        "ALTER TABLE t ADD COLUMN c INTEGER PRIMARY KEY AUTOINCREMENT",
+        "ALTER TABLE t ADD COLUMN c INTEGER PRIMARY KEY AUTOINCREMENT;",
         ignore = "ParserError = Cannot add a PRIMARY KEY column"
     );
 
     to_sql_string_test!(
         test_alter_table_add_generated_column,
-        "ALTER TABLE t ADD COLUMN c_generated AS (a + b) STORED"
+        "ALTER TABLE t ADD COLUMN c_generated AS (a + b) STORED;"
     );
 
     to_sql_string_test!(
         test_alter_table_add_column_schema,
-        "ALTER TABLE schema_name.t ADD COLUMN c INTEGER"
+        "ALTER TABLE schema_name.t ADD COLUMN c INTEGER;"
     );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
@@ -41,7 +41,7 @@ impl ToSqlString for ast::NamedColumnConstraint {
     fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
         let mut ret = Vec::new();
         if let Some(name) = &self.name {
-            ret.push(format!("CONSTRAINT {} ", name.0));
+            ret.push(format!("CONSTRAINT {}", name.0));
         }
         ret.push(self.constraint.to_sql_string(context));
         ret.join(" ")
@@ -104,7 +104,7 @@ impl ToSqlString for ast::ColumnConstraint {
                 auto_increment,
             } => {
                 format!(
-                    "PRIMARY KEY {}{}{}",
+                    "PRIMARY KEY{}{}{}",
                     order.map_or("".to_string(), |order| format!(
                         " {}",
                         order.to_sql_string(context)

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
@@ -1,0 +1,202 @@
+use crate::{ast, to_sql_string::ToSqlString};
+
+impl ToSqlString for ast::AlterTableBody {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        match self {
+            Self::AddColumn(col_def) => format!("ADD COLUMN {}", col_def.to_sql_string(context)),
+            Self::DropColumn(name) => format!("DROP COLUMN {}", name.0),
+            Self::RenameColumn { old, new } => format!("RENAME COLUMN {} TO {}", old.0, new.0),
+            Self::RenameTo(name) => format!("RENAME TO {}", name.0),
+        }
+    }
+}
+
+impl ToSqlString for ast::ColumnDefinition {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        format!(
+            "{}{}{}",
+            self.col_name.0,
+            if let Some(col_type) = &self.col_type {
+                format!(" {}", col_type.to_sql_string(context))
+            } else {
+                "".to_string()
+            },
+            if !self.constraints.is_empty() {
+                self.constraints
+                    .iter()
+                    .map(|constraint| constraint.to_sql_string(context))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            } else {
+                "".to_string()
+            }
+        )
+    }
+}
+
+impl ToSqlString for ast::NamedColumnConstraint {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        let mut ret = Vec::new();
+        if let Some(name) = &self.name {
+            ret.push(format!("CONSTRAINT {}", name.0));
+        }
+        ret.push(self.constraint.to_sql_string(context));
+        ret.join(" ")
+    }
+}
+
+impl ToSqlString for ast::ColumnConstraint {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        match self {
+            Self::Check(expr) => format!("CHECK ({})", expr.to_sql_string(context)),
+            Self::Collate { collation_name } => format!("COLLATE {}", collation_name.0),
+            Self::Default(expr) => {
+                if matches!(expr, ast::Expr::Literal(..)) {
+                    format!("DEFAULT {}", expr.to_sql_string(context))
+                } else {
+                    format!("DEFAULT ({})", expr.to_sql_string(context))
+                }
+            }
+            Self::Defer(expr) => expr.to_sql_string(context),
+            Self::ForeignKey {
+                clause,
+                deref_clause,
+            } => format!(
+                "{}{}",
+                clause.to_sql_string(context),
+                if let Some(deref) = deref_clause {
+                    deref.to_sql_string(context)
+                } else {
+                    "".to_string()
+                }
+            ),
+            Self::Generated { expr, typ } => {
+                format!(
+                    "GENERATED ALWAYS AS ({}){}",
+                    expr.to_sql_string(context),
+                    if let Some(typ) = typ { &typ.0 } else { "" }
+                )
+            }
+            Self::NotNull {
+                nullable: _,
+                conflict_clause,
+            } => {
+                // nullable should always be true here
+                format!(
+                    "NOT NULL{}",
+                    conflict_clause.map_or("".to_string(), |conflict| format!(
+                        " {}",
+                        conflict.to_sql_string(context)
+                    ))
+                )
+            }
+            Self::PrimaryKey {
+                order,
+                conflict_clause,
+                auto_increment,
+            } => {
+                format!(
+                    "PRIMARY KEY {}{}{}",
+                    order.map_or("".to_string(), |order| format!(
+                        " {}",
+                        order.to_sql_string(context)
+                    )),
+                    conflict_clause.map_or("".to_string(), |conflict| format!(
+                        " {}",
+                        conflict.to_sql_string(context)
+                    )),
+                    auto_increment.then_some(" AUTOINCREMENT").unwrap_or("")
+                )
+            }
+            Self::Unique(conflict_clause) => {
+                format!(
+                    "UNIQUE{}",
+                    conflict_clause.map_or("".to_string(), |conflict| format!(
+                        " {}",
+                        conflict.to_sql_string(context)
+                    ))
+                )
+            }
+        }
+    }
+}
+
+impl ToSqlString for ast::ForeignKeyClause {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        format!(
+            "REFERENCES {}{}{}",
+            self.tbl_name.0,
+            if let Some(columns) = &self.columns {
+                format!(
+                    " ({})",
+                    columns
+                        .iter()
+                        .map(|cols| cols.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            } else {
+                "".to_string()
+            },
+            if !self.args.is_empty() {
+                format!(
+                    " {}",
+                    self.args
+                        .iter()
+                        .map(|arg| arg.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                )
+            } else {
+                "".to_string()
+            }
+        )
+    }
+}
+
+impl ToSqlString for ast::RefArg {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        match self {
+            Self::Match(name) => format!("MATCH {}", name.0),
+            Self::OnDelete(act) => format!("ON DELETE {}", act.to_sql_string(context)),
+            Self::OnUpdate(act) => format!("ON UPDATE {}", act.to_sql_string(context)),
+            Self::OnInsert(..) => unimplemented!(
+                "On Insert does not exist in SQLite: https://www.sqlite.org/lang_altertable.html"
+            ),
+        }
+    }
+}
+
+impl ToSqlString for ast::RefAct {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, _context: &C) -> String {
+        match self {
+            Self::Cascade => "CASCADE",
+            Self::NoAction => "NO ACTION",
+            Self::Restrict => "RESTRICT",
+            Self::SetDefault => "SET DEFAULT",
+            Self::SetNull => "SET NULL",
+        }
+        .to_string()
+    }
+}
+
+impl ToSqlString for ast::DeferSubclause {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, _context: &C) -> String {
+        format!(
+            "{}{}",
+            if self.deferrable {
+                "NOT DEFERRABLE"
+            } else {
+                "DEFERRABLE"
+            },
+            if let Some(init_deffered) = &self.init_deferred {
+                match init_deffered {
+                    ast::InitDeferredPred::InitiallyDeferred => " INITIALLY DEFERRED",
+                    ast::InitDeferredPred::InitiallyImmediate => " INITIALLY IMMEDIATE",
+                }
+            } else {
+                ""
+            }
+        )
+    }
+}

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
@@ -22,11 +22,14 @@ impl ToSqlString for ast::ColumnDefinition {
                 "".to_string()
             },
             if !self.constraints.is_empty() {
-                self.constraints
-                    .iter()
-                    .map(|constraint| constraint.to_sql_string(context))
-                    .collect::<Vec<_>>()
-                    .join(" ")
+                format!(
+                    " {}",
+                    self.constraints
+                        .iter()
+                        .map(|constraint| constraint.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                )
             } else {
                 "".to_string()
             }
@@ -38,7 +41,7 @@ impl ToSqlString for ast::NamedColumnConstraint {
     fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
         let mut ret = Vec::new();
         if let Some(name) = &self.name {
-            ret.push(format!("CONSTRAINT {}", name.0));
+            ret.push(format!("CONSTRAINT {} ", name.0));
         }
         ret.push(self.constraint.to_sql_string(context));
         ret.join(" ")
@@ -71,10 +74,15 @@ impl ToSqlString for ast::ColumnConstraint {
                 }
             ),
             Self::Generated { expr, typ } => {
+                // Don't need to add the generated part
                 format!(
-                    "GENERATED ALWAYS AS ({}){}",
+                    "AS ({}){}",
                     expr.to_sql_string(context),
-                    if let Some(typ) = typ { &typ.0 } else { "" }
+                    if let Some(typ) = typ {
+                        format!(" {}", &typ.0)
+                    } else {
+                        "".to_string()
+                    }
                 )
             }
             Self::NotNull {
@@ -128,7 +136,7 @@ impl ToSqlString for ast::ForeignKeyClause {
             self.tbl_name.0,
             if let Some(columns) = &self.columns {
                 format!(
-                    " ({})",
+                    "({})",
                     columns
                         .iter()
                         .map(|cols| cols.to_sql_string(context))
@@ -199,4 +207,78 @@ impl ToSqlString for ast::DeferSubclause {
             }
         )
     }
+}
+#[cfg(test)]
+mod tests {
+    use crate::to_sql_string_test;
+
+    to_sql_string_test!(
+        test_alter_table_rename,
+        "ALTER TABLE t RENAME TO new_table_name"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_column,
+        "ALTER TABLE t ADD COLUMN c INTEGER"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_column_with_default,
+        "ALTER TABLE t ADD COLUMN c TEXT DEFAULT 'value'"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_column_not_null_default,
+        "ALTER TABLE t ADD COLUMN c REAL NOT NULL DEFAULT 0.0"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_column_unique,
+        "ALTER TABLE t ADD COLUMN c TEXT UNIQUE",
+        ignore = "ParserError = Cannot add a UNIQUE column"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_rename_column,
+        "ALTER TABLE t RENAME COLUMN old_name TO new_name"
+    );
+
+    to_sql_string_test!(test_alter_table_drop_column, "ALTER TABLE t DROP COLUMN c");
+
+    to_sql_string_test!(
+        test_alter_table_add_column_check,
+        "ALTER TABLE t ADD COLUMN c INTEGER CHECK (c > 0)"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_column_foreign_key,
+        "ALTER TABLE t ADD COLUMN c INTEGER REFERENCES t2(id) ON DELETE CASCADE"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_column_collate,
+        "ALTER TABLE t ADD COLUMN c TEXT COLLATE NOCASE"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_column_primary_key,
+        "ALTER TABLE t ADD COLUMN c INTEGER PRIMARY KEY",
+        ignore = "ParserError = Cannot add a PRIMARY KEY column"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_column_primary_key_autoincrement,
+        "ALTER TABLE t ADD COLUMN c INTEGER PRIMARY KEY AUTOINCREMENT",
+        ignore = "ParserError = Cannot add a PRIMARY KEY column"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_generated_column,
+        "ALTER TABLE t ADD COLUMN c_generated AS (a + b) STORED"
+    );
+
+    to_sql_string_test!(
+        test_alter_table_add_column_schema,
+        "ALTER TABLE schema_name.t ADD COLUMN c INTEGER"
+    );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/alter_table.rs
@@ -65,7 +65,7 @@ impl ToSqlString for ast::ColumnConstraint {
                 clause,
                 deref_clause,
             } => format!(
-                "{}{}",
+                "FOREIGN KEY {}{}",
                 clause.to_sql_string(context),
                 if let Some(deref) = deref_clause {
                     deref.to_sql_string(context)

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/create_table.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/create_table.rs
@@ -124,118 +124,118 @@ mod tests {
 
     to_sql_string_test!(
         test_create_table_simple,
-        "CREATE TABLE t (a INTEGER, b TEXT)"
+        "CREATE TABLE t (a INTEGER, b TEXT);"
     );
 
     to_sql_string_test!(
         test_create_table_primary_key,
-        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT);"
     );
 
     to_sql_string_test!(
         test_create_table_multi_primary_key,
-        "CREATE TABLE t (a INTEGER, b TEXT, PRIMARY KEY (a, b))"
+        "CREATE TABLE t (a INTEGER, b TEXT, PRIMARY KEY (a, b));"
     );
 
     to_sql_string_test!(
         test_create_table_data_types,
-        "CREATE TABLE t (a INTEGER, b TEXT, c REAL, d BLOB, e NUMERIC)"
+        "CREATE TABLE t (a INTEGER, b TEXT, c REAL, d BLOB, e NUMERIC);"
     );
 
     to_sql_string_test!(
         test_create_table_foreign_key,
-        "CREATE TABLE t2 (id INTEGER PRIMARY KEY, t_id INTEGER, FOREIGN KEY (t_id) REFERENCES t(id))"
+        "CREATE TABLE t2 (id INTEGER PRIMARY KEY, t_id INTEGER, FOREIGN KEY (t_id) REFERENCES t(id));"
     );
 
     to_sql_string_test!(
         test_create_table_foreign_key_cascade,
-        "CREATE TABLE t2 (id INTEGER PRIMARY KEY, t_id INTEGER, FOREIGN KEY (t_id) REFERENCES t(id) ON DELETE CASCADE)"
+        "CREATE TABLE t2 (id INTEGER PRIMARY KEY, t_id INTEGER, FOREIGN KEY (t_id) REFERENCES t(id) ON DELETE CASCADE);"
     );
 
     to_sql_string_test!(
         test_create_table_unique,
-        "CREATE TABLE t (a INTEGER UNIQUE, b TEXT)"
+        "CREATE TABLE t (a INTEGER UNIQUE, b TEXT);"
     );
 
     to_sql_string_test!(
         test_create_table_not_null,
-        "CREATE TABLE t (a INTEGER NOT NULL, b TEXT)"
+        "CREATE TABLE t (a INTEGER NOT NULL, b TEXT);"
     );
 
     to_sql_string_test!(
         test_create_table_check,
-        "CREATE TABLE t (a INTEGER CHECK (a > 0), b TEXT)"
+        "CREATE TABLE t (a INTEGER CHECK (a > 0), b TEXT);"
     );
 
     to_sql_string_test!(
         test_create_table_default,
-        "CREATE TABLE t (a INTEGER DEFAULT 0, b TEXT)"
+        "CREATE TABLE t (a INTEGER DEFAULT 0, b TEXT);"
     );
 
     to_sql_string_test!(
         test_create_table_multiple_constraints,
-        "CREATE TABLE t (a INTEGER NOT NULL UNIQUE, b TEXT DEFAULT 'default')"
+        "CREATE TABLE t (a INTEGER NOT NULL UNIQUE, b TEXT DEFAULT 'default');"
     );
 
     to_sql_string_test!(
         test_create_table_generated_column,
-        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER AS (a + b))"
+        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER AS (a + b));"
     );
 
     to_sql_string_test!(
         test_create_table_generated_stored,
-        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER AS (a + b) STORED)"
+        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER AS (a + b) STORED);"
     );
 
     to_sql_string_test!(
         test_create_table_generated_virtual,
-        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER AS (a + b) VIRTUAL)"
+        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER AS (a + b) VIRTUAL);"
     );
 
     to_sql_string_test!(
         test_create_table_quoted_columns,
-        "CREATE TABLE t (\"select\" INTEGER, \"from\" TEXT)"
+        "CREATE TABLE t (\"select\" INTEGER, \"from\" TEXT);"
     );
 
     to_sql_string_test!(
         test_create_table_quoted_table,
-        "CREATE TABLE \"my table\" (a INTEGER)"
+        "CREATE TABLE \"my table\" (a INTEGER);"
     );
 
     to_sql_string_test!(
         test_create_table_if_not_exists,
-        "CREATE TABLE IF NOT EXISTS t (a INTEGER)"
+        "CREATE TABLE IF NOT EXISTS t (a INTEGER);"
     );
 
-    to_sql_string_test!(test_create_temp_table, "CREATE TEMP TABLE t (a INTEGER)");
+    to_sql_string_test!(test_create_temp_table, "CREATE TEMP TABLE t (a INTEGER);");
 
     to_sql_string_test!(
         test_create_table_without_rowid,
-        "CREATE TABLE t (a INTEGER PRIMARY KEY, b TEXT) WITHOUT ROWID"
+        "CREATE TABLE t (a INTEGER PRIMARY KEY, b TEXT) WITHOUT ROWID;"
     );
 
     to_sql_string_test!(
         test_create_table_named_primary_key,
-        "CREATE TABLE t (a INTEGER CONSTRAINT pk_a PRIMARY KEY)"
+        "CREATE TABLE t (a INTEGER CONSTRAINT pk_a PRIMARY KEY);"
     );
 
     to_sql_string_test!(
         test_create_table_named_unique,
-        "CREATE TABLE t (a INTEGER, CONSTRAINT unique_a UNIQUE (a))"
+        "CREATE TABLE t (a INTEGER, CONSTRAINT unique_a UNIQUE (a));"
     );
 
     to_sql_string_test!(
         test_create_table_named_foreign_key,
-        "CREATE TABLE t2 (id INTEGER, t_id INTEGER, CONSTRAINT fk_t FOREIGN KEY (t_id) REFERENCES t(id))"
+        "CREATE TABLE t2 (id INTEGER, t_id INTEGER, CONSTRAINT fk_t FOREIGN KEY (t_id) REFERENCES t(id));"
     );
 
     to_sql_string_test!(
         test_create_table_complex,
-        "CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER NOT NULL, b TEXT DEFAULT 'default', c INTEGER AS (a * 2), CONSTRAINT unique_a UNIQUE (a))"
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER NOT NULL, b TEXT DEFAULT 'default', c INTEGER AS (a * 2), CONSTRAINT unique_a UNIQUE (a));"
     );
 
     to_sql_string_test!(
         test_create_table_multiple_foreign_keys,
-        "CREATE TABLE t3 (id INTEGER PRIMARY KEY, t1_id INTEGER, t2_id INTEGER, FOREIGN KEY (t1_id) REFERENCES t1(id), FOREIGN KEY (t2_id) REFERENCES t2(id))"
+        "CREATE TABLE t3 (id INTEGER PRIMARY KEY, t1_id INTEGER, t2_id INTEGER, FOREIGN KEY (t1_id) REFERENCES t1(id), FOREIGN KEY (t2_id) REFERENCES t2(id));"
     );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/create_table.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/create_table.rs
@@ -10,7 +10,7 @@ impl ToSqlString for ast::CreateTableBody {
                 options,
             } => {
                 format!(
-                    "({}) {}{}",
+                    "({}{}){}",
                     columns
                         .iter()
                         .map(|(_, col)| col.to_sql_string(context))
@@ -19,7 +19,7 @@ impl ToSqlString for ast::CreateTableBody {
                     constraints
                         .as_ref()
                         .map_or("".to_string(), |constraints| format!(
-                            " {}",
+                            ", {}",
                             constraints
                                 .iter()
                                 .map(|constraint| constraint.to_sql_string(context))
@@ -36,7 +36,11 @@ impl ToSqlString for ast::CreateTableBody {
 impl ToSqlString for ast::NamedTableConstraint {
     fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
         if let Some(name) = &self.name {
-            format!("{} {}", name.0, self.constraint.to_sql_string(context))
+            format!(
+                "CONSTRAINT {} {}",
+                name.0,
+                self.constraint.to_sql_string(context)
+            )
         } else {
             format!("{}", self.constraint.to_sql_string(context))
         }
@@ -52,7 +56,7 @@ impl ToSqlString for ast::TableConstraint {
                 clause,
                 deref_clause,
             } => format!(
-                "FOREIGN KEY ({}){}{}",
+                "FOREIGN KEY ({}) {}{}",
                 columns
                     .iter()
                     .map(|col| col.to_sql_string(context))
@@ -106,10 +110,132 @@ impl ToSqlString for ast::TableOptions {
         if *self == Self::NONE {
             ""
         } else if *self == Self::STRICT {
-            "STRICT"
+            " STRICT"
         } else {
-            "WITHOUT ROWID"
+            " WITHOUT ROWID"
         }
         .to_string()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::to_sql_string_test;
+
+    to_sql_string_test!(
+        test_create_table_simple,
+        "CREATE TABLE t (a INTEGER, b TEXT)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_primary_key,
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_multi_primary_key,
+        "CREATE TABLE t (a INTEGER, b TEXT, PRIMARY KEY (a, b))"
+    );
+
+    to_sql_string_test!(
+        test_create_table_data_types,
+        "CREATE TABLE t (a INTEGER, b TEXT, c REAL, d BLOB, e NUMERIC)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_foreign_key,
+        "CREATE TABLE t2 (id INTEGER PRIMARY KEY, t_id INTEGER, FOREIGN KEY (t_id) REFERENCES t(id))"
+    );
+
+    to_sql_string_test!(
+        test_create_table_foreign_key_cascade,
+        "CREATE TABLE t2 (id INTEGER PRIMARY KEY, t_id INTEGER, FOREIGN KEY (t_id) REFERENCES t(id) ON DELETE CASCADE)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_unique,
+        "CREATE TABLE t (a INTEGER UNIQUE, b TEXT)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_not_null,
+        "CREATE TABLE t (a INTEGER NOT NULL, b TEXT)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_check,
+        "CREATE TABLE t (a INTEGER CHECK (a > 0), b TEXT)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_default,
+        "CREATE TABLE t (a INTEGER DEFAULT 0, b TEXT)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_multiple_constraints,
+        "CREATE TABLE t (a INTEGER NOT NULL UNIQUE, b TEXT DEFAULT 'default')"
+    );
+
+    to_sql_string_test!(
+        test_create_table_generated_column,
+        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER AS (a + b))"
+    );
+
+    to_sql_string_test!(
+        test_create_table_generated_stored,
+        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER AS (a + b) STORED)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_generated_virtual,
+        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER AS (a + b) VIRTUAL)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_quoted_columns,
+        "CREATE TABLE t (\"select\" INTEGER, \"from\" TEXT)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_quoted_table,
+        "CREATE TABLE \"my table\" (a INTEGER)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_if_not_exists,
+        "CREATE TABLE IF NOT EXISTS t (a INTEGER)"
+    );
+
+    to_sql_string_test!(test_create_temp_table, "CREATE TEMP TABLE t (a INTEGER)");
+
+    to_sql_string_test!(
+        test_create_table_without_rowid,
+        "CREATE TABLE t (a INTEGER PRIMARY KEY, b TEXT) WITHOUT ROWID"
+    );
+
+    to_sql_string_test!(
+        test_create_table_named_primary_key,
+        "CREATE TABLE t (a INTEGER CONSTRAINT pk_a PRIMARY KEY)"
+    );
+
+    to_sql_string_test!(
+        test_create_table_named_unique,
+        "CREATE TABLE t (a INTEGER, CONSTRAINT unique_a UNIQUE (a))"
+    );
+
+    to_sql_string_test!(
+        test_create_table_named_foreign_key,
+        "CREATE TABLE t2 (id INTEGER, t_id INTEGER, CONSTRAINT fk_t FOREIGN KEY (t_id) REFERENCES t(id))"
+    );
+
+    to_sql_string_test!(
+        test_create_table_complex,
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER NOT NULL, b TEXT DEFAULT 'default', c INTEGER AS (a * 2), CONSTRAINT unique_a UNIQUE (a))"
+    );
+
+    to_sql_string_test!(
+        test_create_table_multiple_foreign_keys,
+        "CREATE TABLE t3 (id INTEGER PRIMARY KEY, t1_id INTEGER, t2_id INTEGER, FOREIGN KEY (t1_id) REFERENCES t1(id), FOREIGN KEY (t2_id) REFERENCES t2(id))"
+    );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/create_trigger.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/create_trigger.rs
@@ -77,7 +77,7 @@ impl ToSqlString for ast::TriggerCmdDelete {
             self.where_clause
                 .as_ref()
                 .map_or("".to_string(), |expr| format!(
-                    " {}",
+                    " WHERE {}",
                     expr.to_sql_string(context)
                 ))
         )

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/create_trigger.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/create_trigger.rs
@@ -131,7 +131,7 @@ impl ToSqlString for ast::TriggerCmdInsert {
 impl ToSqlString for ast::Upsert {
     fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
         format!(
-            "ON CONFLICT {}{}{}",
+            "ON CONFLICT{}{}{}",
             self.index.as_ref().map_or("".to_string(), |index| format!(
                 "{} ",
                 index.to_sql_string(context)
@@ -167,10 +167,10 @@ impl ToSqlString for ast::UpsertIndex {
 impl ToSqlString for ast::UpsertDo {
     fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
         match self {
-            Self::Nothing => "NOTHING".to_string(),
+            Self::Nothing => "DO NOTHING".to_string(),
             Self::Set { sets, where_clause } => {
                 format!(
-                    "UPDATE SET {}{}",
+                    "DO UPDATE SET {}{}",
                     sets.iter()
                         .map(|set| set.to_sql_string(context))
                         .collect::<Vec<_>>()

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/create_virtual_table.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/create_virtual_table.rs
@@ -1,0 +1,15 @@
+use crate::{ast, to_sql_string::ToSqlString};
+
+impl ToSqlString for ast::CreateVirtualTable {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        format!(
+            "CREATE VIRTUAL TABLE {}{} USING {}{};",
+            self.if_not_exists.then_some("IF NOT EXISTS ").unwrap_or(""),
+            self.tbl_name.to_sql_string(context),
+            self.module_name.0,
+            self.args
+                .as_ref()
+                .map_or("".to_string(), |args| format!(" ({})", args.join(", ")))
+        )
+    }
+}

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/create_virtual_table.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/create_virtual_table.rs
@@ -9,7 +9,72 @@ impl ToSqlString for ast::CreateVirtualTable {
             self.module_name.0,
             self.args
                 .as_ref()
-                .map_or("".to_string(), |args| format!(" ({})", args.join(", ")))
+                .map_or("".to_string(), |args| format!("({})", args.join(", ")))
         )
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::to_sql_string_test;
+
+    to_sql_string_test!(
+        test_create_virtual_table_fts5_basic,
+        "CREATE VIRTUAL TABLE docs USING fts5(title, content);"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_fts5_tokenizer,
+        "CREATE VIRTUAL TABLE docs USING fts5(title, content, tokenize = 'porter');"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_fts5_unindexed,
+        "CREATE VIRTUAL TABLE docs USING fts5(title, content, metadata UNINDEXED);"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_fts5_prefix,
+        "CREATE VIRTUAL TABLE docs USING fts5(title, content, tokenize = 'unicode61', prefix = '2 4');"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_fts5_contentless,
+        "CREATE VIRTUAL TABLE docs USING fts5(title, content, content = '');"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_fts5_external_content,
+        "CREATE VIRTUAL TABLE docs_fts USING fts5(title, content, content = 'documents');"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_rtree,
+        "CREATE VIRTUAL TABLE geo USING rtree(id, min_x, max_x, min_y, max_y);"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_rtree_aux,
+        "CREATE VIRTUAL TABLE geo USING rtree(id, min_x, max_x, min_y, max_y, +name TEXT, +category INTEGER);"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_if_not_exists,
+        "CREATE VIRTUAL TABLE IF NOT EXISTS docs USING fts5(title, content);"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_fts4,
+        "CREATE VIRTUAL TABLE docs USING fts4(title, content, matchinfo = 'fts3');"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_fts5_detail,
+        "CREATE VIRTUAL TABLE docs USING fts5(title, body TEXT, detail = 'none');"
+    );
+
+    to_sql_string_test!(
+        test_create_virtual_table_schema,
+        "CREATE VIRTUAL TABLE main.docs USING fts5(title, content);"
+    );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/delete.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/delete.rs
@@ -18,13 +18,13 @@ impl ToSqlString for ast::Delete {
             self.where_clause
                 .as_ref()
                 .map_or("".to_string(), |expr| format!(
-                    " {}",
+                    " WHERE {}",
                     expr.to_sql_string(context)
                 )),
             self.returning
                 .as_ref()
                 .map_or("".to_string(), |returning| format!(
-                    " {}",
+                    " RETURNING {}",
                     returning
                         .iter()
                         .map(|col| col.to_sql_string(context))
@@ -47,4 +47,90 @@ impl ToSqlString for ast::Delete {
             ))
         )
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::to_sql_string_test;
+
+    // Basic DELETE from a single table
+    to_sql_string_test!(test_delete_all, "DELETE FROM employees;");
+
+    // DELETE with a simple WHERE clause
+    to_sql_string_test!(
+        test_delete_with_where,
+        "DELETE FROM employees WHERE id = 1;"
+    );
+
+    // DELETE with multiple WHERE conditions
+    to_sql_string_test!(
+        test_delete_with_multi_where,
+        "DELETE FROM employees WHERE salary < 50000 AND department_id = 3;"
+    );
+
+    // DELETE with IN clause
+    to_sql_string_test!(
+        test_delete_with_in,
+        "DELETE FROM employees WHERE id IN (1, 2, 3);"
+    );
+
+    // DELETE with subquery in WHERE
+    to_sql_string_test!(
+        test_delete_with_subquery,
+        "DELETE FROM employees WHERE department_id IN (SELECT id FROM departments WHERE name = 'Sales');"
+    );
+
+    // DELETE with EXISTS clause
+    to_sql_string_test!(
+        test_delete_with_exists,
+        "DELETE FROM employees WHERE EXISTS (SELECT 1 FROM orders WHERE orders.employee_id = employees.id AND orders.status = 'pending');"
+    );
+
+    // DELETE with RETURNING clause
+    to_sql_string_test!(
+        test_delete_with_returning,
+        "DELETE FROM employees WHERE salary < 30000 RETURNING id, name;"
+    );
+
+    // DELETE with LIMIT clause
+    to_sql_string_test!(
+        test_delete_with_limit,
+        "DELETE FROM employees WHERE salary < 40000 LIMIT 5;"
+    );
+
+    // DELETE with ORDER BY and LIMIT
+    to_sql_string_test!(
+        test_delete_with_order_by_limit,
+        "DELETE FROM employees WHERE salary < 40000 ORDER BY id DESC LIMIT 5;"
+    );
+
+    // DELETE from schema-qualified table
+    to_sql_string_test!(
+        test_delete_schema_qualified,
+        "DELETE FROM main.employees WHERE id = 1;"
+    );
+
+    // DELETE with BETWEEN clause
+    to_sql_string_test!(
+        test_delete_with_between,
+        "DELETE FROM employees WHERE salary BETWEEN 30000 AND 50000;"
+    );
+
+    // DELETE with NULL check
+    to_sql_string_test!(
+        test_delete_with_null,
+        "DELETE FROM employees WHERE department_id IS NULL;"
+    );
+
+    // DELETE with LIKE clause
+    to_sql_string_test!(
+        test_delete_with_like,
+        "DELETE FROM employees WHERE name LIKE 'J%';"
+    );
+
+    // DELETE with complex expression in WHERE
+    to_sql_string_test!(
+        test_delete_with_complex_expression,
+        "DELETE FROM employees WHERE (salary * 1.1) > 60000 AND department_id != 1;"
+    );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/delete.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/delete.rs
@@ -1,0 +1,50 @@
+use crate::{ast, to_sql_string::ToSqlString};
+
+impl ToSqlString for ast::Delete {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        format!(
+            "{}DELETE FROM {}{}{}{}{}{};",
+            self.with.as_ref().map_or("".to_string(), |with| format!(
+                "{} ",
+                with.to_sql_string(context)
+            )),
+            self.tbl_name.to_sql_string(context),
+            self.indexed
+                .as_ref()
+                .map_or("".to_string(), |indexed| format!(
+                    " {}",
+                    indexed.to_sql_string(context)
+                )),
+            self.where_clause
+                .as_ref()
+                .map_or("".to_string(), |expr| format!(
+                    " {}",
+                    expr.to_sql_string(context)
+                )),
+            self.returning
+                .as_ref()
+                .map_or("".to_string(), |returning| format!(
+                    " {}",
+                    returning
+                        .iter()
+                        .map(|col| col.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )),
+            self.order_by
+                .as_ref()
+                .map_or("".to_string(), |order_by| format!(
+                    " ORDER BY {}",
+                    order_by
+                        .iter()
+                        .map(|col| col.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )),
+            self.limit.as_ref().map_or("".to_string(), |limit| format!(
+                " {}",
+                limit.to_sql_string(context)
+            ))
+        )
+    }
+}

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/insert.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/insert.rs
@@ -1,0 +1,150 @@
+use crate::{ast, to_sql_string::ToSqlString};
+
+impl ToSqlString for ast::Insert {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        format!(
+            "{}INSERT {}INTO {} {}{}{}",
+            self.with.as_ref().map_or("".to_string(), |with| format!(
+                "{} ",
+                with.to_sql_string(context)
+            )),
+            self.or_conflict.map_or("".to_string(), |conflict| format!(
+                "OR {} ",
+                conflict.to_sql_string(context)
+            )),
+            self.tbl_name.to_sql_string(context),
+            self.columns
+                .as_ref()
+                .map_or("".to_string(), |col_names| format!(
+                    "({}) ",
+                    col_names
+                        .iter()
+                        .map(|name| name.0.clone())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )),
+            self.body.to_sql_string(context),
+            self.returning
+                .as_ref()
+                .map_or("".to_string(), |returning| format!(
+                    " RETURNING {}",
+                    returning
+                        .iter()
+                        .map(|col| col.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ))
+        )
+    }
+}
+
+impl ToSqlString for ast::InsertBody {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        match self {
+            Self::DefaultValues => "DEFAULT VALUES".to_string(),
+            Self::Select(select, upsert) => format!(
+                "{}{}",
+                select.to_sql_string(context),
+                upsert.as_ref().map_or("".to_string(), |upsert| format!(
+                    " {}",
+                    upsert.to_sql_string(context)
+                )),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::to_sql_string_test;
+
+    // Basic INSERT with all columns
+    to_sql_string_test!(
+        test_insert_basic,
+        "INSERT INTO employees (id, name, salary) VALUES (1, 'John Doe', 50000);"
+    );
+
+    // INSERT with multiple rows
+    to_sql_string_test!(
+        test_insert_multiple_rows,
+        "INSERT INTO employees (id, name, salary) VALUES (1, 'John Doe', 50000), (2, 'Jane Smith', 60000);"
+    );
+
+    // INSERT with specific columns
+    to_sql_string_test!(
+        test_insert_specific_columns,
+        "INSERT INTO employees (name, salary) VALUES ('Alice Brown', 55000);"
+    );
+
+    // INSERT with DEFAULT VALUES
+    to_sql_string_test!(
+        test_insert_default_values,
+        "INSERT INTO employees DEFAULT VALUES;"
+    );
+
+    // INSERT with SELECT subquery
+    to_sql_string_test!(
+        test_insert_select_subquery,
+        "INSERT INTO employees (id, name, salary) SELECT id, name, salary FROM temp_employees WHERE salary > 40000;"
+    );
+
+    // INSERT with ON CONFLICT IGNORE
+    to_sql_string_test!(
+        test_insert_on_conflict_ignore,
+        "INSERT INTO employees (id, name, salary) VALUES (1, 'John Doe', 50000) ON CONFLICT(id) DO NOTHING;"
+    );
+
+    // INSERT with ON CONFLICT REPLACE
+    to_sql_string_test!(
+        test_insert_on_conflict_replace,
+        "INSERT INTO employees (id, name, salary) VALUES (1, 'John Doe', 50000) ON CONFLICT(id) DO UPDATE SET name = excluded.name, salary = excluded.salary;"
+    );
+
+    // INSERT with RETURNING clause
+    to_sql_string_test!(
+        test_insert_with_returning,
+        "INSERT INTO employees (id, name, salary) VALUES (1, 'John Doe', 50000) RETURNING id, name;"
+    );
+
+    // INSERT with NULL values
+    to_sql_string_test!(
+        test_insert_with_null,
+        "INSERT INTO employees (id, name, salary, department_id) VALUES (1, 'John Doe', NULL, NULL);"
+    );
+
+    // INSERT with expression in VALUES
+    to_sql_string_test!(
+        test_insert_with_expression,
+        "INSERT INTO employees (id, name, salary) VALUES (1, 'John Doe', 50000 * 1.1);"
+    );
+
+    // INSERT into schema-qualified table
+    to_sql_string_test!(
+        test_insert_schema_qualified,
+        "INSERT INTO main.employees (id, name, salary) VALUES (1, 'John Doe', 50000);"
+    );
+
+    // INSERT with subquery and JOIN
+    to_sql_string_test!(
+        test_insert_subquery_join,
+        "INSERT INTO employees (id, name, department_id) SELECT e.id, e.name, d.id FROM temp_employees e JOIN departments d ON e.dept_name = d.name;"
+    );
+
+    // INSERT with all columns from SELECT
+    to_sql_string_test!(
+        test_insert_all_columns_select,
+        "INSERT INTO employees SELECT * FROM temp_employees;"
+    );
+
+    // INSERT with ON CONFLICT and WHERE clause
+    to_sql_string_test!(
+        test_insert_on_conflict_where,
+        "INSERT INTO employees (id, name, salary) VALUES (1, 'John Doe', 50000) ON CONFLICT(id) DO UPDATE SET salary = excluded.salary WHERE excluded.salary > employees.salary;"
+    );
+
+    // INSERT with quoted column names (reserved words)
+    to_sql_string_test!(
+        test_insert_quoted_columns,
+        "INSERT INTO employees (\"select\", \"from\") VALUES (1, 'data');"
+    );
+}

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -1,0 +1,1 @@
+mod select;

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -2,11 +2,20 @@ use crate::ast;
 
 use super::ToSqlString;
 
+mod alter_table;
 mod select;
 
 impl ToSqlString for ast::Stmt {
     fn to_sql_string<C: super::ToSqlContext>(&self, context: &C) -> String {
         match self {
+            Self::AlterTable(alter_table) => {
+                let (name, body) = alter_table.as_ref();
+                format!(
+                    "ALTER TABLE {} {}",
+                    name.to_sql_string(context),
+                    body.to_sql_string(context)
+                )
+            }
             Self::Select(select) => select.to_sql_string(context),
             _ => todo!(),
         }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -3,6 +3,7 @@ use crate::ast;
 use super::ToSqlString;
 
 mod alter_table;
+mod create_table;
 mod select;
 
 impl ToSqlString for ast::Stmt {
@@ -73,6 +74,20 @@ impl ToSqlString for ast::Stmt {
                             " WHERE {}",
                             where_clause.to_sql_string(context)
                         ))
+                )
+            }
+            Self::CreateTable {
+                temporary,
+                if_not_exists,
+                tbl_name,
+                body,
+            } => {
+                format!(
+                    "CREATE{} TABLE {}{} {}",
+                    temporary.then_some(" TEMP").unwrap_or(""),
+                    if_not_exists.then_some("IF NOT EXISTS ").unwrap_or(""),
+                    tbl_name.to_sql_string(context),
+                    body.to_sql_string(context)
                 )
             }
             Self::Select(select) => select.to_sql_string(context),

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -1,1 +1,53 @@
+use crate::ast;
+
+use super::ToSqlString;
+
 mod select;
+
+impl ToSqlString for ast::Stmt {
+    fn to_sql_string<C: super::ToSqlContext>(&self, context: &C) -> String {
+        match self {
+            Self::Select(select) => select.to_sql_string(context),
+            _ => todo!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::to_sql_string::ToSqlContext;
+
+    #[macro_export]
+    /// Create a test that first parses then input, the converts the parsed ast back to a string and compares with original input
+    macro_rules! to_sql_string_test {
+        ($test_name:ident, $input:literal) => {
+            #[test]
+            fn $test_name() {
+                let context = crate::to_sql_string::stmt::tests::TestContext;
+                let input: &str = $input;
+                let mut parser = crate::lexer::sql::Parser::new(input.as_bytes());
+                let cmd = fallible_iterator::FallibleIterator::next(&mut parser)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(
+                    input,
+                    crate::to_sql_string::ToSqlString::to_sql_string(cmd.stmt(), &context)
+                );
+            }
+        };
+    }
+
+    pub(crate) struct TestContext;
+
+    // Placeholders for compilation
+    // Context only necessary parsing inside limbo_core or in the simulator
+    impl ToSqlContext for TestContext {
+        fn get_column_name(&self, _table_id: crate::ast::TableInternalId, _col_idx: usize) -> &str {
+            todo!()
+        }
+
+        fn get_table_name(&self, _id: crate::ast::TableInternalId) -> &str {
+            todo!()
+        }
+    }
+}

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -4,6 +4,7 @@ use super::ToSqlString;
 
 mod alter_table;
 mod create_table;
+mod create_trigger;
 mod select;
 
 impl ToSqlString for ast::Stmt {
@@ -91,6 +92,7 @@ impl ToSqlString for ast::Stmt {
                     body.to_sql_string(context)
                 )
             }
+            Self::CreateTrigger(trigger) => trigger.to_sql_string(context),
             Self::Select(select) => select.to_sql_string(context),
             _ => todo!(),
         }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -23,6 +23,18 @@ impl ToSqlString for ast::Stmt {
                     format!("ANALYZE")
                 }
             }
+            Self::Attach {
+                expr,
+                db_name,
+                key: _,
+            } => {
+                // TODO: what is `key` in the attach syntax?
+                format!(
+                    "ATTACH {} AS {}",
+                    expr.to_sql_string(context),
+                    db_name.to_sql_string(context)
+                )
+            }
             Self::Select(select) => select.to_sql_string(context),
             _ => todo!(),
         }
@@ -96,4 +108,6 @@ mod tests {
         "ANALYZE schema.table",
         ignore = "parser can't parse schema.table name"
     );
+
+    to_sql_string_test!(test_attach, "ATTACH './test.db' AS test_db");
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -9,6 +9,7 @@ mod create_virtual_table;
 mod delete;
 mod insert;
 mod select;
+mod update;
 
 impl ToSqlString for ast::Stmt {
     fn to_sql_string<C: super::ToSqlContext>(&self, context: &C) -> String {
@@ -184,6 +185,7 @@ impl ToSqlString for ast::Stmt {
             ),
             Self::Savepoint(name) => format!("SAVEPOINT {};", name.0),
             Self::Select(select) => format!("{};", select.to_sql_string(context)),
+            Self::Update(update) => format!("{};", update.to_sql_string(context)),
             _ => todo!(),
         }
     }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -8,6 +8,7 @@ mod select;
 
 impl ToSqlString for ast::Stmt {
     fn to_sql_string<C: super::ToSqlContext>(&self, context: &C) -> String {
+        dbg!(self);
         match self {
             Self::AlterTable(alter_table) => {
                 let (name, body) = alter_table.as_ref();
@@ -103,7 +104,7 @@ mod tests {
     #[macro_export]
     /// Create a test that first parses then input, the converts the parsed ast back to a string and compares with original input
     macro_rules! to_sql_string_test {
-        ($test_name:ident, $input:literal) => {
+        ($test_name:ident, $input:expr) => {
             #[test]
             fn $test_name() {
                 let context = crate::to_sql_string::stmt::tests::TestContext;
@@ -118,7 +119,7 @@ mod tests {
                 );
             }
         };
-        ($test_name:ident, $input:literal, $($attribute:meta),*) => {
+        ($test_name:ident, $input:expr, $($attribute:meta),*) => {
             #[test]
             $(#[$attribute])*
             fn $test_name() {

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -186,7 +186,17 @@ impl ToSqlString for ast::Stmt {
             Self::Savepoint(name) => format!("SAVEPOINT {};", name.0),
             Self::Select(select) => format!("{};", select.to_sql_string(context)),
             Self::Update(update) => format!("{};", update.to_sql_string(context)),
-            _ => todo!(),
+            Self::Vacuum(name, expr) => {
+                format!(
+                    "VACUUM{}{};",
+                    name.as_ref()
+                        .map_or("".to_string(), |name| format!(" {}", name.0)),
+                    expr.as_ref().map_or("".to_string(), |expr| format!(
+                        " INTO {}",
+                        expr.to_sql_string(context)
+                    ))
+                )
+            }
         }
     }
 }
@@ -398,4 +408,10 @@ mod tests {
     to_sql_string_test!(test_rollback_2, "ROLLBACK TO savepoint_name;");
 
     to_sql_string_test!(test_savepoint, "SAVEPOINT savepoint_name;");
+
+    to_sql_string_test!(test_vacuum, "VACUUM;");
+
+    to_sql_string_test!(test_vacuum_2, "VACUUM schema_name;");
+
+    to_sql_string_test!(test_vacuum_3, "VACUUM schema_name INTO test.db;");
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -7,6 +7,7 @@ mod create_table;
 mod create_trigger;
 mod create_virtual_table;
 mod delete;
+mod insert;
 mod select;
 
 impl ToSqlString for ast::Stmt {
@@ -154,6 +155,7 @@ impl ToSqlString for ast::Stmt {
                 if_exists.then_some("IF EXISTS ").unwrap_or(""),
                 view_name.to_sql_string(context)
             ),
+            Self::Insert(insert) => format!("{};", insert.to_sql_string(context)),
             Self::Select(select) => format!("{};", select.to_sql_string(context)),
             _ => todo!(),
         }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -35,6 +35,22 @@ mod tests {
                 );
             }
         };
+        ($test_name:ident, $input:literal, $($attribute:meta),*) => {
+            #[test]
+            $(#[$attribute])*
+            fn $test_name() {
+                let context = crate::to_sql_string::stmt::tests::TestContext;
+                let input: &str = $input;
+                let mut parser = crate::lexer::sql::Parser::new(input.as_bytes());
+                let cmd = fallible_iterator::FallibleIterator::next(&mut parser)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(
+                    input,
+                    crate::to_sql_string::ToSqlString::to_sql_string(cmd.stmt(), &context)
+                );
+            }
+        }
     }
 
     pub(crate) struct TestContext;

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -121,6 +121,7 @@ impl ToSqlString for ast::Stmt {
                 create_virtual_table.to_sql_string(context)
             }
             Self::Delete(delete) => delete.to_sql_string(context),
+            Self::Detach(name) => format!("DETACH {};", name.to_sql_string(context)),
             Self::Select(select) => format!("{};", select.to_sql_string(context)),
             _ => todo!(),
         }
@@ -307,5 +308,11 @@ mod tests {
     to_sql_string_test!(
         test_create_view_arithmetic,
         "CREATE VIEW view_arithmetic AS SELECT name, salary * 1.1 AS adjusted_salary FROM employees;"
+    );
+
+   
+    to_sql_string_test!(
+        test_detach,
+        "DETACH 'x.db';"
     );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -5,6 +5,7 @@ use super::ToSqlString;
 mod alter_table;
 mod create_table;
 mod create_trigger;
+mod create_virtual_table;
 mod select;
 
 impl ToSqlString for ast::Stmt {
@@ -100,7 +101,7 @@ impl ToSqlString for ast::Stmt {
                 select,
             } => {
                 format!(
-                    "CREATE{} VIEW {}{}{} AS {}",
+                    "CREATE{} VIEW {}{}{} AS {};",
                     temporary.then_some(" TEMP").unwrap_or(""),
                     if_not_exists.then_some("IF NOT EXISTS ").unwrap_or(""),
                     view_name.to_sql_string(context),
@@ -114,6 +115,9 @@ impl ToSqlString for ast::Stmt {
                     )),
                     select.to_sql_string(context)
                 )
+            }
+            Self::CreateVirtualTable(create_virtual_table) => {
+                create_virtual_table.to_sql_string(context)
             }
             Self::Select(select) => format!("{};", select.to_sql_string(context)),
             _ => todo!(),
@@ -246,60 +250,60 @@ mod tests {
     // Test 1: View with DISTINCT keyword
     to_sql_string_test!(
         test_create_view_distinct,
-        "CREATE VIEW view_distinct AS SELECT DISTINCT name FROM employees"
+        "CREATE VIEW view_distinct AS SELECT DISTINCT name FROM employees;"
     );
 
     // Test 2: View with LIMIT clause
     to_sql_string_test!(
         test_create_view_limit,
-        "CREATE VIEW view_limit AS SELECT id, name FROM employees LIMIT 10"
+        "CREATE VIEW view_limit AS SELECT id, name FROM employees LIMIT 10;"
     );
 
     // Test 3: View with CASE expression
     to_sql_string_test!(
         test_create_view_case,
-        "CREATE VIEW view_case AS SELECT name, CASE WHEN salary > 70000 THEN 'High' ELSE 'Low' END AS salary_level FROM employees"
+        "CREATE VIEW view_case AS SELECT name, CASE WHEN salary > 70000 THEN 'High' ELSE 'Low' END AS salary_level FROM employees;"
     );
 
     // Test 4: View with LEFT JOIN
     to_sql_string_test!(
         test_create_view_left_join,
-        "CREATE VIEW view_left_join AS SELECT e.name, d.name AS department FROM employees e LEFT JOIN departments d ON e.department_id = d.id"
+        "CREATE VIEW view_left_join AS SELECT e.name, d.name AS department FROM employees e LEFT JOIN departments d ON e.department_id = d.id;"
     );
 
     // Test 5: View with HAVING clause
     to_sql_string_test!(
         test_create_view_having,
-        "CREATE VIEW view_having AS SELECT department_id, AVG(salary) AS avg_salary FROM employees GROUP BY department_id HAVING AVG(salary) > 55000"
+        "CREATE VIEW view_having AS SELECT department_id, AVG(salary) AS avg_salary FROM employees GROUP BY department_id HAVING AVG(salary) > 55000;"
     );
 
     // Test 6: View with CTE (Common Table Expression)
     to_sql_string_test!(
         test_create_view_cte,
-        "CREATE VIEW view_cte AS WITH high_earners AS (SELECT * FROM employees WHERE salary > 80000) SELECT id, name FROM high_earners"
+        "CREATE VIEW view_cte AS WITH high_earners AS (SELECT * FROM employees WHERE salary > 80000) SELECT id, name FROM high_earners;"
     );
 
     // Test 7: View with multiple conditions in WHERE
     to_sql_string_test!(
         test_create_view_multi_where,
-        "CREATE VIEW view_multi_where AS SELECT id, name FROM employees WHERE salary > 50000 AND department_id = 3"
+        "CREATE VIEW view_multi_where AS SELECT id, name FROM employees WHERE salary > 50000 AND department_id = 3;"
     );
 
     // Test 8: View with NULL handling
     to_sql_string_test!(
         test_create_view_null,
-        "CREATE VIEW view_null AS SELECT name, COALESCE(salary, 0) AS salary FROM employees"
+        "CREATE VIEW view_null AS SELECT name, COALESCE(salary, 0) AS salary FROM employees;"
     );
 
     // Test 9: View with subquery in WHERE clause
     to_sql_string_test!(
         test_create_view_subquery_where,
-        "CREATE VIEW view_subquery_where AS SELECT name FROM employees WHERE department_id IN (SELECT id FROM departments WHERE name = 'Sales')"
+        "CREATE VIEW view_subquery_where AS SELECT name FROM employees WHERE department_id IN (SELECT id FROM departments WHERE name = 'Sales');"
     );
 
     // Test 10: View with arithmetic expression
     to_sql_string_test!(
         test_create_view_arithmetic,
-        "CREATE VIEW view_arithmetic AS SELECT name, salary * 1.1 AS adjusted_salary FROM employees"
+        "CREATE VIEW view_arithmetic AS SELECT name, salary * 1.1 AS adjusted_salary FROM employees;"
     );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -16,6 +16,13 @@ impl ToSqlString for ast::Stmt {
                     body.to_sql_string(context)
                 )
             }
+            Self::Analyze(name) => {
+                if let Some(name) = name {
+                    format!("ANALYZE {}", name.to_sql_string(context))
+                } else {
+                    format!("ANALYZE")
+                }
+            }
             Self::Select(select) => select.to_sql_string(context),
             _ => todo!(),
         }
@@ -75,4 +82,18 @@ mod tests {
             todo!()
         }
     }
+
+    to_sql_string_test!(test_analyze, "ANALYZE");
+
+    to_sql_string_test!(
+        test_analyze_table,
+        "ANALYZE table",
+        ignore = "parser can't parse table name"
+    );
+
+    to_sql_string_test!(
+        test_analyze_schema_table,
+        "ANALYZE schema.table",
+        ignore = "parser can't parse schema.table name"
+    );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -122,6 +122,38 @@ impl ToSqlString for ast::Stmt {
             }
             Self::Delete(delete) => delete.to_sql_string(context),
             Self::Detach(name) => format!("DETACH {};", name.to_sql_string(context)),
+            Self::DropIndex {
+                if_exists,
+                idx_name,
+            } => format!(
+                "DROP INDEX{} {};",
+                if_exists.then_some("IF EXISTS ").unwrap_or(""),
+                idx_name.to_sql_string(context)
+            ),
+            Self::DropTable {
+                if_exists,
+                tbl_name,
+            } => format!(
+                "DROP TABLE{} {};",
+                if_exists.then_some("IF EXISTS ").unwrap_or(""),
+                tbl_name.to_sql_string(context)
+            ),
+            Self::DropTrigger {
+                if_exists,
+                trigger_name,
+            } => format!(
+                "DROP TRIGGER{} {};",
+                if_exists.then_some("IF EXISTS ").unwrap_or(""),
+                trigger_name.to_sql_string(context)
+            ),
+            Self::DropView {
+                if_exists,
+                view_name,
+            } => format!(
+                "DROP VIEW{} {};",
+                if_exists.then_some("IF EXISTS ").unwrap_or(""),
+                view_name.to_sql_string(context)
+            ),
             Self::Select(select) => format!("{};", select.to_sql_string(context)),
             _ => todo!(),
         }
@@ -310,9 +342,13 @@ mod tests {
         "CREATE VIEW view_arithmetic AS SELECT name, salary * 1.1 AS adjusted_salary FROM employees;"
     );
 
-   
-    to_sql_string_test!(
-        test_detach,
-        "DETACH 'x.db';"
-    );
+    to_sql_string_test!(test_detach, "DETACH 'x.db';");
+
+    to_sql_string_test!(test_drop_index, "DROP INDEX schema_name.test_index;");
+
+    to_sql_string_test!(test_drop_table, "DROP TABLE schema_name.test_table;");
+
+    to_sql_string_test!(test_drop_trigger, "DROP TRIGGER schema_name.test_trigger;");
+
+    to_sql_string_test!(test_drop_view, "DROP VIEW schema_name.test_view;");
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -6,6 +6,7 @@ mod alter_table;
 mod create_table;
 mod create_trigger;
 mod create_virtual_table;
+mod delete;
 mod select;
 
 impl ToSqlString for ast::Stmt {
@@ -119,6 +120,7 @@ impl ToSqlString for ast::Stmt {
             Self::CreateVirtualTable(create_virtual_table) => {
                 create_virtual_table.to_sql_string(context)
             }
+            Self::Delete(delete) => delete.to_sql_string(context),
             Self::Select(select) => format!("{};", select.to_sql_string(context)),
             _ => todo!(),
         }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/mod.rs
@@ -92,6 +92,29 @@ impl ToSqlString for ast::Stmt {
                 )
             }
             Self::CreateTrigger(trigger) => trigger.to_sql_string(context),
+            Self::CreateView {
+                temporary,
+                if_not_exists,
+                view_name,
+                columns,
+                select,
+            } => {
+                format!(
+                    "CREATE{} VIEW {}{}{} AS {}",
+                    temporary.then_some(" TEMP").unwrap_or(""),
+                    if_not_exists.then_some("IF NOT EXISTS ").unwrap_or(""),
+                    view_name.to_sql_string(context),
+                    columns.as_ref().map_or("".to_string(), |columns| format!(
+                        " ({})",
+                        columns
+                            .iter()
+                            .map(|col| col.to_sql_string(context))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )),
+                    select.to_sql_string(context)
+                )
+            }
             Self::Select(select) => format!("{};", select.to_sql_string(context)),
             _ => todo!(),
         }
@@ -218,5 +241,65 @@ mod tests {
     to_sql_string_test!(
         test_create_index_mixed_order,
         "CREATE INDEX idx_name_asc_salary_desc ON employees (last_name ASC, salary DESC);"
+    );
+
+    // Test 1: View with DISTINCT keyword
+    to_sql_string_test!(
+        test_create_view_distinct,
+        "CREATE VIEW view_distinct AS SELECT DISTINCT name FROM employees"
+    );
+
+    // Test 2: View with LIMIT clause
+    to_sql_string_test!(
+        test_create_view_limit,
+        "CREATE VIEW view_limit AS SELECT id, name FROM employees LIMIT 10"
+    );
+
+    // Test 3: View with CASE expression
+    to_sql_string_test!(
+        test_create_view_case,
+        "CREATE VIEW view_case AS SELECT name, CASE WHEN salary > 70000 THEN 'High' ELSE 'Low' END AS salary_level FROM employees"
+    );
+
+    // Test 4: View with LEFT JOIN
+    to_sql_string_test!(
+        test_create_view_left_join,
+        "CREATE VIEW view_left_join AS SELECT e.name, d.name AS department FROM employees e LEFT JOIN departments d ON e.department_id = d.id"
+    );
+
+    // Test 5: View with HAVING clause
+    to_sql_string_test!(
+        test_create_view_having,
+        "CREATE VIEW view_having AS SELECT department_id, AVG(salary) AS avg_salary FROM employees GROUP BY department_id HAVING AVG(salary) > 55000"
+    );
+
+    // Test 6: View with CTE (Common Table Expression)
+    to_sql_string_test!(
+        test_create_view_cte,
+        "CREATE VIEW view_cte AS WITH high_earners AS (SELECT * FROM employees WHERE salary > 80000) SELECT id, name FROM high_earners"
+    );
+
+    // Test 7: View with multiple conditions in WHERE
+    to_sql_string_test!(
+        test_create_view_multi_where,
+        "CREATE VIEW view_multi_where AS SELECT id, name FROM employees WHERE salary > 50000 AND department_id = 3"
+    );
+
+    // Test 8: View with NULL handling
+    to_sql_string_test!(
+        test_create_view_null,
+        "CREATE VIEW view_null AS SELECT name, COALESCE(salary, 0) AS salary FROM employees"
+    );
+
+    // Test 9: View with subquery in WHERE clause
+    to_sql_string_test!(
+        test_create_view_subquery_where,
+        "CREATE VIEW view_subquery_where AS SELECT name FROM employees WHERE department_id IN (SELECT id FROM departments WHERE name = 'Sales')"
+    );
+
+    // Test 10: View with arithmetic expression
+    to_sql_string_test!(
+        test_create_view_arithmetic,
+        "CREATE VIEW view_arithmetic AS SELECT name, salary * 1.1 AS adjusted_salary FROM employees"
     );
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/select.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/select.rs
@@ -5,7 +5,6 @@ use crate::{
 
 impl ToSqlString for ast::Select {
     fn to_sql_string<C: ToSqlContext>(&self, context: &C) -> String {
-        dbg!(&self);
         let mut ret = Vec::new();
         if let Some(with) = &self.with {
             let joined_expr = with
@@ -78,12 +77,12 @@ impl ToSqlString for ast::OneSelect {
                             .iter()
                             .map(|e| e.to_sql_string(context))
                             .collect::<Vec<_>>()
-                            .join(",");
+                            .join(", ");
                         format!("({})", joined_value)
                     })
                     .collect::<Vec<_>>()
                     .join(", ");
-                joined_values
+                format!("VALUES {}", joined_values)
             }
         }
     }
@@ -523,119 +522,125 @@ impl ToSqlString for ast::FrameExclude {
 mod tests {
     use crate::to_sql_string_test;
 
-    to_sql_string_test!(test_select_basic, "SELECT 1");
+    to_sql_string_test!(test_select_basic, "SELECT 1;");
 
-    to_sql_string_test!(test_select_table, "SELECT * FROM t");
+    to_sql_string_test!(test_select_table, "SELECT * FROM t;");
 
-    to_sql_string_test!(test_select_table_2, "SELECT a FROM t");
+    to_sql_string_test!(test_select_table_2, "SELECT a FROM t;");
 
-    to_sql_string_test!(test_select_multiple_columns, "SELECT a, b, c FROM t");
+    to_sql_string_test!(test_select_multiple_columns, "SELECT a, b, c FROM t;");
 
-    to_sql_string_test!(test_select_with_alias, "SELECT a AS col1 FROM t");
+    to_sql_string_test!(test_select_with_alias, "SELECT a AS col1 FROM t;");
 
-    to_sql_string_test!(test_select_with_table_alias, "SELECT t1.a FROM t AS t1");
+    to_sql_string_test!(test_select_with_table_alias, "SELECT t1.a FROM t AS t1;");
 
-    to_sql_string_test!(test_select_with_where, "SELECT a FROM t WHERE b = 1");
+    to_sql_string_test!(test_select_with_where, "SELECT a FROM t WHERE b = 1;");
 
     to_sql_string_test!(
         test_select_with_multiple_conditions,
-        "SELECT a FROM t WHERE b = 1 AND c > 2"
+        "SELECT a FROM t WHERE b = 1 AND c > 2;"
     );
 
-    to_sql_string_test!(test_select_with_order_by, "SELECT a FROM t ORDER BY a DESC");
+    to_sql_string_test!(
+        test_select_with_order_by,
+        "SELECT a FROM t ORDER BY a DESC;"
+    );
 
-    to_sql_string_test!(test_select_with_limit, "SELECT a FROM t LIMIT 10");
+    to_sql_string_test!(test_select_with_limit, "SELECT a FROM t LIMIT 10;");
 
-    to_sql_string_test!(test_select_with_offset, "SELECT a FROM t LIMIT 10 OFFSET 5");
+    to_sql_string_test!(
+        test_select_with_offset,
+        "SELECT a FROM t LIMIT 10 OFFSET 5;"
+    );
 
     to_sql_string_test!(
         test_select_with_join,
-        "SELECT a FROM t JOIN t2 ON t.b = t2.b"
+        "SELECT a FROM t JOIN t2 ON t.b = t2.b;"
     );
 
     to_sql_string_test!(
         test_select_with_group_by,
-        "SELECT a, COUNT(*) FROM t GROUP BY a"
+        "SELECT a, COUNT(*) FROM t GROUP BY a;"
     );
 
     to_sql_string_test!(
         test_select_with_having,
-        "SELECT a, COUNT(*) FROM t GROUP BY a HAVING COUNT(*) > 1"
+        "SELECT a, COUNT(*) FROM t GROUP BY a HAVING COUNT(*) > 1;"
     );
 
-    to_sql_string_test!(test_select_with_distinct, "SELECT DISTINCT a FROM t");
+    to_sql_string_test!(test_select_with_distinct, "SELECT DISTINCT a FROM t;");
 
-    to_sql_string_test!(test_select_with_function, "SELECT COUNT(a) FROM t");
+    to_sql_string_test!(test_select_with_function, "SELECT COUNT(a) FROM t;");
 
     to_sql_string_test!(
         test_select_with_subquery,
-        "SELECT a FROM (SELECT b FROM t) AS sub"
+        "SELECT a FROM (SELECT b FROM t) AS sub;"
     );
 
     to_sql_string_test!(
         test_select_nested_subquery,
-        "SELECT a FROM (SELECT b FROM (SELECT c FROM t WHERE c > 10) AS sub1 WHERE b < 20) AS sub2"
+        "SELECT a FROM (SELECT b FROM (SELECT c FROM t WHERE c > 10) AS sub1 WHERE b < 20) AS sub2;"
     );
 
     to_sql_string_test!(
         test_select_multiple_joins,
-        "SELECT t1.a, t2.b, t3.c FROM t1 JOIN t2 ON t1.id = t2.id LEFT JOIN t3 ON t2.id = t3.id"
+        "SELECT t1.a, t2.b, t3.c FROM t1 JOIN t2 ON t1.id = t2.id LEFT JOIN t3 ON t2.id = t3.id;"
     );
 
     to_sql_string_test!(
         test_select_with_cte,
-        "WITH cte AS (SELECT a FROM t WHERE b = 1) SELECT a FROM cte WHERE a > 10"
+        "WITH cte AS (SELECT a FROM t WHERE b = 1) SELECT a FROM cte WHERE a > 10;"
     );
 
     to_sql_string_test!(
         test_select_with_window_function,
-        "SELECT a, ROW_NUMBER() OVER (PARTITION BY b ORDER BY c DESC) AS rn FROM t"
+        "SELECT a, ROW_NUMBER() OVER (PARTITION BY b ORDER BY c DESC) AS rn FROM t;"
     );
 
     to_sql_string_test!(
         test_select_with_complex_where,
-        "SELECT a FROM t WHERE b IN (1, 2, 3) AND c BETWEEN 10 AND 20 OR d IS NULL"
+        "SELECT a FROM t WHERE b IN (1, 2, 3) AND c BETWEEN 10 AND 20 OR d IS NULL;"
     );
 
     to_sql_string_test!(
         test_select_with_case,
-        "SELECT CASE WHEN a > 0 THEN 'positive' ELSE 'non-positive' END AS result FROM t"
+        "SELECT CASE WHEN a > 0 THEN 'positive' ELSE 'non-positive' END AS result FROM t;"
     );
 
-    to_sql_string_test!(test_select_with_aggregate_and_join, "SELECT t1.a, COUNT(t2.b) FROM t1 LEFT JOIN t2 ON t1.id = t2.id GROUP BY t1.a HAVING COUNT(t2.b) > 5");
+    to_sql_string_test!(test_select_with_aggregate_and_join, "SELECT t1.a, COUNT(t2.b) FROM t1 LEFT JOIN t2 ON t1.id = t2.id GROUP BY t1.a HAVING COUNT(t2.b) > 5;");
 
-    to_sql_string_test!(test_select_with_multiple_ctes, "WITH cte1 AS (SELECT a FROM t WHERE b = 1), cte2 AS (SELECT c FROM t2 WHERE d = 2) SELECT cte1.a, cte2.c FROM cte1 JOIN cte2 ON cte1.a = cte2.c");
+    to_sql_string_test!(test_select_with_multiple_ctes, "WITH cte1 AS (SELECT a FROM t WHERE b = 1), cte2 AS (SELECT c FROM t2 WHERE d = 2) SELECT cte1.a, cte2.c FROM cte1 JOIN cte2 ON cte1.a = cte2.c;");
 
     to_sql_string_test!(
         test_select_with_union,
-        "SELECT a FROM t1 UNION SELECT b FROM t2"
+        "SELECT a FROM t1 UNION SELECT b FROM t2;"
     );
 
     to_sql_string_test!(
         test_select_with_union_all,
-        "SELECT a FROM t1 UNION ALL SELECT b FROM t2"
+        "SELECT a FROM t1 UNION ALL SELECT b FROM t2;"
     );
 
     to_sql_string_test!(
         test_select_with_exists,
-        "SELECT a FROM t WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.b = t.a)"
+        "SELECT a FROM t WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.b = t.a);"
     );
 
     to_sql_string_test!(
         test_select_with_correlated_subquery,
-        "SELECT a, (SELECT COUNT(*) FROM t2 WHERE t2.b = t.a) AS count_b FROM t"
+        "SELECT a, (SELECT COUNT(*) FROM t2 WHERE t2.b = t.a) AS count_b FROM t;"
     );
 
     to_sql_string_test!(
         test_select_with_complex_order_by,
-        "SELECT a, b FROM t ORDER BY CASE WHEN a IS NULL THEN 1 ELSE 0 END, b ASC, c DESC"
+        "SELECT a, b FROM t ORDER BY CASE WHEN a IS NULL THEN 1 ELSE 0 END, b ASC, c DESC;"
     );
 
     to_sql_string_test!(
         test_select_with_full_outer_join,
-        "SELECT t1.a, t2.b FROM t1 FULL OUTER JOIN t2 ON t1.id = t2.id",
+        "SELECT t1.a, t2.b FROM t1 FULL OUTER JOIN t2 ON t1.id = t2.id;",
         ignore = "OUTER JOIN is incorrectly parsed in parser"
     );
 
-    to_sql_string_test!(test_select_with_aggregate_window, "SELECT a, SUM(b) OVER (PARTITION BY c ORDER BY d ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS running_sum FROM t");
+    to_sql_string_test!(test_select_with_aggregate_window, "SELECT a, SUM(b) OVER (PARTITION BY c ORDER BY d ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS running_sum FROM t;");
 }

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/select.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/select.rs
@@ -1,0 +1,36 @@
+use crate::{
+    ast,
+    to_sql_string::{ToSqlContext, ToSqlString},
+};
+
+impl ToSqlString for ast::Select {
+    fn to_sql_string<C: ToSqlContext>(&self, context: &C) -> String {
+        let mut ret = String::new();
+        ret
+    }
+}
+
+impl ToSqlString for ast::SelectBody {
+    fn to_sql_string<C: ToSqlContext>(&self, context: &C) -> String {
+        let mut ret = String::new();
+        ret
+    }
+}
+
+impl ToSqlString for ast::OneSelect {
+    fn to_sql_string<C: ToSqlContext>(&self, context: &C) -> String {
+        let mut ret = String::new();
+        match self {
+            ast::OneSelect::Select(select) => ret,
+            // TODO: come back here when we implement ToSqlString for Expr
+            ast::OneSelect::Values(values) => ret,
+        }
+    }
+}
+
+impl ToSqlString for ast::SelectInner {
+    fn to_sql_string<C: ToSqlContext>(&self, context: &C) -> String {
+        let mut ret = String::new();
+        ret
+    }
+}

--- a/vendored/sqlite3-parser/src/to_sql_string/stmt/update.rs
+++ b/vendored/sqlite3-parser/src/to_sql_string/stmt/update.rs
@@ -1,0 +1,144 @@
+use crate::{ast, to_sql_string::ToSqlString};
+
+impl ToSqlString for ast::Update {
+    fn to_sql_string<C: crate::to_sql_string::ToSqlContext>(&self, context: &C) -> String {
+        format!(
+            "{}UPDATE {}{}{} SET {}{}{}{}",
+            self.with.as_ref().map_or("".to_string(), |with| format!(
+                "{} ",
+                with.to_sql_string(context)
+            )),
+            self.or_conflict.map_or("".to_string(), |conflict| format!(
+                "OR {} ",
+                conflict.to_sql_string(context)
+            )),
+            self.tbl_name.to_sql_string(context),
+            self.indexed
+                .as_ref()
+                .map_or("".to_string(), |indexed| format!(
+                    " {}",
+                    indexed.to_sql_string(context)
+                )),
+            self.sets
+                .iter()
+                .map(|set| set.to_sql_string(context))
+                .collect::<Vec<_>>()
+                .join(", "),
+            self.from.as_ref().map_or("".to_string(), |from| format!(
+                " {}",
+                from.to_sql_string(context)
+            )),
+            self.where_clause
+                .as_ref()
+                .map_or("".to_string(), |expr| format!(
+                    " WHERE {}",
+                    expr.to_sql_string(context)
+                )),
+            self.returning
+                .as_ref()
+                .map_or("".to_string(), |returning| format!(
+                    " RETURNING {}",
+                    returning
+                        .iter()
+                        .map(|col| col.to_sql_string(context))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ))
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::to_sql_string_test;
+
+    // Basic UPDATE with a single column
+    to_sql_string_test!(
+        test_update_single_column,
+        "UPDATE employees SET salary = 55000;"
+    );
+
+    // UPDATE with multiple columns
+    to_sql_string_test!(
+        test_update_multiple_columns,
+        "UPDATE employees SET salary = 60000, name = 'John Smith';"
+    );
+
+    // UPDATE with a WHERE clause
+    to_sql_string_test!(
+        test_update_with_where,
+        "UPDATE employees SET salary = 60000 WHERE id = 1;"
+    );
+
+    // UPDATE with multiple WHERE conditions
+    to_sql_string_test!(
+        test_update_with_multi_where,
+        "UPDATE employees SET salary = 65000 WHERE department_id = 3 AND salary < 50000;"
+    );
+
+    // UPDATE with a subquery in SET
+    to_sql_string_test!(
+        test_update_with_subquery_set,
+        "UPDATE employees SET department_id = (SELECT id FROM departments WHERE name = 'Sales') WHERE id = 1;"
+    );
+
+    // UPDATE with a subquery in WHERE
+    to_sql_string_test!(
+        test_update_with_subquery_where,
+        "UPDATE employees SET salary = 70000 WHERE department_id IN (SELECT id FROM departments WHERE name = 'Marketing');"
+    );
+
+    // UPDATE with EXISTS clause
+    to_sql_string_test!(
+        test_update_with_exists,
+        "UPDATE employees SET salary = 75000 WHERE EXISTS (SELECT 1 FROM orders WHERE orders.employee_id = employees.id AND orders.status = 'pending');"
+    );
+
+    // UPDATE with FROM clause (join-like behavior)
+    to_sql_string_test!(
+        test_update_with_from,
+        "UPDATE employees SET salary = 80000 FROM departments WHERE employees.department_id = departments.id AND departments.name = 'Engineering';"
+    );
+
+    // UPDATE with RETURNING clause
+    to_sql_string_test!(
+        test_update_with_returning,
+        "UPDATE employees SET salary = 60000 WHERE id = 1 RETURNING id, name, salary;"
+    );
+
+    // UPDATE with expression in SET
+    to_sql_string_test!(
+        test_update_with_expression,
+        "UPDATE employees SET salary = salary * 1.1 WHERE department_id = 2;"
+    );
+
+    // UPDATE with NULL value
+    to_sql_string_test!(
+        test_update_with_null,
+        "UPDATE employees SET department_id = NULL WHERE id = 1;"
+    );
+
+    // UPDATE with schema-qualified table
+    to_sql_string_test!(
+        test_update_schema_qualified,
+        "UPDATE main.employees SET salary = 65000 WHERE id = 1;"
+    );
+
+    // UPDATE with CASE expression
+    to_sql_string_test!(
+        test_update_with_case,
+        "UPDATE employees SET salary = CASE WHEN salary < 50000 THEN 55000 ELSE salary * 1.05 END WHERE department_id = 3;"
+    );
+
+    // UPDATE with LIKE clause in WHERE
+    to_sql_string_test!(
+        test_update_with_like,
+        "UPDATE employees SET name = 'Updated' WHERE name LIKE 'J%';"
+    );
+
+    // UPDATE with ON CONFLICT (upsert-like behavior)
+    to_sql_string_test!(
+        test_update_with_on_conflict,
+        "INSERT INTO employees (id, name, salary) VALUES (1, 'John Doe', 50000) ON CONFLICT(id) DO UPDATE SET name = excluded.name, salary = excluded.salary;"
+    );
+}


### PR DESCRIPTION
This PR implements the `ToSqlString` trait to most of the `ast` structs and to the `SelectPlan`, `UpdatePlan`, `DeletePlan`, `CompoundSelectPlan`.

Inside the files in the `to_sql_string` folder, I annotated many `TODOs` with things that seem to diverge from SQLite syntax. The most egregious by far was that Create Trigger statements do not use the standard `delete`, `select`, `update`, and `insert` statements. The parser uses different structs for those statements only in Create Trigger. E.g `ast::TriggerCmdUpdate` instead of `ast::Update` and so on. 

Also, as this iteration of reverse parsing is not particularly efficient in the number of string allocations it does. I tested different methods of achieving this by using `format!`, pushing directly to a `String`, or just pushing to `Vec<String>` and joining all the string with a space separator. I focused mainly on trying to get the syntax to print correctly without major hurdles in understanding the code. 

Lastly, I intend in the future to use this code in the simulator to expand the its available syntax.