### PR TITLE
Fix large inserts to unique indexes hanging

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4071,7 +4071,13 @@ pub fn op_idx_insert(
                         CursorResult::IO => return Ok(InsnFunctionStepResult::IO),
                         CursorResult::Ok(false) => {}
                     };
-                    false
+                    // uniqueness check already moved us to the correct place in the index.
+                    // the uniqueness check uses SeekOp::GE, which means a non-matching entry
+                    // will now be positioned at the insertion point where there currently is
+                    // a) nothing, or
+                    // b) the first entry greater than the key we are inserting.
+                    // In both cases, we can insert the new entry without moving again.
+                    true
                 } else {
                     flags.has(IdxInsertFlags::USE_SEEK)
                 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4077,6 +4077,11 @@ pub fn op_idx_insert(
                     // a) nothing, or
                     // b) the first entry greater than the key we are inserting.
                     // In both cases, we can insert the new entry without moving again.
+                    //
+                    // This is re-entrant, because once we call cursor.insert() with moved_before=true,
+                    // we will immediately set BTreeCursor::state to CursorState::Write(WriteInfo::new()),
+                    // in BTreeCursor::insert_into_page; thus, if this function is called again,
+                    // moved_before will again be true due to cursor.is_write_in_progress() returning true.
                     true
                 } else {
                     flags.has(IdxInsertFlags::USE_SEEK)


### PR DESCRIPTION
Closes #1717

We were incorrectly setting `moved_before` as `false` after checking for unique constraint violation, but the reality is that after the uniqueness check, we are already correctly positioned -- if no match was found, the cursor is positioned at either:

a) no row, or
b) at the first entry that is greater than the key we are inserting.

This means we don't have to move anymore and can just insert.