### PR TITLE
Simulator integrity_check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrayref"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,6 +1955,7 @@ name = "limbo_sim"
 version = "0.0.22-pre.1"
 dependencies = [
  "anarchist-readable-name-generator-lib",
+ "anyhow",
  "chrono",
  "clap",
  "dirs 6.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 serde = "1.0"
 serde_json = "1.0"
+anyhow = "1.0.98"
 
 [profile.release]
 debug = "line-tables-only"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "main.rs"
 
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow.workspace = true
 cfg-if = "1.0.0"
 clap = { version = "4.5.31", features = ["derive"] }
 clap_complete = { version = "=4.5.47", features = ["unstable-dynamic"] }

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -34,4 +34,5 @@ dirs = "6.0.0"
 chrono = { version = "0.4.40", features = ["serde"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+anyhow.workspace = true
 

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -93,12 +93,12 @@ pub enum SimulatorCommand {
 }
 
 impl SimulatorCLI {
-    pub fn validate(&mut self) -> Result<(), String> {
+    pub fn validate(&mut self) -> anyhow::Result<()> {
         if self.minimum_tests < 1 {
-            return Err("minimum size must be at least 1".to_string());
+            anyhow::bail!("minimum size must be at least 1");
         }
         if self.maximum_tests < 1 {
-            return Err("maximum size must be at least 1".to_string());
+            anyhow::bail!("maximum size must be at least 1");
         }
 
         if self.minimum_tests > self.maximum_tests {
@@ -112,7 +112,7 @@ impl SimulatorCLI {
         }
 
         if self.seed.is_some() && self.load.is_some() {
-            return Err("Cannot set seed and load plan at the same time".to_string());
+            anyhow::bail!("Cannot set seed and load plan at the same time");
         }
 
         Ok(())

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,7 +15,7 @@ name = "integration_tests"
 path = "integration/mod.rs"
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow.workspace = true
 env_logger = "0.10.1"
 limbo_core = { path = "../core" }
 rusqlite = { version = "0.34", features = ["bundled"] }


### PR DESCRIPTION
Adds a Sqlite integrity check after the simulator completes a run. Also changed error handling in the simulator to use `anyhow` to lazily add context to error methods instead of eagerly using `.or` and losing the original error. 