### PR TITLE
bindings/javascript: Add proper exec() method and raw() mode

### DIFF
--- a/bindings/javascript/__test__/artifacts/basic-test.sql
+++ b/bindings/javascript/__test__/artifacts/basic-test.sql
@@ -1,0 +1,3 @@
+CREATE TABLE users (name TEXT, age INTEGER);
+INSERT INTO users (name, age) VALUES ('Bob', 24); 
+INSERT INTO users (name, age) VALUES ('Alice', 42);

--- a/bindings/javascript/__test__/better-sqlite3.spec.mjs
+++ b/bindings/javascript/__test__/better-sqlite3.spec.mjs
@@ -66,6 +66,7 @@ test("Test bind()", async (t) => {
   db.prepare("CREATE TABLE users (name TEXT, age INTEGER)").run();
   db.prepare("INSERT INTO users (name, age) VALUES (?, ?)").run("Alice", 42);
   let stmt = db.prepare("SELECT * FROM users WHERE name = ?").bind("Alice");
+  console.log(db.prepare("SELECT * FROM users").raw().get());
 
   for (const row of stmt.iterate()) {
     t.truthy(row.name);

--- a/bindings/javascript/__test__/better-sqlite3.spec.mjs
+++ b/bindings/javascript/__test__/better-sqlite3.spec.mjs
@@ -1,4 +1,7 @@
 import test from "ava";
+import fs from "node:fs";
+import { fileURLToPath } from "url";
+import path from "node:path"
 
 import Database from "better-sqlite3";
 
@@ -76,6 +79,21 @@ test("Test bind()", async (t) => {
     { instanceOf: Error },
   );
 });
+
+test("Test exec()", async (t) => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+
+  const [db] = await connect(":memory:");
+  const file = fs.readFileSync(path.resolve(__dirname, "./artifacts/basic-test.sql"), "utf8");
+  db.exec(file);
+  let rows = db.prepare("SELECT * FROM users").iterate();
+  for (const row of rows) {
+    t.truthy(row.name);
+    t.true(typeof row.age === "number");
+  }
+});
+
 
 const connect = async (path) => {
   const db = new Database(path);

--- a/bindings/javascript/__test__/limbo.spec.mjs
+++ b/bindings/javascript/__test__/limbo.spec.mjs
@@ -1,4 +1,7 @@
 import test from "ava";
+import fs from "node:fs";
+import { fileURLToPath } from "url";
+import path from "node:path";
 
 import { Database } from "../wrapper.js";
 
@@ -100,6 +103,20 @@ test("Test pluck(): Rows should only have the values of the first column", async
   for (const row of stmt.iterate()) {
     t.truthy(row.name);
     t.true(typeof row.age === "undefined");
+  }
+});
+
+test("Test exec()", async (t) => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+
+  const [db] = await connect(":memory:");
+  const file = fs.readFileSync(path.resolve(__dirname, "./artifacts/basic-test.sql"), "utf8");
+  db.exec(file);
+  let rows = db.prepare("SELECT * FROM users").iterate();
+  for (const row of rows) {
+    t.truthy(row.name);
+    t.true(typeof row.age === "number");
   }
 });
 


### PR DESCRIPTION
Now we can execute a sequence of statements from exec, it's similar to `execute_batch()` from rusqlite

EDIT: It also add support for raw mode and do a small clean up to push if statements outside loops