### PR TITLE
Fix UPDATE straight up not working on non-unique indexes

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3982,7 +3982,12 @@ pub fn op_idx_insert(
             let cursor = cursor.as_btree_mut();
             let record = match &state.registers[record_reg] {
                 Register::Record(ref r) => r,
-                _ => return Err(LimboError::InternalError("expected record".into())),
+                o => {
+                    return Err(LimboError::InternalError(format!(
+                        "expected record, got {:?}",
+                        o
+                    )));
+                }
             };
             // To make this reentrant in case of `moved_before` = false, we need to check if the previous cursor.insert started
             // a write/balancing operation. If it did, it means we already moved to the place we wanted.

--- a/testing/update.test
+++ b/testing/update.test
@@ -170,3 +170,18 @@ do_execsql_test_on_specific_db {:memory:} update_cache_full_regression_test_#162
     UPDATE t SET x = randomblob(4096) WHERE rowid = 1;
     SELECT count(*) FROM t;
 } {1}
+
+do_execsql_test_on_specific_db {:memory:} update_index_regression_test {
+    CREATE TABLE t(x, y);
+    CREATE INDEX tx ON t (x);
+    CREATE UNIQUE INDEX tyu ON t (y);
+    INSERT INTO t VALUES (1, 1);
+    SELECT x FROM t; -- uses tx index
+    SELECT y FROM t; -- uses ty index
+    UPDATE t SET x=2, y=2;
+    SELECT x FROM t; -- uses tx index
+    SELECT y FROM t; -- uses ty index    
+} {1
+1
+2
+2}


### PR DESCRIPTION
we were skipping `MakeRecord` for the new values from the `SET` clause if the index wasn't unique, effectively emitting NULLs. Although this would actually already fail in the `IdxInsert` instruction because the record register didn't actually contain a record.

this has been (I think) caught in at least 1. limbo stress 2. antithesis, but I incorrectly assumed it was something more edge-casey instead of broken like this in a fairly basic way