### PR TITLE
Fix:  ensure `PRAGMA cache_size` changes persist only for current session

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -240,6 +240,7 @@ impl Database {
             syms: RefCell::new(SymbolTable::new()),
             total_changes: Cell::new(0),
             _shared_cache: false,
+            cache_size: Cell::new(self.header.lock().default_page_cache_size),
         });
         if let Err(e) = conn.register_builtins() {
             return Err(LimboError::ExtensionError(e));
@@ -339,6 +340,7 @@ pub struct Connection {
     total_changes: Cell<i64>,
     syms: RefCell<SymbolTable>,
     _shared_cache: bool,
+    cache_size: Cell<i32>,
 }
 
 impl Connection {
@@ -593,6 +595,13 @@ impl Connection {
 
     pub fn total_changes(&self) -> i64 {
         self.total_changes.get()
+    }
+
+    pub fn get_cache_size(&self) -> i32 {
+        self.cache_size.get()
+    }
+    pub fn set_cache_size(&self, size: i32) {
+        self.cache_size.set(size);
     }
 
     #[cfg(feature = "fs")]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -251,7 +251,7 @@ impl Default for DatabaseHeader {
             freelist_pages: 0,
             schema_cookie: 0,
             schema_format: 4, // latest format, new sqlite3 databases use this format
-            default_page_cache_size: 500, // pages
+            default_page_cache_size: DEFAULT_CACHE_SIZE,
             vacuum_mode_largest_root_page: 0,
             text_encoding: 1, // utf-8
             user_version: 0,

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -88,6 +88,7 @@ pub fn translate(
             body.map(|b| *b),
             database_header.clone(),
             pager,
+            connection.clone(),
             program,
         )?,
         stmt => translate_inner(schema, stmt, syms, query_mode, program)?,

--- a/testing/pragma.test
+++ b/testing/pragma.test
@@ -3,6 +3,16 @@
 set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
+do_execsql_test_on_specific_db ":memory:" pragma-cache-size-default {
+  PRAGMA cache_size
+} {-2000}
+
+do_execsql_test pragma-set-cache-size {
+  PRAGMA cache_size = 100;
+  PRAGMA cache_size
+} {100}
+
+# Even though the cache size was set to 100 in previous test, a new connection defaults back to -2000.
 do_execsql_test pragma-cache-size {
   PRAGMA cache_size
 } {-2000}


### PR DESCRIPTION
According to [the document](https://www.sqlite.org/pragma.html#pragma_cache_size): 
```
When you change the cache size using the cache_size pragma, the change only endures for the current session. The cache size reverts to the default value when the database is closed and reopened.
```
so, we shouldn't persist cache_size to database header.

this PR also addresses two minor issues:

1. Sets the default cache_size to -2000 to align with SQLite's default
2. Uses the actual page size to calculate the cache size.
