### PR TITLE
Switch Connection to use Arc instead of Rc

### DIFF
--- a/bindings/go/rs_src/lib.rs
+++ b/bindings/go/rs_src/lib.rs
@@ -5,7 +5,6 @@ mod types;
 use limbo_core::{Connection, Database, LimboError, IO};
 use std::{
     ffi::{c_char, c_void},
-    rc::Rc,
     sync::Arc,
 };
 
@@ -40,13 +39,13 @@ pub unsafe extern "C" fn db_open(path: *const c_char) -> *mut c_void {
 
 #[allow(dead_code)]
 struct LimboConn {
-    conn: Rc<Connection>,
+    conn: Arc<Connection>,
     io: Arc<dyn limbo_core::IO>,
     err: Option<LimboError>,
 }
 
 impl LimboConn {
-    fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
+    fn new(conn: Arc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
         LimboConn {
             conn,
             io,

--- a/bindings/java/rs_src/limbo_connection.rs
+++ b/bindings/java/rs_src/limbo_connection.rs
@@ -8,19 +8,16 @@ use jni::objects::{JByteArray, JObject};
 use jni::sys::jlong;
 use jni::JNIEnv;
 use limbo_core::Connection;
-use std::rc::Rc;
 use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct LimboConnection {
-    // Because java's LimboConnection is 1:1 mapped to limbo connection, we can use Rc
-    pub(crate) conn: Rc<Connection>,
-    // Because io is shared across multiple `LimboConnection`s, wrap it with Arc
+    pub(crate) conn: Arc<Connection>,
     pub(crate) io: Arc<dyn limbo_core::IO>,
 }
 
 impl LimboConnection {
-    pub fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
+    pub fn new(conn: Arc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
         LimboConnection { conn, io }
     }
 

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -41,7 +41,7 @@ pub struct Database {
     #[napi(writable = false)]
     pub name: String,
     _db: Arc<limbo_core::Database>,
-    conn: Rc<limbo_core::Connection>,
+    conn: Arc<limbo_core::Connection>,
     io: Arc<dyn limbo_core::IO>,
 }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -228,7 +228,7 @@ fn stmt_is_ddl(sql: &str) -> bool {
 #[pyclass(unsendable)]
 #[derive(Clone)]
 pub struct Connection {
-    conn: Rc<limbo_core::Connection>,
+    conn: Arc<limbo_core::Connection>,
     io: Arc<dyn limbo_core::IO>,
 }
 
@@ -310,13 +310,13 @@ pub fn connect(path: &str) -> Result<Connection> {
         ":memory:" => {
             let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::MemoryIO::new());
             let db = open_or(io.clone(), path)?;
-            let conn: Rc<limbo_core::Connection> = db.connect().unwrap();
+            let conn: Arc<limbo_core::Connection> = db.connect().unwrap();
             Ok(Connection { conn, io })
         }
         path => {
             let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::PlatformIO::new()?);
             let db = open_or(io.clone(), path)?;
-            let conn: Rc<limbo_core::Connection> = db.connect().unwrap();
+            let conn: Arc<limbo_core::Connection> = db.connect().unwrap();
             Ok(Connection { conn, io })
         }
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -8,7 +8,6 @@ pub use params::params_from_iter;
 use crate::params::*;
 use std::fmt::Debug;
 use std::num::NonZero;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug, thiserror::Error)]
@@ -84,7 +83,7 @@ impl Database {
 }
 
 pub struct Connection {
-    inner: Arc<Mutex<Rc<limbo_core::Connection>>>,
+    inner: Arc<Mutex<Arc<limbo_core::Connection>>>,
 }
 
 impl Clone for Connection {

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -1,14 +1,13 @@
 use js_sys::{Array, Object};
 use limbo_core::{maybe_init_database_file, Clock, Instant, OpenFlags, Result};
 use std::cell::RefCell;
-use std::rc::Rc;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 #[allow(dead_code)]
 #[wasm_bindgen]
 pub struct Database {
     db: Arc<limbo_core::Database>,
-    conn: Rc<limbo_core::Connection>,
+    conn: Arc<limbo_core::Connection>,
 }
 
 #[allow(clippy::arc_with_non_send_sync)]

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -21,7 +21,6 @@ use std::{
     fmt,
     io::{self, BufRead as _, Write},
     path::PathBuf,
-    rc::Rc,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -68,7 +67,7 @@ pub struct Limbo {
     pub prompt: String,
     io: Arc<dyn limbo_core::IO>,
     writer: Box<dyn Write>,
-    conn: Rc<limbo_core::Connection>,
+    conn: Arc<limbo_core::Connection>,
     pub interrupt_count: Arc<AtomicUsize>,
     input_buff: String,
     opts: Settings,

--- a/cli/commands/import.rs
+++ b/cli/commands/import.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use clap_complete::{ArgValueCompleter, PathCompleter};
 use limbo_core::Connection;
-use std::{fs::File, io::Write, path::PathBuf, rc::Rc, sync::Arc};
+use std::{fs::File, io::Write, path::PathBuf, sync::Arc};
 
 #[derive(Debug, Clone, Args)]
 pub struct ImportArgs {
@@ -20,14 +20,14 @@ pub struct ImportArgs {
 }
 
 pub struct ImportFile<'a> {
-    conn: Rc<Connection>,
+    conn: Arc<Connection>,
     io: Arc<dyn limbo_core::IO>,
     writer: &'a mut dyn Write,
 }
 
 impl<'a> ImportFile<'a> {
     pub fn new(
-        conn: Rc<Connection>,
+        conn: Arc<Connection>,
         io: Arc<dyn limbo_core::IO>,
         writer: &'a mut dyn Write,
     ) -> Self {

--- a/cli/helper.rs
+++ b/cli/helper.rs
@@ -8,7 +8,6 @@ use rustyline::{Completer, Helper, Hinter, Validator};
 use shlex::Shlex;
 use std::cell::RefCell;
 use std::marker::PhantomData;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::{ffi::OsString, path::PathBuf, str::FromStr as _};
 use syntect::dumps::from_uncompressed_data;
@@ -42,7 +41,7 @@ pub struct LimboHelper {
 
 impl LimboHelper {
     pub fn new(
-        conn: Rc<Connection>,
+        conn: Arc<Connection>,
         io: Arc<dyn limbo_core::IO>,
         syntax_config: Option<HighlightConfig>,
     ) -> Self {
@@ -141,7 +140,7 @@ impl Highlighter for LimboHelper {
 }
 
 pub struct SqlCompleter<C: Parser + Send + Sync + 'static> {
-    conn: Rc<Connection>,
+    conn: Arc<Connection>,
     io: Arc<dyn limbo_core::IO>,
     // Has to be a ref cell as Rustyline takes immutable reference to self
     // This problem would be solved with Reedline as it uses &mut self for completions
@@ -150,7 +149,7 @@ pub struct SqlCompleter<C: Parser + Send + Sync + 'static> {
 }
 
 impl<C: Parser + Send + Sync + 'static> SqlCompleter<C> {
-    pub fn new(conn: Rc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
+    pub fn new(conn: Arc<Connection>, io: Arc<dyn limbo_core::IO>) -> Self {
         Self {
             conn,
             io,

--- a/core/ext/dynamic.rs
+++ b/core/ext/dynamic.rs
@@ -6,7 +6,6 @@ use libloading::{Library, Symbol};
 use limbo_ext::{ExtensionApi, ExtensionApiRef, ExtensionEntryPoint, ResultCode, VfsImpl};
 use std::{
     ffi::{c_char, CString},
-    rc::Rc,
     sync::{Arc, Mutex, OnceLock},
 };
 
@@ -31,7 +30,7 @@ unsafe impl Sync for VfsMod {}
 
 impl Connection {
     pub fn load_extension<P: AsRef<std::ffi::OsStr>>(
-        self: &Rc<Connection>,
+        self: &Arc<Connection>,
         path: P,
     ) -> crate::Result<()> {
         use limbo_ext::ExtensionApiRef;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6227,7 +6227,7 @@ mod tests {
         pos: usize,
         page: &mut PageContent,
         record: ImmutableRecord,
-        conn: &Rc<Connection>,
+        conn: &Arc<Connection>,
     ) -> Vec<u8> {
         let mut payload: Vec<u8> = Vec::new();
         fill_cell_payload(

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -46,7 +46,7 @@ use insert::translate_insert;
 use limbo_sqlite3_parser::ast::{self, Delete, Insert};
 use schema::{translate_create_table, translate_create_virtual_table, translate_drop_table};
 use select::translate_select;
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
 use std::sync::Arc;
 use tracing::{instrument, Level};
 use transaction::{translate_tx_begin, translate_tx_commit};
@@ -58,7 +58,7 @@ pub fn translate(
     stmt: ast::Stmt,
     database_header: Arc<SpinLock<DatabaseHeader>>,
     pager: Rc<Pager>,
-    connection: Weak<Connection>,
+    connection: Arc<Connection>,
     syms: &SymbolTable,
     query_mode: QueryMode,
     _input: &str, // TODO: going to be used for CREATE VIEW

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -3,7 +3,7 @@
 
 use limbo_sqlite3_parser::ast::PragmaName;
 use limbo_sqlite3_parser::ast::{self, Expr};
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::fast_lock::SpinLock;
@@ -34,7 +34,7 @@ pub fn translate_pragma(
     body: Option<ast::PragmaBody>,
     database_header: Arc<SpinLock<DatabaseHeader>>,
     pager: Rc<Pager>,
-    connection: Weak<crate::Connection>,
+    connection: Arc<crate::Connection>,
     mut program: ProgramBuilder,
 ) -> crate::Result<ProgramBuilder> {
     let opts = ProgramBuilderOpts {
@@ -124,7 +124,7 @@ fn update_pragma(
     value: ast::Expr,
     header: Arc<SpinLock<DatabaseHeader>>,
     pager: Rc<Pager>,
-    connection: Weak<crate::Connection>,
+    connection: Arc<crate::Connection>,
     program: &mut ProgramBuilder,
 ) -> crate::Result<()> {
     match pragma {
@@ -268,16 +268,13 @@ fn query_pragma(
     value: Option<ast::Expr>,
     database_header: Arc<SpinLock<DatabaseHeader>>,
     pager: Rc<Pager>,
-    connection: Weak<crate::Connection>,
+    connection: Arc<crate::Connection>,
     program: &mut ProgramBuilder,
 ) -> crate::Result<()> {
     let register = program.alloc_register();
     match pragma {
         PragmaName::CacheSize => {
-            program.emit_int(
-                connection.upgrade().unwrap().get_cache_size() as i64,
-                register,
-            );
+            program.emit_int(connection.get_cache_size() as i64, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
         }
@@ -417,7 +414,7 @@ fn update_cache_size(
     value: i64,
     header: Arc<SpinLock<DatabaseHeader>>,
     pager: Rc<Pager>,
-    connection: Weak<crate::Connection>,
+    connection: Arc<crate::Connection>,
 ) -> crate::Result<()> {
     let mut cache_size_unformatted: i64 = value;
     let mut cache_size = if cache_size_unformatted < 0 {
@@ -432,10 +429,7 @@ fn update_cache_size(
         cache_size = MIN_PAGE_CACHE_SIZE;
         cache_size_unformatted = MIN_PAGE_CACHE_SIZE as i64;
     }
-    connection
-        .upgrade()
-        .unwrap()
-        .set_cache_size(cache_size_unformatted as i32);
+    connection.set_cache_size(cache_size_unformatted as i32);
 
     // update cache size
     pager

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,9 +1,4 @@
-use std::{
-    cell::Cell,
-    cmp::Ordering,
-    rc::{Rc, Weak},
-    sync::Arc,
-};
+use std::{cell::Cell, cmp::Ordering, rc::Rc, sync::Arc};
 
 use limbo_sqlite3_parser::ast::{self, TableInternalId};
 use tracing::{instrument, Level};
@@ -856,7 +851,7 @@ impl ProgramBuilder {
     pub fn build(
         mut self,
         database_header: Arc<SpinLock<DatabaseHeader>>,
-        connection: Weak<Connection>,
+        connection: Arc<Connection>,
         change_cnt_on: bool,
     ) -> Program {
         self.resolve_labels();

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -54,8 +54,7 @@ use std::{
     cell::{Cell, RefCell},
     collections::HashMap,
     num::NonZero,
-    ops::Deref,
-    rc::{Rc, Weak},
+    rc::Rc,
     sync::Arc,
 };
 use tracing::{instrument, Level};
@@ -351,7 +350,6 @@ macro_rules! must_be_btree_cursor {
     }};
 }
 
-#[derive(Debug)]
 pub struct Program {
     pub max_registers: usize,
     pub insns: Vec<(Insn, InsnFunction)>,
@@ -359,7 +357,7 @@ pub struct Program {
     pub database_header: Arc<SpinLock<DatabaseHeader>>,
     pub comments: Option<Vec<(InsnReference, &'static str)>>,
     pub parameters: crate::parameters::Parameters,
-    pub connection: Weak<Connection>,
+    pub connection: Arc<Connection>,
     pub n_change: Cell<i64>,
     pub change_cnt_on: bool,
     pub result_columns: Vec<ResultSetColumn>,
@@ -401,7 +399,7 @@ impl Program {
         mv_store: Option<&Rc<MvStore>>,
     ) -> Result<StepResult> {
         if let Some(mv_store) = mv_store {
-            let conn = self.connection.upgrade().unwrap();
+            let conn = self.connection.clone();
             let auto_commit = conn.auto_commit.get();
             if auto_commit {
                 let mut mv_transactions = conn.mv_transactions.borrow_mut();
@@ -412,21 +410,18 @@ impl Program {
             }
             Ok(StepResult::Done)
         } else {
-            let connection = self
-                .connection
-                .upgrade()
-                .expect("only weak ref to connection?");
+            let connection = self.connection.clone();
             let auto_commit = connection.auto_commit.get();
             tracing::trace!("Halt auto_commit {}", auto_commit);
             if program_state.commit_state == CommitState::Committing {
-                self.step_end_write_txn(&pager, &mut program_state.commit_state, connection.deref())
+                self.step_end_write_txn(&pager, &mut program_state.commit_state, &connection)
             } else if auto_commit {
                 let current_state = connection.transaction_state.get();
                 match current_state {
                     TransactionState::Write => self.step_end_write_txn(
                         &pager,
                         &mut program_state.commit_state,
-                        connection.deref(),
+                        &connection,
                     ),
                     TransactionState::Read => {
                         connection.transaction_state.replace(TransactionState::None);
@@ -437,9 +432,7 @@ impl Program {
                 }
             } else {
                 if self.change_cnt_on {
-                    if let Some(conn) = self.connection.upgrade() {
-                        conn.set_changes(self.n_change.get());
-                    }
+                    self.connection.set_changes(self.n_change.get());
                 }
                 Ok(StepResult::Done)
             }
@@ -457,9 +450,7 @@ impl Program {
         match cacheflush_status {
             PagerCacheflushStatus::Done(_) => {
                 if self.change_cnt_on {
-                    if let Some(conn) = self.connection.upgrade() {
-                        conn.set_changes(self.n_change.get());
-                    }
+                    self.connection.set_changes(self.n_change.get());
                 }
                 connection.transaction_state.replace(TransactionState::None);
                 *commit_state = CommitState::Ready;

--- a/extensions/completion/src/lib.rs
+++ b/extensions/completion/src/lib.rs
@@ -3,7 +3,7 @@
 
 mod keywords;
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use keywords::KEYWORDS;
 use limbo_ext::{
@@ -87,7 +87,7 @@ impl VTable for CompletionTable {
     type Cursor = CompletionCursor;
     type Error = ResultCode;
 
-    fn open(&self, _conn: Option<Rc<Connection>>) -> Result<Self::Cursor, Self::Error> {
+    fn open(&self, _conn: Option<Arc<Connection>>) -> Result<Self::Cursor, Self::Error> {
         Ok(CompletionCursor::default())
     }
 }

--- a/extensions/csv/src/lib.rs
+++ b/extensions/csv/src/lib.rs
@@ -26,7 +26,7 @@ use limbo_ext::{
 };
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
-use std::rc::Rc;
+use std::sync::Arc;
 
 register_extension! {
     vtabs: { CsvVTabModule }
@@ -260,7 +260,7 @@ impl VTable for CsvTable {
     type Cursor = CsvCursor;
     type Error = ResultCode;
 
-    fn open(&self, _conn: Option<Rc<Connection>>) -> Result<Self::Cursor, Self::Error> {
+    fn open(&self, _conn: Option<Arc<Connection>>) -> Result<Self::Cursor, Self::Error> {
         match self.new_reader() {
             Ok(reader) => Ok(CsvCursor::new(reader, self)),
             Err(_) => Err(ResultCode::Error),

--- a/extensions/series/src/lib.rs
+++ b/extensions/series/src/lib.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use limbo_ext::{
     register_extension, Connection, ResultCode, VTabCursor, VTabKind, VTabModule, VTabModuleDerive,
@@ -45,7 +45,7 @@ impl VTable for GenerateSeriesTable {
     type Cursor = GenerateSeriesCursor;
     type Error = ResultCode;
 
-    fn open(&self, _conn: Option<Rc<Connection>>) -> Result<Self::Cursor, Self::Error> {
+    fn open(&self, _conn: Option<Arc<Connection>>) -> Result<Self::Cursor, Self::Error> {
         Ok(GenerateSeriesCursor {
             start: 0,
             stop: 0,

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -10,8 +10,7 @@ use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::num::NonZeroUsize;
-use std::rc::Rc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 register_extension! {
     vtabs: { KVStoreVTabModule, TableStatsVtabModule },
@@ -139,7 +138,7 @@ impl VTable for KVStoreTable {
     type Cursor = KVStoreCursor;
     type Error = String;
 
-    fn open(&self, _conn: Option<Rc<Connection>>) -> Result<Self::Cursor, Self::Error> {
+    fn open(&self, _conn: Option<Arc<Connection>>) -> Result<Self::Cursor, Self::Error> {
         let _ = env_logger::try_init();
         Ok(KVStoreCursor {
             rows: Vec::new(),
@@ -303,7 +302,7 @@ pub struct TableStatsVtabModule;
 pub struct StatsCursor {
     pos: usize,
     rows: Vec<(String, i64)>,
-    conn: Option<Rc<Connection>>,
+    conn: Option<Arc<Connection>>,
 }
 
 pub struct StatsTable {}
@@ -322,7 +321,7 @@ impl VTable for StatsTable {
     type Cursor = StatsCursor;
     type Error = String;
 
-    fn open(&self, conn: Option<Rc<Connection>>) -> Result<Self::Cursor, Self::Error> {
+    fn open(&self, conn: Option<Arc<Connection>>) -> Result<Self::Cursor, Self::Error> {
         Ok(StatsCursor {
             pos: 0,
             rows: Vec::new(),

--- a/macros/src/ext/vtab_derive.rs
+++ b/macros/src/ext/vtab_derive.rs
@@ -55,7 +55,7 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
                 }
                 let table = table as *const <#struct_name as ::limbo_ext::VTabModule>::Table;
                 let table: &<#struct_name as ::limbo_ext::VTabModule>::Table = &*table;
-                let conn = if conn.is_null() { None } else { Some(::std::rc::Rc::new(::limbo_ext::Connection::new(conn)))};
+                let conn = if conn.is_null() { None } else { Some(::std::sync::Arc::new(::limbo_ext::Connection::new(conn)))};
                 if let Ok(cursor) = <#struct_name as ::limbo_ext::VTabModule>::Table::open(table, conn) {
                     return ::std::boxed::Box::into_raw(::std::boxed::Box::new(cursor)) as *const ::std::ffi::c_void;
                 } else {

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashSet,
     fmt::{Debug, Display},
     path::Path,
-    rc::Rc,
+    sync::Arc,
     vec,
 };
 
@@ -504,7 +504,7 @@ impl Interaction {
             Self::Assumption(_) | Self::Assertion(_) | Self::Fault(_) => vec![],
         }
     }
-    pub(crate) fn execute_query(&self, conn: &mut Rc<Connection>, io: &SimulatorIO) -> ResultSet {
+    pub(crate) fn execute_query(&self, conn: &mut Arc<Connection>, io: &SimulatorIO) -> ResultSet {
         if let Self::Query(query) = self {
             let query_str = query.to_string();
             let rows = conn.query(&query_str);

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 use std::mem;
 use std::path::Path;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use limbo_core::Database;
@@ -164,7 +163,7 @@ where
 }
 
 pub(crate) enum SimConnection {
-    LimboConnection(Rc<limbo_core::Connection>),
+    LimboConnection(Arc<limbo_core::Connection>),
     SQLiteConnection(rusqlite::Connection),
     Disconnected,
 }

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -5,7 +5,6 @@ use limbo_core::Value;
 use std::ffi::{self, CStr, CString};
 use tracing::trace;
 
-use std::rc::Rc;
 use std::sync::Arc;
 
 macro_rules! stub {
@@ -42,7 +41,7 @@ use util::sqlite3_safety_check_sick_or_ok;
 pub struct sqlite3 {
     pub(crate) io: Arc<dyn limbo_core::IO>,
     pub(crate) _db: Arc<limbo_core::Database>,
-    pub(crate) conn: Rc<limbo_core::Connection>,
+    pub(crate) conn: Arc<limbo_core::Connection>,
     pub(crate) err_code: ffi::c_int,
     pub(crate) err_mask: ffi::c_int,
     pub(crate) malloc_failed: bool,
@@ -54,7 +53,7 @@ impl sqlite3 {
     pub fn new(
         io: Arc<dyn limbo_core::IO>,
         db: Arc<limbo_core::Database>,
-        conn: Rc<limbo_core::Connection>,
+        conn: Arc<limbo_core::Connection>,
     ) -> Self {
         Self {
             io,

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -2,7 +2,6 @@ use limbo_core::{Connection, Database, PagerCacheflushStatus, IO};
 use rand::{rng, RngCore};
 use rusqlite::params;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tracing_subscriber::layer::SubscriberExt;
@@ -55,14 +54,14 @@ impl TempDatabase {
         Self { path, io }
     }
 
-    pub fn connect_limbo(&self) -> Rc<limbo_core::Connection> {
+    pub fn connect_limbo(&self) -> Arc<limbo_core::Connection> {
         Self::connect_limbo_with_flags(&self, limbo_core::OpenFlags::default())
     }
 
     pub fn connect_limbo_with_flags(
         &self,
         flags: limbo_core::OpenFlags,
-    ) -> Rc<limbo_core::Connection> {
+    ) -> Arc<limbo_core::Connection> {
         log::debug!("conneting to limbo");
         let db = Database::open_file_with_flags(
             self.io.clone(),
@@ -83,7 +82,7 @@ impl TempDatabase {
     }
 }
 
-pub(crate) fn do_flush(conn: &Rc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
+pub(crate) fn do_flush(conn: &Arc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
     loop {
         match conn.cacheflush()? {
             PagerCacheflushStatus::Done(_) => {
@@ -155,7 +154,7 @@ pub(crate) fn sqlite_exec_rows(
 
 pub(crate) fn limbo_exec_rows(
     db: &TempDatabase,
-    conn: &Rc<limbo_core::Connection>,
+    conn: &Arc<limbo_core::Connection>,
     query: &str,
 ) -> Vec<Vec<rusqlite::types::Value>> {
     let mut stmt = conn.prepare(query).unwrap();
@@ -193,7 +192,7 @@ pub(crate) fn limbo_exec_rows(
 
 pub(crate) fn limbo_exec_rows_error(
     db: &TempDatabase,
-    conn: &Rc<limbo_core::Connection>,
+    conn: &Arc<limbo_core::Connection>,
     query: &str,
 ) -> limbo_core::Result<()> {
     let mut stmt = conn.prepare(query)?;

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -112,7 +112,7 @@ fn test_wal_1_writer_1_reader() -> Result<()> {
 /// Execute a statement and get strings result
 pub(crate) fn execute_and_get_strings(
     tmp_db: &TempDatabase,
-    conn: &Rc<Connection>,
+    conn: &Arc<Connection>,
     sql: &str,
 ) -> Result<Vec<String>> {
     let statement = conn.prepare(sql)?;
@@ -140,7 +140,7 @@ pub(crate) fn execute_and_get_strings(
 /// Execute a statement and get integers
 pub(crate) fn execute_and_get_ints(
     tmp_db: &TempDatabase,
-    conn: &Rc<Connection>,
+    conn: &Arc<Connection>,
     sql: &str,
 ) -> Result<Vec<i64>> {
     let statement = conn.prepare(sql)?;


### PR DESCRIPTION
Connection needs to be Arc so that bindings can wrap it with `Mutex` for multi-threading.