### PR TITLE
Small tracing enhancement

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -855,6 +855,7 @@ impl Limbo {
             } else {
                 (tracing_appender::non_blocking(std::io::stderr()), true)
             };
+        // Disable rustyline traces
         if let Err(e) = tracing_subscriber::registry()
             .with(
                 tracing_subscriber::fmt::layer()
@@ -863,7 +864,7 @@ impl Limbo {
                     .with_thread_ids(true)
                     .with_ansi(should_emit_ansi),
             )
-            .with(EnvFilter::from_default_env())
+            .with(EnvFilter::from_default_env().add_directive("rustyline=off".parse().unwrap()))
             .try_init()
         {
             println!("Unable to setup tracing appender: {:?}", e);

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -563,6 +563,7 @@ fn make_record(registers: &[Register], start_reg: &usize, count: &usize) -> Immu
     ImmutableRecord::from_registers(&registers[*start_reg..*start_reg + *count])
 }
 
+#[tracing::instrument(skip(program), level = tracing::Level::TRACE)]
 fn trace_insn(program: &Program, addr: InsnReference, insn: &Insn) {
     if !tracing::enabled!(tracing::Level::TRACE) {
         return;


### PR DESCRIPTION
Instrument trace_insn to debug print its the stack pc and instruction. Also, disable rustyline logs for the CLI as it is too noisy to work with.