### PR TITLE
`LimboRwLock` write and read lock fixes

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -133,7 +133,7 @@ impl LimboRwLock {
                 // no op
                 false
             }
-            WRITE_LOCK => true,
+            WRITE_LOCK => false,
             _ => unreachable!(),
         };
         tracing::trace!("write_lock({})", ok);


### PR DESCRIPTION
* `write` was returning `true` even though it shouldn't because it should return `false` in case it was already acquired.
* `read` theoritically can increase `nread` after another thread calls `unlock` between first lock load and increase of `nread`. So it looks something like this:
                  1. THREAD  1: read() 
                  2. THREAD 2: get lock = `SHARED_LOCK`
                  3. THREAD 1: unlock -> lock is now `NO_LOCK`
                  4. THREAD 2: increase nread, return true.
    This is obviously wrong because `nreads` will be ` > 0 ` but `lock` is `NO_LOCK`
