### PR TITLE
[Issue-1681] Fix `Update` query to update `n_changes` 

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -29,7 +29,7 @@ use crate::translate::plan::{DeletePlan, Plan, Search};
 use crate::translate::values::emit_values;
 use crate::util::exprs_are_equivalent;
 use crate::vdbe::builder::{CursorKey, CursorType, ProgramBuilder};
-use crate::vdbe::insn::{CmpInsFlags, IdxInsertFlags, RegisterOrLiteral};
+use crate::vdbe::insn::{CmpInsFlags, IdxInsertFlags, InsertFlags, RegisterOrLiteral};
 use crate::vdbe::{insn::Insn, BranchOffset};
 use crate::{Result, SymbolTable};
 
@@ -1319,7 +1319,7 @@ fn emit_update_insns(
             cursor: cursor_id,
             key_reg: rowid_set_clause_reg.unwrap_or(beg),
             record_reg,
-            flag: 0,
+            flag: InsertFlags::new().update(true),
             table_name: table_ref.identifier.clone(),
         });
     } else if let Some(_) = table_ref.virtual_table() {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -8,7 +8,7 @@ use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
 use crate::schema::{IndexColumn, Table};
 use crate::util::normalize_ident;
 use crate::vdbe::builder::{ProgramBuilderOpts, QueryMode};
-use crate::vdbe::insn::{IdxInsertFlags, RegisterOrLiteral};
+use crate::vdbe::insn::{IdxInsertFlags, InsertFlags, RegisterOrLiteral};
 use crate::vdbe::BranchOffset;
 use crate::{
     schema::{Column, Schema},
@@ -212,7 +212,7 @@ pub fn translate_insert(
                         cursor: temp_cursor_id,
                         key_reg: rowid_reg,
                         record_reg,
-                        flag: 0,
+                        flag: InsertFlags::new(),
                         table_name: "".to_string(),
                     });
 
@@ -520,7 +520,7 @@ pub fn translate_insert(
         cursor: cursor_id,
         key_reg: rowid_reg,
         record_reg: record_register,
-        flag: 0,
+        flag: InsertFlags::new(),
         table_name: table_name.to_string(),
     });
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -66,7 +66,10 @@ pub fn translate(
 ) -> Result<Program> {
     let change_cnt_on = matches!(
         stmt,
-        ast::Stmt::CreateIndex { .. } | ast::Stmt::Delete(..) | ast::Stmt::Insert(..)
+        ast::Stmt::CreateIndex { .. }
+            | ast::Stmt::Delete(..)
+            | ast::Stmt::Insert(..)
+            | ast::Stmt::Update(..)
     );
 
     // These options will be extended whithin each translate program

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -16,7 +16,7 @@ use crate::translate::ProgramBuilderOpts;
 use crate::translate::QueryMode;
 use crate::util::PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX;
 use crate::vdbe::builder::CursorType;
-use crate::vdbe::insn::{CmpInsFlags, Insn};
+use crate::vdbe::insn::{CmpInsFlags, InsertFlags, Insn};
 use crate::LimboError;
 use crate::SymbolTable;
 use crate::{bail_parse_error, Result};
@@ -234,7 +234,7 @@ pub fn emit_schema_entry(
         cursor: sqlite_schema_cursor_id,
         key_reg: rowid_reg,
         record_reg,
-        flag: 0,
+        flag: InsertFlags::new(),
         table_name: tbl_name.to_string(),
     });
 }
@@ -843,7 +843,7 @@ pub fn translate_drop_table(
             cursor: ephemeral_cursor_id,
             key_reg: schema_row_id_register,
             record_reg: schema_data_register,
-            flag: 0,
+            flag: InsertFlags::new(),
             table_name: "scratch_table".to_string(),
         });
 
@@ -925,7 +925,7 @@ pub fn translate_drop_table(
             cursor: sqlite_schema_cursor_id_1,
             key_reg: schema_row_id_register,
             record_reg: new_record_register,
-            flag: 0,
+            flag: InsertFlags::new(),
             table_name: SQLITE_TABLEID.to_string(),
         });
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3871,7 +3871,6 @@ pub fn op_delete(
         return_if_io!(cursor.delete());
     }
     let prev_changes = program.n_change.get();
-    println!("[Insn::Delete] set n_changes to {}", prev_changes + 1);
     program.n_change.set(prev_changes + 1);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -3931,7 +3930,7 @@ pub fn op_idx_delete(
                     return_if_io!(cursor.delete());
                 }
                 let n_change = program.n_change.get();
