### PR TITLE
Simple integrity check on btree

### DIFF
--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -73,6 +73,10 @@ fn pragma_for(pragma: PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["auto_vacuum"],
         ),
+        IntegrityCheck => Pragma::new(
+            PragmaFlags::NeedSchema | PragmaFlags::ReadOnly | PragmaFlags::Result0,
+            &["message"],
+        ),
     }
 }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5152,7 +5152,8 @@ pub fn integrity_check(
         page_idx,
         level,
         max_intkey,
-    }) = state.page_stack.last().cloned() else {
+    }) = state.page_stack.last().cloned()
+    else {
         return Ok(CursorResult::Ok(()));
     };
     let page = btree_read_page(pager, page_idx)?;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5101,6 +5101,19 @@ impl BTreeCursor {
     }
 }
 
+#[derive(Debug)]
+pub struct IntegrityCheckState {
+    pub current_page: usize,
+}
+
+pub fn integrity_check(
+    state: &mut IntegrityCheckState,
+    error_count: &mut usize,
+    message: &mut String,
+) -> Result<CursorResult<()>> {
+    Ok(CursorResult::Ok(()))
+}
+
 #[cfg(debug_assertions)]
 fn validate_cells_after_insertion(cell_array: &CellArray, leaf_data: bool) {
     for cell in &cell_array.cells {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5148,7 +5148,11 @@ pub fn integrity_check(
     message: &mut String,
     pager: &Rc<Pager>,
 ) -> Result<CursorResult<()>> {
-    let Some(IntegrityCheckPageEntry { page_idx, level, max_intkey }) = state.page_stack.last().cloned() else {
+    let Some(IntegrityCheckPageEntry {
+        page_idx,
+        level,
+        max_intkey,
+    }) = state.page_stack.last().cloned() else {
         return Ok(CursorResult::Ok(()));
     };
     let page = btree_read_page(pager, page_idx)?;

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -1,0 +1,45 @@
+use std::{
+    rc::{Rc, Weak},
+    sync::Arc,
+};
+
+use limbo_sqlite3_parser::ast;
+
+use crate::{
+    fast_lock::SpinLock,
+    schema::Schema,
+    storage::sqlite3_ondisk::DatabaseHeader,
+    vdbe::{builder::ProgramBuilder, insn::Insn},
+    Pager,
+};
+
+/// Maximum number of errors to report with integrity check. If we exceed this number we will short
+/// circuit the procedure and return early to not waste time.
+const MAX_INTEGRITY_CHECK_ERRORS: usize = 10;
+
+pub fn translate_integrity_check(
+    schema: &Schema,
+    program: &mut ProgramBuilder,
+) -> crate::Result<()> {
+    let mut root_pages = Vec::with_capacity(schema.tables.len() + schema.indexes.len());
+    // Collect root pages to run integrity check on
+    for (name, table) in &schema.tables {
+        match table.as_ref() {
+            crate::schema::Table::BTree(table) => {
+                root_pages.push(table.root_page);
+            }
+            _ => {}
+        };
+    }
+    let message_register = program.alloc_register();
+    program.emit_insn(Insn::IntegrityCk {
+        max_errors: MAX_INTEGRITY_CHECK_ERRORS,
+        roots: root_pages,
+        message_register,
+    });
+    program.emit_insn(Insn::ResultRow {
+        start_reg: message_register,
+        count: 1,
+    });
+    Ok(())
+}

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod expr;
 pub(crate) mod group_by;
 pub(crate) mod index;
 pub(crate) mod insert;
+pub(crate) mod integrity_check;
 pub(crate) mod main_loop;
 pub(crate) mod optimizer;
 pub(crate) mod order_by;

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -18,6 +18,8 @@ use crate::{bail_parse_error, LimboError, Pager, Value};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
+use super::integrity_check::translate_integrity_check;
+
 fn list_pragmas(program: &mut ProgramBuilder) {
     for x in PragmaName::iter() {
         let register = program.emit_string8_new_reg(x.to_string());
@@ -259,6 +261,7 @@ fn update_pragma(
             });
             Ok(())
         }
+        PragmaName::IntegrityCheck => unreachable!("integrity_check cannot be set"),
     }
 }
 
@@ -384,6 +387,9 @@ fn query_pragma(
                 value: auto_vacuum_mode_i64,
             });
             program.emit_result_row(register, 1);
+        }
+        PragmaName::IntegrityCheck => {
+            translate_integrity_check(schema, program)?;
         }
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5060,7 +5060,7 @@ pub fn op_integrity_check(
     let Insn::IntegrityCk {
         max_errors,
         roots,
-        message_register
+        message_register,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5071,9 +5071,7 @@ pub fn op_integrity_check(
                 error_count: 0,
                 message: String::new(),
                 current_root_idx: 0,
-                state: IntegrityCheckState {
-                    current_page: roots[0],
-                },
+                state: IntegrityCheckState::new(roots[0]),
             };
         }
         OpIntegrityCheckState::Checking {
@@ -5082,12 +5080,15 @@ pub fn op_integrity_check(
             current_root_idx,
             state: integrity_check_state,
         } => {
-            return_if_io!(integrity_check(integrity_check_state, error_count, message));
+            return_if_io!(integrity_check(
+                integrity_check_state,
+                error_count,
+                message,
+                pager
+            ));
             *current_root_idx += 1;
             if *current_root_idx < roots.len() {
-                *integrity_check_state = IntegrityCheckState {
-                    current_page: roots[*current_root_idx],
-                };
+                *integrity_check_state = IntegrityCheckState::new(roots[*current_root_idx]);
                 return Ok(InsnFunctionStepResult::Step);
             } else {
                 if *error_count == 0 {

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1576,6 +1576,19 @@ pub fn insn_to_str(
                 0,
                 format!("r[{}]={}", *out_reg, *value),
             ),
+            Insn::IntegrityCk {
+                max_errors,
+                roots,
+                message_register,
+            } => (
+                "IntegrityCk",
+                *max_errors as i32,
+                0,
+                0,
+                Value::build_text(""),
+                0,
+                format!("roots={:?} message_register={}", roots, message_register),
+            ),
         };
     format!(
         "{:<4}  {:<17}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -915,6 +915,18 @@ pub enum Insn {
         target_reg: usize,
         exact: bool,
     },
+
+    /// Do an analysis of the currently open database. Store in register (P1+1) the text of an error message describing any problems.
+    /// If no problems are found, store a NULL in register (P1+1).
+    /// The register (P1) contains one less than the maximum number of allowed errors.
+    /// At most reg(P1) errors will be reported. In other words, the analysis stops as soon as reg(P1) errors are seen.
+    /// Reg(P1) is updated with the number of errors remaining. The root page numbers of all tables in the database are integers
+    /// stored in P4_INTARRAY argument. If P5 is not zero, the check is done on the auxiliary database file, not the main database file. This opcode is used to implement the integrity_check pragma.
+    IntegrityCk {
+        max_errors: usize,
+        roots: Vec<usize>,
+        message_register: usize,
+    },
 }
 
 impl Insn {
@@ -1038,6 +1050,7 @@ impl Insn {
             Insn::Affinity { .. } => execute::op_affinity,
             Insn::IdxDelete { .. } => execute::op_idx_delete,
             Insn::Count { .. } => execute::op_count,
+            Insn::IntegrityCk { .. } => execute::op_integrity_check,
         }
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -43,7 +43,7 @@ use crate::{
 use crate::json::JsonCacheCell;
 use crate::{Connection, MvStore, Result, TransactionState};
 use builder::CursorKey;
-use execute::{InsnFunction, InsnFunctionStepResult, OpIdxDeleteState};
+use execute::{InsnFunction, InsnFunctionStepResult, OpIdxDeleteState, OpIntegrityCheckState};
 
 use rand::{
     distributions::{Distribution, Uniform},
@@ -248,6 +248,7 @@ pub struct ProgramState {
     #[cfg(feature = "json")]
     json_cache: JsonCacheCell,
     op_idx_delete_state: Option<OpIdxDeleteState>,
+    op_integrity_check_state: OpIntegrityCheckState,
 }
 
 impl ProgramState {
@@ -272,6 +273,7 @@ impl ProgramState {
             #[cfg(feature = "json")]
             json_cache: JsonCacheCell::new(),
             op_idx_delete_state: None,
+            op_integrity_check_state: OpIntegrityCheckState::Start,
         }
     }
 

--- a/testing/all.test
+++ b/testing/all.test
@@ -36,3 +36,4 @@ source $testdir/null.test
 source $testdir/create_table.test
 source $testdir/collate.test
 source $testdir/values.test
+source $testdir/integrity_check.test

--- a/testing/integrity_check.test
+++ b/testing/integrity_check.test
@@ -1,0 +1,7 @@
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test integrity-check {
+    PRAGMA integrity_check;
+} {ok}

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1675,6 +1675,8 @@ pub enum PragmaName {
     UserVersion,
     /// trigger a checkpoint to run on database(s) if WAL is enabled
     WalCheckpoint,
+    /// Run integrity check on the database file
+    IntegrityCheck,
 }
 
 /// `CREATE TRIGGER` time

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1659,6 +1659,8 @@ pub enum PragmaName {
     AutoVacuum,
     /// `cache_size` pragma
     CacheSize,
+    /// Run integrity check on the database file
+    IntegrityCheck,
     /// `journal_mode` pragma
     JournalMode,
     /// Noop as per SQLite docs
@@ -1675,8 +1677,6 @@ pub enum PragmaName {
     UserVersion,
     /// trigger a checkpoint to run on database(s) if WAL is enabled
     WalCheckpoint,
-    /// Run integrity check on the database file
-    IntegrityCheck,
 }
 
 /// `CREATE TRIGGER` time


### PR DESCRIPTION
This PR adds support for the instruction `IntegrityCk` which performs an integrity check on the contents of a single table. Next PR I will try to implement the rest of the integrity check where we would check indexes containt correct amount of data and some more.

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/29d54148-55ba-480f-b972-e38587f0a483" />
