### PR TITLE
sim/aws: fix vibecoding errors in logic

### DIFF
--- a/simulator-docker-runner/docker-entrypoint.simulator.ts
+++ b/simulator-docker-runner/docker-entrypoint.simulator.ts
@@ -107,7 +107,7 @@ const run = async (seed: string, bin: string, args: string[]) => {
             type: "assertion",
             seed: seedForGithubIssue,
             command: args.join(" "),
-            output: output,
+            failureInfo,
           });
         }
       } catch (err2) {

--- a/simulator-docker-runner/logParse.ts
+++ b/simulator-docker-runner/logParse.ts
@@ -9,6 +9,7 @@ export type StackTraceInfo = {
 export type AssertionFailureInfo = {
   type: "assertion";
   output: string;
+  mainError: string;
 }
 
 /**
@@ -16,8 +17,6 @@ export type AssertionFailureInfo = {
  */
 export function extractFailureInfo(output: string): StackTraceInfo | AssertionFailureInfo {
   const lines = output.split('\n');
-
-  const panicLineIndex = lines.findIndex(line => line.includes("panic occurred"));
 
   const info = getTraceFromOutput(lines) ?? getAssertionFailureInfo(lines);
 
@@ -50,9 +49,10 @@ function getAssertionFailureInfo(lines: string[]): AssertionFailureInfo | null {
   }
 
   const startIndex = simulationFailedLineIndex;
-  const endIndex = Math.min(lines.length, startIndex + 1);
+  const endIndex = Math.min(lines.length, startIndex + 50);
 
   const output = lines.slice(startIndex, endIndex).join('\n');
+  const mainError = lines[startIndex] ?? "???";
 
-  return { type: "assertion", output };
+  return { type: "assertion", output, mainError };
 }


### PR DESCRIPTION
- Entire stdout+stderr was passed to both title and body for the github issue, resulting in a failure due to github's validation

Fixes:

- Pass only the line containing "simulation failed:" as title
- Pass max 50 lines following title as body
- Truncate title and body to 255 and 65536 chars respectively before posting github issue, just to be sure