### PR TITLE
Minor: use use_eq_ignore_ascii_case in some places

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -425,8 +425,8 @@ impl Limbo {
         };
         // TODO this is a quickfix. Some ideas to do case insensitive comparisons is to use
         // Uncased or Unicase.
-        let temp = input.to_lowercase();
-        if temp.trim_start().starts_with("explain") {
+        let explain_str = "explain";
+        if input.trim_start()[0..explain_str.len()].eq_ignore_ascii_case(explain_str) {
             match self.conn.query(input) {
                 Ok(Some(stmt)) => {
                     let _ = self.writeln(stmt.explain().as_bytes());

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -44,7 +44,7 @@ pub fn translate_pragma(
     program.extend(&opts);
     let mut write = false;
 
-    if name.name.0.to_lowercase() == "pragma_list" {
+    if name.name.0.eq_ignore_ascii_case("pragma_list") {
         list_pragmas(&mut program);
         return Ok(program);
     }


### PR DESCRIPTION
Use `eq_ignore_ascii_case` because it's cooler 😎 than `x.to_lowercase() == y.to_lowercase()`.