### PR TITLE
Return parse error instead of corrupt error for `no such table`

### DIFF
--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -49,14 +49,14 @@ pub fn prepare_delete_plan(
 ) -> Result<Plan> {
     let table = match schema.get_table(tbl_name.name.0.as_str()) {
         Some(table) => table,
-        None => crate::bail_corrupt_error!("Parse error: no such table: {}", tbl_name),
+        None => crate::bail_parse_error!("no such table: {}", tbl_name),
     };
     let table = if let Some(table) = table.virtual_table() {
         Table::Virtual(table.clone())
     } else if let Some(table) = table.btree() {
         Table::BTree(table.clone())
     } else {
-        crate::bail_corrupt_error!("Table is neither a virtual table nor a btree table");
+        crate::bail_parse_error!("Table is neither a virtual table nor a btree table");
     };
     let name = tbl_name.name.0.as_str().to_string();
     let indexes = schema

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -61,7 +61,7 @@ pub fn translate_insert(
     let table_name = &tbl_name.name;
     let table = match schema.get_table(table_name.0.as_str()) {
         Some(table) => table,
-        None => crate::bail_corrupt_error!("Parse error: no such table: {}", table_name),
+        None => crate::bail_parse_error!("no such table: {}", table_name),
     };
 
     let resolver = Resolver::new(schema, syms);
@@ -80,7 +80,7 @@ pub fn translate_insert(
     }
 
     let Some(btree_table) = table.btree() else {
-        crate::bail_corrupt_error!("Parse error: no such table: {}", table_name);
+        crate::bail_parse_error!("no such table: {}", table_name);
     };
     if !btree_table.has_rowid {
         crate::bail_parse_error!("INSERT into WITHOUT ROWID table is not supported");


### PR DESCRIPTION
This is more in line with SQLite:

```sql
sqlite> insert into t values (randomblob(1024*1024 * 6));
Parse error: no such table: t
```