### PR TITLE
Pass input string to `translate` function

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -60,6 +60,7 @@ pub fn translate(
     connection: Weak<Connection>,
     syms: &SymbolTable,
     query_mode: QueryMode,
+    _input: &str, // TODO: going to be used for CREATE VIEW
 ) -> Result<Program> {
     let change_cnt_on = matches!(
         stmt,


### PR DESCRIPTION
In preparation for `CREATE VIEW`, we need to have the original sql query that was used to create the view. I'm using the scanner's offset to slice into the original input, trimming the newlines, and passing it to the translate function.