### PR TITLE
integrity_check: add row count check for indexes

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -654,7 +654,6 @@ impl BTreeCursor {
                         self.stack.pop();
                     } else {
                         // moved to begin of btree
-                        // dbg!(false);
                         return Ok(CursorResult::Ok(false));
                     }
                 }
@@ -5108,6 +5107,7 @@ pub struct IntegrityCheckState {
     pub current_page: usize,
     page_stack: Vec<IntegrityCheckPageEntry>,
     first_leaf_level: Option<usize>,
+    pub row_count: usize,
 }
 
 impl IntegrityCheckState {
@@ -5120,6 +5120,7 @@ impl IntegrityCheckState {
                 max_intkey: i64::MAX,
             }],
             first_leaf_level: None,
+            row_count: 0,
         }
     }
 }
@@ -5258,6 +5259,15 @@ pub fn integrity_check(
         }
     }
 
+    // go to rightmost page too!
+    if let Some(rightmost_page) = contents.rightmost_pointer() {
+        state.page_stack.push(IntegrityCheckPageEntry {
+            page_idx: rightmost_page as usize,
+            level: level + 1,
+            max_intkey, // we don't care about intkey in non-table pages
+        });
+    }
+
     // Now we add free blocks to the coverage checker
     let first_freeblock = contents.first_freeblock();
     if first_freeblock > 0 {
@@ -5290,6 +5300,10 @@ pub fn integrity_check(
         error_count,
         contents.num_frag_free_bytes() as usize,
     );
+
+    if page.is_index() || page.is_leaf() {
+        state.row_count += contents.cell_count();
+    }
 
     Ok(CursorResult::IO)
 }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -140,6 +140,13 @@ impl Page {
             PageType::TableLeaf | PageType::TableInterior => false,
         }
     }
