### PR TITLE
Add abbreviated alias for `.quit` and `.exit`

### DIFF
--- a/cli/commands/mod.rs
+++ b/cli/commands/mod.rs
@@ -27,10 +27,10 @@ pub struct CommandParser {
 #[command(disable_help_flag(false), disable_version_flag(true))]
 pub enum Command {
     /// Exit this program with return-code CODE
-    #[command(display_name = ".exit")]
+    #[command(display_name = ".exit", alias = "ex", alias = "exi")]
     Exit(ExitArgs),
     /// Quit the shell
-    #[command(display_name = ".quit")]
+    #[command(display_name = ".quit", alias = "q", alias = "qu", alias = "qui")]
     Quit,
     /// Open a database file
     #[command(display_name = ".open")]


### PR DESCRIPTION
Accidentally found that you can quit SQLite CLI just by typing `.q`, `.qu` and `.qui` instead of full `.quit`. 

IMO this will be an improvement to the DX. 

I've also found bunch of other dot commands that work with abbreviated aliases in SQLite. If this PR is okay then I will also add them here.