### PR TITLE
simulator: options to disable certain query types

### DIFF
--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -461,7 +461,7 @@ pub(crate) fn remaining(env: &SimulatorEnv, stats: &InteractionStats) -> Remaini
     let remaining_delete = ((env.opts.max_interactions as f64 * env.opts.delete_percent / 100.0)
         - (stats.delete_count as f64))
         .max(0.0);
-    let remaining_update = ((env.opts.max_interactions as f64 * env.opts.delete_percent / 100.0)
+    let remaining_update = ((env.opts.max_interactions as f64 * env.opts.update_percent / 100.0)
         - (stats.update_count as f64))
         .max(0.0);
     let remaining_drop = ((env.opts.max_interactions as f64 * env.opts.drop_percent / 100.0)
@@ -716,7 +716,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     Box::new(|rng: &mut R| property_select_limit(rng, env)),
                 ),
                 (
-                    f64::min(remaining_.read, remaining_.write),
+                    f64::min(remaining_.read, remaining_.write).min(remaining_.delete),
                     Box::new(|rng: &mut R| property_delete_select(rng, env, &remaining_)),
                 ),
                 (

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -128,7 +128,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &Remaining)> for Query {
                     Box::new(|rng| Self::Insert(Insert::arbitrary_from(rng, env))),
                 ),
                 (
-                    remaining.write,
+                    f64::min(remaining.write, remaining.delete),
                     Box::new(|rng| Self::Delete(Delete::arbitrary_from(rng, env))),
                 ),
             ],

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -48,6 +48,14 @@ pub struct SimulatorCLI {
     pub subcommand: Option<SimulatorCommand>,
     #[clap(long, help = "disable BugBase", default_value_t = false)]
     pub disable_bugbase: bool,
+    #[clap(long, help = "disable UPDATE Statement", default_value_t = false)]
+    pub disable_update: bool,
+    #[clap(long, help = "disable DELETE Statement", default_value_t = false)]
+    pub disable_delete: bool,
+    #[clap(long, help = "disable CREATE Statement", default_value_t = false)]
+    pub disable_create: bool,
+    #[clap(long, help = "disable DROP Statement", default_value_t = false)]
+    pub disable_drop: bool,
 }
 
 #[derive(Parser, Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]


### PR DESCRIPTION
Some additional cli options and some adjustments to determine if a query statement is disabled for this run. This enables us to at least run the simulator to completion when other parts of the system cause infinite loops almost every time. I'm looking at you UPDATE