+
+    pub fn is_leaf(&self) -> bool {
+        match self.get_contents().page_type() {
+            PageType::IndexLeaf | PageType::TableLeaf => true,
+            PageType::TableInterior | PageType::IndexInterior => false,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -1,6 +1,9 @@
 use crate::{
     schema::Schema,
-    vdbe::{builder::ProgramBuilder, insn::Insn},
+    vdbe::{
+        builder::ProgramBuilder,
+        insn::{CmpInsFlags, Insn},
+    },
 };
 
 /// Maximum number of errors to report with integrity check. If we exceed this number we will short
@@ -13,17 +16,68 @@ pub fn translate_integrity_check(
 ) -> crate::Result<()> {
     let mut root_pages = Vec::with_capacity(schema.tables.len() + schema.indexes.len());
     // Collect root pages to run integrity check on
-    for table in schema.tables.values() {
+    let mut number_of_tables = 0;
+    for (table_name, table) in &schema.tables {
         if let crate::schema::Table::BTree(table) = table.as_ref() {
             root_pages.push(table.root_page);
+            number_of_tables += 1;
+            if let Some(indexes) = schema.indexes.get(table_name) {
+                for index in indexes {
+                    root_pages.push(index.root_page);
+                    number_of_tables += 1;
+                }
+            }
         };
     }
     let message_register = program.alloc_register();
+    let max_error_updated_register = program.alloc_register();
+    let start_count_register = program.alloc_registers(number_of_tables);
     program.emit_insn(Insn::IntegrityCk {
         max_errors: MAX_INTEGRITY_CHECK_ERRORS,
         roots: root_pages,
         message_register,
+        start_count_register,
+        max_error_updated_register,
     });
+
+    // Check index number of rows is correct
+    let mut root_index = 0;
+    let error_msg_wrong_index_count_string =
+        program.emit_string8_new_reg("wrong # of entries in index ".to_string());
+    for (table_name, table) in &schema.tables {
+        let table_index = root_index;
+        root_index += 1;
+        if let crate::schema::Table::BTree(_) = table.as_ref() {
+            if let Some(indexes) = schema.indexes.get(table_name) {
+                for index in indexes {
+                    // FIXME: check these are not partial indexes
+                    let jump = program.allocate_label();
+                    program.emit_insn(Insn::Eq {
+                        lhs: start_count_register + root_index,
+                        rhs: start_count_register + table_index,
+                        target_pc: jump,
+                        flags: CmpInsFlags::default(),
+                        collation: None,
+                    });
+                    let table_name_register =
+                        program.emit_string8_new_reg(index.table_name.to_string());
+                    let res = program.alloc_register();
+                    program.emit_insn(Insn::Concat {
+                        lhs: error_msg_wrong_index_count_string,
+                        rhs: table_name_register,
+                        dest: res,
+                    });
+                    program.emit_insn(Insn::ResultRow {
+                        start_reg: res,
+                        count: 1,
+                    });
+                    program.preassign_label_to_next_insn(jump);
+                    root_index += 1;
+                }
+            }
+        };
+    }
+
     program.emit_insn(Insn::ResultRow {
         start_reg: message_register,
         count: 1,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5061,6 +5061,8 @@ pub fn op_integrity_check(
         max_errors,
         roots,
         message_register,
+        start_count_register,
+        max_error_updated_register,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -5084,8 +5086,10 @@ pub fn op_integrity_check(
                 integrity_check_state,
                 error_count,
                 message,
-                pager
+                pager,
             ));
+            state.registers[*start_count_register + *current_root_idx] =
+                Register::Value(Value::Integer(integrity_check_state.row_count as i64));
             *current_root_idx += 1;
             if *current_root_idx < roots.len() {
                 *integrity_check_state = IntegrityCheckState::new(roots[*current_root_idx]);
@@ -5100,6 +5104,8 @@ pub fn op_integrity_check(
                     })?;
                 }
                 state.registers[*message_register] = Register::Value(Value::build_text(message));
+                state.registers[*max_error_updated_register] =
+                    Register::Value(Value::Integer((max_errors - *error_count) as i64));
                 state.op_integrity_check_state = OpIntegrityCheckState::Start;
                 state.pc += 1;
             }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1580,6 +1580,8 @@ pub fn insn_to_str(
                 max_errors,
                 roots,
                 message_register,
+                start_count_register,
+                max_error_updated_register,
             } => (
                 "IntegrityCk",
                 *max_errors as i32,
@@ -1587,7 +1589,7 @@ pub fn insn_to_str(
                 0,
                 Value::build_text(""),
                 0,
-                format!("roots={:?} message_register={}", roots, message_register),
+                format!("roots={:?} message_register={}, start_count_register={} max_error_updated_register={}", roots, message_register, start_count_register, max_error_updated_register),
             ),
         };
     format!(

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -925,7 +925,10 @@ pub enum Insn {
     IntegrityCk {
         max_errors: usize,
         roots: Vec<usize>,
+        /// list of root pages to analyze
         message_register: usize,
+        start_count_register: usize, // list of registers to store the count of rows in the tree, roots.len() represents the end register
+        max_error_updated_register: usize,
     },
 }
 


### PR DESCRIPTION
Now `IntegrityCk` will load the number of rows in each root page in order to validate if index has the same number of rows as the table. **This is assuming the index is not a partial index which we should handle later**.
```sql
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     9     0                    0   Start at 9
1     IntegrityCk        10    0     0                    0   roots=[2, 274, 1, 3] message_register=2, start_count_register=4 max_error_updated_register=3
2     String8            0     8     0     wrong # of entries in index   0   r[8]='wrong # of entries in index '
3     Eq                 5     4     7                    0   if r[5]==r[4] goto 7
4     String8            0     9     0     users          0   r[9]='users'
5     Concat             9     8     10                   0   r[10]=r[8] + r[9]
6     ResultRow          10    1     0                    0   output=r[10]
7     ResultRow          2     1     0                    0   output=r[2]
8     Halt               0     0     0                    0   
9     Transaction        0     0     0                    0   write=false
10    Goto               0     1     0                    0
```