### PR TITLE
simulator: disable all ansi encodings for debug print log file

### DIFF
--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -18,6 +18,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
 use tracing_subscriber::field::MakeExt;
+use tracing_subscriber::fmt::format;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -696,6 +697,7 @@ fn run_simulation(
     result
 }
 
+#[allow(deprecated)]
 fn init_logger() {
     let file = OpenOptions::new()
         .create(true)
@@ -709,14 +711,14 @@ fn init_logger() {
                 .with_ansi(true)
                 .with_line_number(true)
                 .without_time()
-                .with_thread_ids(false)
-                .map_fmt_fields(|f| f.debug_alt()),
+                .with_thread_ids(false),
         )
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .with(
             tracing_subscriber::fmt::layer()
                 .with_writer(file)
                 .with_ansi(false)
+                .fmt_fields(format::PrettyFields::new().with_ansi(false)) // with_ansi is deprecated, but I cannot find another way to remove ansi codes
                 .with_line_number(true)
                 .without_time()
                 .with_thread_ids(false)


### PR DESCRIPTION
This solves the issue of having weird ansi escape codes when creating github issues for the simulator