### PR TITLE
simulator: switch to tracing, run io.run_once and add update queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,8 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -32,3 +32,6 @@ notify = "8.0.0"
 rusqlite = { version = "0.34", features = ["bundled"] }
 dirs = "6.0.0"
 chrono = { version = "0.4.40", features = ["serde"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -482,7 +482,6 @@ impl Interaction {
     pub(crate) fn execute_query(&self, conn: &mut Rc<Connection>, io: &SimulatorIO) -> ResultSet {
         if let Self::Query(query) = self {
             let query_str = query.to_string();
-            tracing::info!("executing: {}", query_str);
             let rows = conn.query(&query_str);
             if rows.is_err() {
                 let err = rows.err();

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -515,7 +515,6 @@ impl Interaction {
                     }
                     StepResult::IO => {
                         io.run_once().unwrap();
-                        tracing::info!("io");
                     }
                     StepResult::Interrupt => {}
                     StepResult::Done => {

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -1,17 +1,18 @@
 use std::{fmt::Display, path::Path, rc::Rc, vec};
 
-use limbo_core::{Connection, Result, StepResult};
+use limbo_core::{Connection, Result, StepResult, IO};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     model::{
         query::{
             select::{Distinctness, Predicate, ResultColumn},
+            update::Update,
             Create, Delete, Drop, Insert, Query, Select,
         },
         table::Value,
     },
-    runner::env::SimConnection,
+    runner::{env::SimConnection, io::SimulatorIO},
     SimulatorEnv,
 };
 
@@ -202,6 +203,7 @@ pub(crate) struct InteractionStats {
     pub(crate) read_count: usize,
     pub(crate) write_count: usize,
     pub(crate) delete_count: usize,
+    pub(crate) update_count: usize,
     pub(crate) create_count: usize,
     pub(crate) drop_count: usize,
 }
@@ -210,10 +212,11 @@ impl Display for InteractionStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Read: {}, Write: {}, Delete: {}, Create: {}, Drop: {}",
+            "Read: {}, Write: {}, Delete: {}, Update: {}, Create: {}, Drop: {}",
             self.read_count,
             self.write_count,
             self.delete_count,
+            self.update_count,
             self.create_count,
             self.drop_count
         )
@@ -369,6 +372,9 @@ impl Interactions {
                             Query::Select(select) => {
                                 select.shadow(env);
                             }
+                            Query::Update(update) => {
+                                update.shadow(env);
+                            }
                         },
                         Interaction::Assertion(_) => {}
                         Interaction::Assumption(_) => {}
@@ -395,6 +401,7 @@ impl InteractionPlan {
         let mut delete = 0;
         let mut create = 0;
         let mut drop = 0;
+        let mut update = 0;
 
         for interactions in &self.plan {
             match interactions {
@@ -407,6 +414,7 @@ impl InteractionPlan {
                                 Query::Delete(_) => delete += 1,
                                 Query::Create(_) => create += 1,
                                 Query::Drop(_) => drop += 1,
+                                Query::Update(_) => update += 1,
                             }
                         }
                     }
@@ -417,6 +425,7 @@ impl InteractionPlan {
                     Query::Delete(_) => delete += 1,
                     Query::Create(_) => create += 1,
                     Query::Drop(_) => drop += 1,
+                    Query::Update(_) => update += 1,
                 },
                 Interactions::Fault(_) => {}
             }
@@ -428,6 +437,7 @@ impl InteractionPlan {
             delete_count: delete,
             create_count: create,
             drop_count: drop,
+            update_count: update,
         }
     }
 }
@@ -446,7 +456,7 @@ impl ArbitraryFrom<&mut SimulatorEnv> for InteractionPlan {
             .push(Interactions::Query(Query::Create(create_query)));
 
         while plan.plan.len() < num_interactions {
-            log::debug!(
+            tracing::debug!(
                 "Generating interaction {}/{}",
                 plan.plan.len(),
                 num_interactions
@@ -457,7 +467,7 @@ impl ArbitraryFrom<&mut SimulatorEnv> for InteractionPlan {
             plan.plan.push(interactions);
         }
 
-        log::info!("Generated plan with {} interactions", plan.plan.len());
+        tracing::info!("Generated plan with {} interactions", plan.plan.len());
         plan
     }
 }
@@ -469,13 +479,14 @@ impl Interaction {
             Self::Assumption(_) | Self::Assertion(_) | Self::Fault(_) => vec![],
         }
     }
-    pub(crate) fn execute_query(&self, conn: &mut Rc<Connection>) -> ResultSet {
+    pub(crate) fn execute_query(&self, conn: &mut Rc<Connection>, io: &SimulatorIO) -> ResultSet {
         if let Self::Query(query) = self {
             let query_str = query.to_string();
+            tracing::info!("executing: {}", query_str);
             let rows = conn.query(&query_str);
             if rows.is_err() {
                 let err = rows.err();
-                log::debug!(
+                tracing::debug!(
                     "Error running query '{}': {:?}",
                     &query_str[0..query_str.len().min(4096)],
                     err
@@ -503,7 +514,10 @@ impl Interaction {
                         }
                         out.push(r);
                     }
-                    StepResult::IO => {}
+                    StepResult::IO => {
+                        io.run_once().unwrap();
+                        tracing::info!("io");
+                    }
                     StepResult::Interrupt => {}
                     StepResult::Done => {
                         break;
@@ -626,6 +640,10 @@ fn random_delete<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Interactions 
     Interactions::Query(Query::Delete(Delete::arbitrary_from(rng, env)))
 }
 
+fn random_update<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Interactions {
+    Interactions::Query(Query::Update(Update::arbitrary_from(rng, env)))
+}
+
 fn random_drop<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Interactions {
     Interactions::Query(Query::Drop(Drop::arbitrary_from(rng, env)))
 }
@@ -663,6 +681,10 @@ impl ArbitraryFrom<(&SimulatorEnv, InteractionStats)> for Interactions {
                 (
                     remaining_.delete,
                     Box::new(|rng: &mut R| random_delete(rng, env)),
+                ),
+                (
+                    remaining_.update,
+                    Box::new(|rng: &mut R| random_update(rng, env)),
                 ),
                 (
                     // remaining_.drop,

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -444,6 +444,7 @@ pub(crate) struct Remaining {
     pub(crate) write: f64,
     pub(crate) create: f64,
     pub(crate) delete: f64,
+    pub(crate) update: f64,
     pub(crate) drop: f64,
 }
 
@@ -460,6 +461,9 @@ pub(crate) fn remaining(env: &SimulatorEnv, stats: &InteractionStats) -> Remaini
     let remaining_delete = ((env.opts.max_interactions as f64 * env.opts.delete_percent / 100.0)
         - (stats.delete_count as f64))
         .max(0.0);
+    let remaining_update = ((env.opts.max_interactions as f64 * env.opts.delete_percent / 100.0)
+        - (stats.update_count as f64))
+        .max(0.0);
     let remaining_drop = ((env.opts.max_interactions as f64 * env.opts.drop_percent / 100.0)
         - (stats.drop_count as f64))
         .max(0.0);
@@ -470,6 +474,7 @@ pub(crate) fn remaining(env: &SimulatorEnv, stats: &InteractionStats) -> Remaini
         create: remaining_create,
         delete: remaining_delete,
         drop: remaining_drop,
+        update: remaining_update,
     }
 }
 

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -600,6 +600,7 @@ fn setup_simulation(
             let mut rng = rand::thread_rng();
             rng.next_u64()
         });
+        tracing::info!("seed={}", seed);
 
         let paths = bugbase.paths(seed);
         if !paths.base.exists() {

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -12,6 +12,7 @@ use runner::execution::{execute_plans, Execution, ExecutionHistory, ExecutionRes
 use runner::{differential, watch};
 use std::any::Any;
 use std::backtrace::Backtrace;
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
@@ -654,6 +655,12 @@ fn run_simulation(
 }
 
 fn init_logger() {
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open("simulator.log")
+        .unwrap();
     let _ = tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
@@ -663,6 +670,14 @@ fn init_logger() {
                 .with_thread_ids(false),
         )
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(file)
+                .with_ansi(false)
+                .with_line_number(true)
+                .without_time()
+                .with_thread_ids(false),
+        )
         .try_init();
 }
 

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -564,6 +564,7 @@ fn setup_simulation(
 ) -> (u64, SimulatorEnv, Vec<InteractionPlan>) {
     if let Some(seed) = &cli_opts.load {
         let seed = seed.parse::<u64>().expect("seed should be a number");
+        tracing::info!("seed={}", seed);
         let bug = bugbase
             .get_bug(seed)
             .unwrap_or_else(|| panic!("bug '{}' not found in bug base", seed));
@@ -660,7 +661,7 @@ fn init_logger() {
                 .without_time()
                 .with_thread_ids(false),
         )
-        .with(EnvFilter::from_default_env())
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .try_init();
 }
 

--- a/simulator/model/query/mod.rs
+++ b/simulator/model/query/mod.rs
@@ -6,6 +6,7 @@ pub(crate) use drop::Drop;
 pub(crate) use insert::Insert;
 pub(crate) use select::Select;
 use serde::{Deserialize, Serialize};
+use update::Update;
 
 use crate::{model::table::Value, runner::env::SimulatorEnv};
 
@@ -14,6 +15,7 @@ pub mod delete;
 pub mod drop;
 pub mod insert;
 pub mod select;
+pub mod update;
 
 // This type represents the potential queries on the database.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,6 +24,7 @@ pub(crate) enum Query {
     Select(Select),
     Insert(Insert),
     Delete(Delete),
+    Update(Update),
     Drop(Drop),
 }
 
@@ -33,6 +36,7 @@ impl Query {
             | Query::Insert(Insert::Select { table, .. })
             | Query::Insert(Insert::Values { table, .. })
             | Query::Delete(Delete { table, .. })
+            | Query::Update(Update { table, .. })
             | Query::Drop(Drop { table, .. }) => vec![table.clone()],
         }
     }
@@ -43,6 +47,7 @@ impl Query {
             | Query::Insert(Insert::Select { table, .. })
             | Query::Insert(Insert::Values { table, .. })
             | Query::Delete(Delete { table, .. })
+            | Query::Update(Update { table, .. })
             | Query::Drop(Drop { table, .. }) => vec![table.clone()],
         }
     }
@@ -53,6 +58,7 @@ impl Query {
             Query::Insert(insert) => insert.shadow(env),
             Query::Delete(delete) => delete.shadow(env),
             Query::Select(select) => select.shadow(env),
+            Query::Update(update) => update.shadow(env),
             Query::Drop(drop) => drop.shadow(env),
         }
     }
@@ -65,6 +71,7 @@ impl Display for Query {
             Self::Select(select) => write!(f, "{}", select),
             Self::Insert(insert) => write!(f, "{}", insert),
             Self::Delete(delete) => write!(f, "{}", delete),
+            Self::Update(update) => write!(f, "{}", update),
             Self::Drop(drop) => write!(f, "{}", drop),
         }
     }

--- a/simulator/model/query/update.rs
+++ b/simulator/model/query/update.rs
@@ -1,0 +1,56 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{model::table::Value, SimulatorEnv};
+
+use super::select::Predicate;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct Update {
+    pub(crate) table: String,
+    pub(crate) set_values: Vec<(String, Value)>, // Pair of value for set expressions => SET name=value
+    pub(crate) predicate: Predicate,
+}
+
+impl Update {
+    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<Value>> {
+        let table = env
+            .tables
+            .iter_mut()
+            .find(|t| t.name == self.table)
+            .unwrap();
+        let t2 = table.clone();
+        for row in table
+            .rows
+            .iter_mut()
+            .filter(|r| self.predicate.test(r, &t2))
+        {
+            for (column, set_value) in &self.set_values {
+                let (idx, _) = table
+                    .columns
+                    .iter()
+                    .enumerate()
+                    .find(|(_, c)| &c.name == column)
+                    .unwrap();
+                row[idx] = set_value.clone();
+            }
+        }
+
+        vec![]
+    }
+}
+
+impl Display for Update {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "UPDATE {} SET ", self.table)?;
+        for (i, (name, value)) in self.set_values.iter().enumerate() {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{} = {}", name, value)?;
+        }
+        write!(f, " WHERE {}", self.predicate)?;
+        Ok(())
+    }
+}

--- a/simulator/runner/bugbase.rs
+++ b/simulator/runner/bugbase.rs
@@ -116,7 +116,7 @@ impl BugBase {
         for path in potential_paths {
             let path = path.join(".bugbase");
             if std::fs::create_dir_all(&path).is_ok() {
-                log::info!("bug base created at {}", path.display());
+                tracing::info!("bug base created at {}", path.display());
                 return BugBase::new(path);
             }
         }
@@ -172,7 +172,7 @@ impl BugBase {
             unreachable!("bug base already exists at {}", path.display());
         } else {
             std::fs::create_dir_all(&path).or(Err("failed to create bug base"))?;
-            log::info!("bug base created at {}", path.display());
+            tracing::info!("bug base created at {}", path.display());
             BugBase::new(path)
         }
     }
@@ -185,7 +185,7 @@ impl BugBase {
         error: Option<String>,
         cli_options: &SimulatorCLI,
     ) -> Result<(), String> {
-        log::debug!("adding bug with seed {}", seed);
+        tracing::debug!("adding bug with seed {}", seed);
         let bug = self.get_bug(seed);
 
         if bug.is_some() {
@@ -290,11 +290,11 @@ impl BugBase {
                 };
 
                 self.bugs.insert(seed, Bug::Loaded(bug.clone()));
-                log::debug!("Loaded bug with seed {}", seed);
+                tracing::debug!("Loaded bug with seed {}", seed);
                 Ok(bug)
             }
             Some(Bug::Loaded(bug)) => {
-                log::warn!(
+                tracing::warn!(
                     "Bug with seed {} is already loaded, returning the existing plan",
                     seed
                 );
@@ -311,7 +311,7 @@ impl BugBase {
         let bug = self.get_bug(seed);
         match bug {
             None => {
-                log::debug!("removing bug base entry for {}", seed);
+                tracing::debug!("removing bug base entry for {}", seed);
                 std::fs::remove_dir_all(self.path.join(seed.to_string()))
                     .or(Err("should be able to remove bug directory".to_string()))?;
             }
@@ -327,7 +327,7 @@ impl BugBase {
                 // Save the bug to the bug base.
                 self.save_bug(seed)
                     .or(Err("should be able to save bug".to_string()))?;
-                log::debug!("Updated bug with seed {}", seed);
+                tracing::debug!("Updated bug with seed {}", seed);
             }
         }
 

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -90,7 +90,7 @@ impl SimulatorCLI {
         }
 
         if self.minimum_tests > self.maximum_tests {
-            log::warn!(
+            tracing::warn!(
                 "minimum size '{}' is greater than '{}' maximum size, setting both to '{}'",
                 self.minimum_tests,
                 self.maximum_tests,

--- a/simulator/runner/file.rs
+++ b/simulator/runner/file.rs
@@ -32,29 +32,29 @@ impl SimulatorFile {
     }
 
     pub(crate) fn print_stats(&self) {
-        log::info!("op           calls   faults");
-        log::info!("--------- -------- --------");
-        log::info!(
+        tracing::info!("op           calls   faults");
+        tracing::info!("--------- -------- --------");
+        tracing::info!(
             "pread     {:8} {:8}",
             *self.nr_pread_calls.borrow(),
             *self.nr_pread_faults.borrow()
         );
-        log::info!(
+        tracing::info!(
             "pwrite    {:8} {:8}",
             *self.nr_pwrite_calls.borrow(),
             *self.nr_pwrite_faults.borrow()
         );
-        log::info!(
+        tracing::info!(
             "sync      {:8} {:8}",
             *self.nr_sync_calls.borrow(),
             0 // No fault counter for sync
         );
-        log::info!("--------- -------- --------");
+        tracing::info!("--------- -------- --------");
         let sum_calls = *self.nr_pread_calls.borrow()
             + *self.nr_pwrite_calls.borrow()
             + *self.nr_sync_calls.borrow();
         let sum_faults = *self.nr_pread_faults.borrow() + *self.nr_pwrite_faults.borrow();
-        log::info!("total     {:8} {:8}", sum_calls, sum_faults);
+        tracing::info!("total     {:8} {:8}", sum_calls, sum_faults);
     }
 }
 

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -43,10 +43,10 @@ impl SimulatorIO {
     }
 
     pub(crate) fn print_stats(&self) {
-        log::info!("run_once faults: {}", self.nr_run_once_faults.borrow());
+        tracing::info!("run_once faults: {}", self.nr_run_once_faults.borrow());
         for file in self.files.borrow().iter() {
-            log::info!("");
-            log::info!("===========================");
+            tracing::info!("");
+            tracing::info!("===========================");
             file.print_stats();
         }
     }

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -31,7 +31,7 @@ pub(crate) fn run_simulation(
     let env = env.lock().unwrap();
     env.io.print_stats();
 
-    log::info!("Simulation completed");
+    tracing::info!("Simulation completed");
 
     result
 }
@@ -97,13 +97,13 @@ fn execute_plan(
     let interaction = &plan[state.interaction_pointer][state.secondary_pointer];
 
     if let SimConnection::Disconnected = connection {
-        log::debug!("connecting {}", connection_index);
+        tracing::debug!("connecting {}", connection_index);
         env.connections[connection_index] =
             SimConnection::LimboConnection(env.db.connect().unwrap());
     } else {
         match execute_interaction(env, connection_index, interaction, &mut state.stack) {
             Ok(next_execution) => {
-                log::debug!("connection {} processed", connection_index);
+                tracing::debug!("connection {} processed", connection_index);
                 // Move to the next interaction or property
                 match next_execution {
                     ExecutionContinuation::NextInteraction => {
@@ -124,7 +124,7 @@ fn execute_plan(
                 }
             }
             Err(err) => {
-                log::error!("error {}", err);
+                tracing::error!("error {}", err);
                 return Err(err);
             }
         }

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -46,7 +46,7 @@ impl InteractionPlan {
 
         let after = plan.plan.len();
 
-        log::info!(
+        tracing::info!(
             "Shrinking interaction plan from {} to {} properties",
             before,
             after


### PR DESCRIPTION
* Without tracing crate we cannot log anything that happens in limbo_core
* IO never ran in step loop inside simulator.
* Added update queries (which currently loop forever for some reason I'm debugging).