### PR TITLE
simulator: Fix floating point equality assertion

### DIFF
--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -73,14 +73,19 @@ impl SimulatorEnv {
         let write_percent =
             write_percent - create_percent - delete_percent - drop_percent - update_percent;
 
-        assert_eq!(
-            read_percent
-                + write_percent
-                + create_percent
-                + drop_percent
-                + update_percent
-                + delete_percent,
-            total
+        let sum: f64 = read_percent
+            + write_percent
+            + create_percent
+            + drop_percent
+            + update_percent
+            + delete_percent;
+
+        assert!(
+            (sum - total).abs() < 0.001,
+            "Sum of percentages ({}) does not match total ({}) - difference: {}",
+            sum,
+            total,
+            sum - total
         );
 
         let opts = SimulatorOpts {


### PR DESCRIPTION
You cannot compare floating point values for equality...

```
 INFO limbo_sim: 624: seed=8124814905522081926
thread 'main' panicked at simulator/runner/env.rs:76:9:
assertion `left == right` failed
  left: 100.00000000000001
 right: 100.0
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/panicking.rs:74:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /Users/penberg/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panicking.rs:367:5
   4: limbo_sim::runner::env::SimulatorEnv::new
             at ./simulator/runner/env.rs:76:9
   5: limbo_sim::setup_simulation
             at ./simulator/main.rs:641:23
   6: limbo_sim::testing_main
             at ./simulator/main.rs:139:9
   7: limbo_sim::main
             at ./simulator/main.rs:125:13
   8: core::ops::function::FnOnce::call_once
             at /Users/penberg/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```