-                println!("[Insn::IdxDelete] set n_changes to {}", n_change + 1);
+                tracing::debug!("[Insn::IdxDelete] set n_changes to {}", n_change + 1);
                 program.n_change.set(n_change + 1);
                 state.pc += 1;
                 state.op_idx_delete_state = None;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3838,7 +3838,7 @@ pub fn op_insert(
                     conn.update_last_rowid(rowid);
                 }
 
-                // n_changes is increased when Insn::Delete is executed, so we can skip for Insn::Insert
+                // n_change is increased when Insn::Delete is executed, so we can skip for Insn::Insert
                 if !flag.has(InsertFlags::UPDATE) {
                     let prev_changes = program.n_change.get();
                     program.n_change.set(prev_changes + 1);
@@ -3930,7 +3930,6 @@ pub fn op_idx_delete(
                     return_if_io!(cursor.delete());
                 }
                 let n_change = program.n_change.get();
-                tracing::debug!("[Insn::IdxDelete] set n_changes to {}", n_change + 1);
                 program.n_change.set(n_change + 1);
                 state.pc += 1;
                 state.op_idx_delete_state = None;

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1091,7 +1091,7 @@ pub fn insn_to_str(
                 *record_reg as i32,
                 *key_reg as i32,
                 Value::build_text(&table_name),
-                *flag as u16,
+                flag.0 as u16,
                 format!("intkey=r[{}] data=r[{}]", key_reg, record_reg),
             ),
             Insn::Delete { cursor_id } => (

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -82,6 +82,30 @@ impl IdxInsertFlags {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct InsertFlags(pub u8);
+
+impl InsertFlags {
+    pub const UPDATE: u8 = 0x01; // Flag indicating this is part of an UPDATE statement
+
+    pub fn new() -> Self {
+        InsertFlags(0)
+    }
+
+    pub fn has(&self, flag: u8) -> bool {
+        (self.0 & flag) != 0
+    }
+
+    pub fn update(mut self, is_update: bool) -> Self {
+        if is_update {
+            self.0 |= InsertFlags::UPDATE;
+        } else {
+            self.0 &= !InsertFlags::UPDATE;
+        }
+        self
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum RegisterOrLiteral<T: Copy + std::fmt::Display> {
     Register(usize),
@@ -665,7 +689,7 @@ pub enum Insn {
         cursor: CursorID,
         key_reg: usize,    // Must be int.
         record_reg: usize, // Blob of record data.
-        flag: usize,       // Flags used by insert, for now not used.
+        flag: InsertFlags, // Flags used by insert, for now not used.
         table_name: String,
     },
 

--- a/testing/total-changes.test
+++ b/testing/total-changes.test
@@ -21,3 +21,24 @@ do_execsql_test_on_specific_db {:memory:} total-changes-on-multiple-inserts {
     insert into temp values (4), (5), (6), (7);
     select total_changes();
 } {7}
+
+do_execsql_test_on_specific_db {:memory:} total-changes-on-update-single-row {
+    create table temp (t1 integer primary key, t2 text);
+    insert into temp values (1, 'a'), (2, 'b'), (3, 'c');
+    update temp set t2 = 'z' where t1 = 2;
+    select total_changes();
+} {4}
+
+do_execsql_test_on_specific_db {:memory:} total-changes-on-update-multiple-rows {
+    create table temp (t1 integer primary key, t2 text);
+    insert into temp values (1, 'a'), (2, 'b'), (3, 'c');
+    update temp set t2 = 'x' where t1 > 1;
+    select total_changes();
+} {5}
+
+do_execsql_test_on_specific_db {:memory:} total-changes-on-update-no-match {
+    create table temp (t1 integer primary key, t2 text);
+    insert into temp values (1, 'a'), (2, 'b');
+    update temp set t2 = 'y' where t1 = 99;
+    select total_changes();
+} {2}


### PR DESCRIPTION
## Purpose 

- `Update` query doesn't update `n_changes`. Let's make it work 

## Changes 

- Add `InsertFlags` to add meta information related to insert operations 
- For update query, add `UPDATE` flag 
- Becaues `UPDATE` does `Insn::Delete` and `Insn::Insert` internally, it increases `n_changes` by 2. So, for `UPDATE` query, let's skip increasing `n_changes` for the `Insn::Insert` 
