### PR TITLE
Fix WAL frame checksum mismatch

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -191,10 +191,12 @@ pub struct WalHeader {
     /// Checkpoint sequence number. Increases with each checkpoint
     pub checkpoint_seq: u32,
 
-    /// Random value used for the first salt in checksum calculations, incremented with each checkpoint
+    /// Random value used for the first salt in checksum calculations
+    /// TODO: Incremented with each checkpoint
     pub salt_1: u32,
 
-    /// Random value used for the second salt in checksum calculations. A different random value for each checkpoint
+    /// Random value used for the second salt in checksum calculations.
+    /// TODO: A different random value for each checkpoint
     pub salt_2: u32,
 
     /// First checksum value in the wal-header

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -191,10 +191,10 @@ pub struct WalHeader {
     /// Checkpoint sequence number. Increases with each checkpoint
     pub checkpoint_seq: u32,
 
-    /// Random value used for the first salt in checksum calculations
+    /// Random value used for the first salt in checksum calculations, incremented with each checkpoint
     pub salt_1: u32,
 
-    /// Random value used for the second salt in checksum calculations
+    /// Random value used for the second salt in checksum calculations. A different random value for each checkpoint
     pub salt_2: u32,
 
     /// First checksum value in the wal-header
@@ -1471,11 +1471,16 @@ pub fn read_entire_wal_dumb(file: &Arc<dyn File>) -> Result<Arc<UnsafeCell<WalFi
             let frame_h_checksum_2 =
                 u32::from_be_bytes(frame_header_slice[20..24].try_into().unwrap());
 
+            // It contains more frames with mismatched SALT values, which means they're leftovers from previous checkpoints
             if frame_h_salt_1 != header_locked.salt_1 || frame_h_salt_2 != header_locked.salt_2 {
-                panic!(
-                    "WAL frame salt mismatch. Expected ({}, {}), Got ({}, {})",
-                    header_locked.salt_1, header_locked.salt_2, frame_h_salt_1, frame_h_salt_2
+                tracing::trace!(
+                    "WAL frame salt mismatch: expected ({}, {}), got ({}, {}), ignoring frame",
+                    header_locked.salt_1,
+                    header_locked.salt_2,
+                    frame_h_salt_1,
+                    frame_h_salt_2
                 );
+                break;
             }
 
             let checksum_after_fh_meta = checksum_wal(


### PR DESCRIPTION
Closes #1622

I did an A/B test between SQLite and Limbo and they can restart the db from each other, indicating that there isn't something very wrong with our file format. Turns out it was with our reset logic without truncating the file. I assumed it's safe to don't reset if we're in `PASSIVE` mode, given the [docs](https://www.sqlite.org/c3ref/wal_checkpoint_v2.html) and [source code](https://github.com/sqlite/sqlite/blob/2bd9f69d40dd240c4122c6d02f1ff447e7b5c098/src/wal.c#L2193).

It also does some small clean ups and fixes.