### PR TITLE
Fix database header initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
  "miette",
  "mimalloc",
  "parking_lot",
+ "paste",
  "polling",
  "pprof",
  "quickcheck",
@@ -2477,6 +2478,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -585,7 +585,7 @@ impl limbo_core::DatabaseStorage for DatabaseFile {
     }
 
     fn size(&self) -> limbo_core::Result<u64> {
-        todo!()
+        self.file.size()
     }
 }
 

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -6,7 +6,7 @@ use std::num::NonZeroUsize;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use limbo_core::{maybe_init_database_file, LimboError, StepResult};
+use limbo_core::{LimboError, StepResult};
 use napi::iterator::Generator;
 use napi::{bindgen_prelude::ObjectFinalize, Env, JsUnknown};
 use napi_derive::napi;
@@ -65,7 +65,6 @@ impl Database {
         let file = io
             .open_file(&path, limbo_core::OpenFlags::Create, false)
             .map_err(into_napi_error)?;
-        maybe_init_database_file(&file, &io).map_err(into_napi_error)?;
         let db_file = Arc::new(DatabaseFile::new(file));
         let db = limbo_core::Database::open(io.clone(), &path, db_file, false)
             .map_err(into_napi_error)?;

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -584,6 +584,10 @@ impl limbo_core::DatabaseStorage for DatabaseFile {
     fn sync(&self, c: Arc<limbo_core::Completion>) -> limbo_core::Result<()> {
         self.file.sync(c)
     }
+
+    fn size(&self) -> limbo_core::Result<u64> {
+        todo!()
+    }
 }
 
 #[inline]

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -363,12 +363,12 @@ impl limbo_core::DatabaseStorage for DatabaseFile {
         Ok(())
     }
 
-    fn sync(&self, _c: Arc<limbo_core::Completion>) -> Result<()> {
-        todo!()
+    fn sync(&self, c: Arc<limbo_core::Completion>) -> Result<()> {
+        self.file.sync(c)
     }
 
     fn size(&self) -> Result<u64> {
-        todo!()
+        self.file.size()
     }
 }
 

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -2,7 +2,7 @@
 compile_error!("Features 'web' and 'nodejs' cannot be enabled at the same time");
 
 use js_sys::{Array, Object};
-use limbo_core::{maybe_init_database_file, Clock, Instant, OpenFlags, Result};
+use limbo_core::{Clock, Instant, OpenFlags, Result};
 use std::cell::RefCell;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
@@ -21,7 +21,6 @@ impl Database {
     pub fn new(path: &str) -> Database {
         let io: Arc<dyn limbo_core::IO> = Arc::new(PlatformIO { vfs: VFS::new() });
         let file = io.open_file(path, OpenFlags::Create, false).unwrap();
-        maybe_init_database_file(&file, &io).unwrap();
         let db_file = Arc::new(DatabaseFile::new(file));
         let db = limbo_core::Database::open(io, path, db_file, false).unwrap();
         let conn = db.connect().unwrap();

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -367,6 +367,10 @@ impl limbo_core::DatabaseStorage for DatabaseFile {
     fn sync(&self, _c: Arc<limbo_core::Completion>) -> Result<()> {
         todo!()
     }
+
+    fn size(&self) -> Result<u64> {
+        todo!()
+    }
 }
 
 #[cfg(all(feature = "web", not(feature = "nodejs")))]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -84,6 +84,7 @@ uncased = "0.9.10"
 strum_macros = { workspace = true }
 bitflags = "2.9.0"
 serde = { workspace = true , optional = true, features = ["derive"] }
+paste = "1.0.15"
 
 [build-dependencies]
 chrono = { version = "0.4.38", default-features = false }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -159,6 +159,7 @@ impl Database {
         } else {
             None
         };
+        let wal_exists = maybe_shared_wal.is_some();
 
         let shared_page_cache = Arc::new(RwLock::new(DumbLruPageCache::default()));
         let schema = Arc::new(RwLock::new(Schema::new()));
@@ -173,7 +174,7 @@ impl Database {
             open_flags: flags,
         };
         let db = Arc::new(db);
-        if db_size > 0 {
+        if db_size > 0 || wal_exists {
             // parse schema
             let conn = db.connect()?;
             let rows = conn.query("SELECT * FROM sqlite_schema")?;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -197,12 +197,12 @@ impl Database {
         let buffer_pool = Rc::new(BufferPool::new(None));
 
         let conn = if let Some(shared_wal) = self.maybe_shared_wal.clone() {
+            let is_empty = false;
             let wal = Rc::new(RefCell::new(WalFile::new(
                 self.io.clone(),
                 shared_wal,
                 buffer_pool.clone(),
             )));
-            let is_empty = false;
             let pager = Rc::new(Pager::new(
                 self.db_file.clone(),
                 wal,
@@ -232,7 +232,7 @@ impl Database {
             })
         } else {
             let dummy_wal = Rc::new(RefCell::new(DummyWAL {}));
-            let is_empty = true;
+            let is_empty = self.db_file.size()? == 0;
             let mut pager = Pager::new(
                 self.db_file.clone(),
                 dummy_wal,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -539,8 +539,7 @@ impl Connection {
     }
 
     pub fn checkpoint(&self) -> Result<CheckpointResult> {
-        let checkpoint_result = self.pager.wal_checkpoint();
-        Ok(checkpoint_result)
+        self.pager.wal_checkpoint()
     }
 
     /// Close a connection and checkpoint.

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -51,6 +51,7 @@ pub use io::{
 use limbo_sqlite3_parser::{ast, ast::Cmd, lexer::sql::Parser};
 use parking_lot::RwLock;
 use schema::Schema;
+use std::sync::atomic::Ordering;
 use std::{
     borrow::Cow,
     cell::{Cell, RefCell, UnsafeCell},
@@ -175,6 +176,8 @@ impl Database {
             open_flags: flags,
         };
         let db = Arc::new(db);
+
+        // Check: https://github.com/tursodatabase/limbo/pull/1761#discussion_r2154013123
         if db_size > 0 || wal_has_frames {
             // parse schema
             let conn = db.connect()?;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -202,12 +202,14 @@ impl Database {
                 shared_wal,
                 buffer_pool.clone(),
             )));
+            let is_empty = false;
             let pager = Rc::new(Pager::new(
                 self.db_file.clone(),
                 wal,
                 self.io.clone(),
                 Arc::new(RwLock::new(DumbLruPageCache::default())),
                 buffer_pool,
+                is_empty,
             )?);
 
             let header = pager.db_header()?;
@@ -230,12 +232,14 @@ impl Database {
             })
         } else {
             let dummy_wal = Rc::new(RefCell::new(DummyWAL {}));
+            let is_empty = true;
             let mut pager = Pager::new(
                 self.db_file.clone(),
                 dummy_wal,
                 self.io.clone(),
                 Arc::new(RwLock::new(DumbLruPageCache::default())),
                 buffer_pool.clone(),
+                is_empty,
             )?;
             let header = pager.db_header()?;
             let wal_path = format!("{}-wal", self.path);

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -255,7 +255,7 @@ impl Database {
         let page_size = header_accessor::get_page_size(&pager)
             .unwrap_or(storage::sqlite3_ondisk::DEFAULT_PAGE_SIZE) as u32;
         let default_cache_size = header_accessor::get_default_page_cache_size(&pager)
-            .unwrap_or(storage::sqlite3_ondisk::DEFAULT_CACHE_SIZE as i32);
+            .unwrap_or(storage::sqlite3_ondisk::DEFAULT_CACHE_SIZE);
 
         let wal_path = format!("{}-wal", self.path);
         let file = self.io.open_file(&wal_path, OpenFlags::Create, false)?;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -60,7 +60,7 @@ use std::{
     num::NonZero,
     ops::Deref,
     rc::Rc,
-    sync::{atomic::Ordering, Arc},
+    sync::Arc,
 };
 #[cfg(feature = "fs")]
 use storage::database::DatabaseFile;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6868,7 +6868,7 @@ mod tests {
         let wal = Rc::new(RefCell::new(wal_file));
 
         let page_cache = Arc::new(parking_lot::RwLock::new(DumbLruPageCache::new(2000)));
-        let pager = { Pager::new(db_file, wal, io, page_cache, buffer_pool).unwrap() };
+        let pager = { Pager::new(db_file, wal, io, page_cache, buffer_pool, true).unwrap() };
         let pager = Rc::new(pager);
         // FIXME: handle page cache is full
         pager.allocate_page1().unwrap();
@@ -7390,6 +7390,7 @@ mod tests {
                 io,
                 Arc::new(parking_lot::RwLock::new(DumbLruPageCache::new(10))),
                 buffer_pool,
+                true,
             )
             .unwrap(),
         );

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -16,6 +16,7 @@ pub trait DatabaseStorage: Send + Sync {
         c: Arc<Completion>,
     ) -> Result<()>;
     fn sync(&self, c: Arc<Completion>) -> Result<()>;
+    fn size(&self) -> Result<u64>;
 }
 
 #[cfg(feature = "fs")]
@@ -60,6 +61,10 @@ impl DatabaseStorage for DatabaseFile {
 
     fn sync(&self, c: Arc<Completion>) -> Result<()> {
         self.file.sync(c)
+    }
+
+    fn size(&self) -> Result<u64> {
+        self.file.size()
     }
 }
 
@@ -110,6 +115,10 @@ impl DatabaseStorage for FileMemoryStorage {
 
     fn sync(&self, c: Arc<Completion>) -> Result<()> {
         self.file.sync(c)
+    }
+
+    fn size(&self) -> Result<u64> {
+        self.file.size()
     }
 }
 

--- a/core/storage/header_accessor.rs
+++ b/core/storage/header_accessor.rs
@@ -6,7 +6,6 @@ use crate::{
     },
     LimboError, Result,
 };
-use paste;
 use std::sync::atomic::Ordering;
 
 // const HEADER_OFFSET_MAGIC: usize = 0;
@@ -142,7 +141,7 @@ impl_header_field_accessor!(
     default_page_cache_size,
     i32,
     HEADER_OFFSET_DEFAULT_PAGE_CACHE_SIZE,
-    storage::sqlite3_ondisk::DEFAULT_CACHE_SIZE as i32
+    storage::sqlite3_ondisk::DEFAULT_CACHE_SIZE
 );
 impl_header_field_accessor!(
     vacuum_mode_largest_root_page,

--- a/core/storage/header_accessor.rs
+++ b/core/storage/header_accessor.rs
@@ -1,0 +1,162 @@
+use crate::{
+    storage::{
+        self,
+        pager::{PageRef, Pager},
+        sqlite3_ondisk::DATABASE_HEADER_PAGE_ID,
+    },
+    LimboError, Result,
+};
+use paste;
+use std::sync::atomic::Ordering;
+
+// const HEADER_OFFSET_MAGIC: usize = 0;
+const HEADER_OFFSET_PAGE_SIZE: usize = 16;
+const HEADER_OFFSET_WRITE_VERSION: usize = 18;
+const HEADER_OFFSET_READ_VERSION: usize = 19;
+const HEADER_OFFSET_RESERVED_SPACE: usize = 20;
+const HEADER_OFFSET_MAX_EMBED_FRAC: usize = 21;
+const HEADER_OFFSET_MIN_EMBED_FRAC: usize = 22;
+const HEADER_OFFSET_MIN_LEAF_FRAC: usize = 23;
+const HEADER_OFFSET_CHANGE_COUNTER: usize = 24;
+const HEADER_OFFSET_DATABASE_SIZE: usize = 28;
+const HEADER_OFFSET_FREELIST_TRUNK_PAGE: usize = 32;
+const HEADER_OFFSET_FREELIST_PAGES: usize = 36;
+const HEADER_OFFSET_SCHEMA_COOKIE: usize = 40;
+const HEADER_OFFSET_SCHEMA_FORMAT: usize = 44;
+const HEADER_OFFSET_DEFAULT_PAGE_CACHE_SIZE: usize = 48;
+const HEADER_OFFSET_VACUUM_MODE_LARGEST_ROOT_PAGE: usize = 52;
+const HEADER_OFFSET_TEXT_ENCODING: usize = 56;
+const HEADER_OFFSET_USER_VERSION: usize = 60;
+const HEADER_OFFSET_INCREMENTAL_VACUUM_ENABLED: usize = 64;
+const HEADER_OFFSET_APPLICATION_ID: usize = 68;
+//const HEADER_OFFSET_RESERVED_FOR_EXPANSION: usize = 72;
+const HEADER_OFFSET_VERSION_VALID_FOR: usize = 92;
+const HEADER_OFFSET_VERSION_NUMBER: usize = 96;
+
+// Helper to get a read-only reference to the header page.
+fn get_header_page(pager: &Pager) -> Result<PageRef> {
+    if pager.is_empty.load(Ordering::SeqCst) {
+        return Err(LimboError::InternalError(
+            "Database is empty, header does not exist - page 1 should've been allocated before this".to_string(),
+        ));
+    }
+    let page = pager.read_page(DATABASE_HEADER_PAGE_ID)?;
+    while !page.is_loaded() || page.is_locked() {
+        // FIXME: LETS STOP DOING THESE SYNCHRONOUS IO HACKS
+        pager.io.run_once()?;
+    }
+    Ok(page)
+}
+
+// Helper to get a writable reference to the header page and mark it dirty.
+fn get_header_page_for_write(pager: &Pager) -> Result<PageRef> {
+    if pager.is_empty.load(Ordering::SeqCst) {
+        // This should not be called on an empty DB for writing, as page 1 is allocated on first transaction.
+        return Err(LimboError::InternalError(
+            "Cannot write to header of an empty database - page 1 should've been allocated before this".to_string(),
+        ));
+    }
+    let page = pager.read_page(DATABASE_HEADER_PAGE_ID)?;
+    while !page.is_loaded() || page.is_locked() {
+        // FIXME: LETS STOP DOING THESE SYNCHRONOUS IO HACKS
+        pager.io.run_once()?;
+    }
+    page.set_dirty();
+    pager.add_dirty(DATABASE_HEADER_PAGE_ID);
+    Ok(page)
+}
+
+/// Helper macro to implement getters and setters for header fields.
+/// For example, `impl_header_field_accessor!(page_size, u16, HEADER_OFFSET_PAGE_SIZE);`
+/// will generate the following functions:
+/// - `pub fn get_page_size(pager: &Pager) -> Result<u16>`
+/// - `pub fn set_page_size(pager: &Pager, value: u16) -> Result<()>`
+///
+/// The macro takes three required arguments:
+/// - `$field_name`: The name of the field to implement.
+/// - `$type`: The type of the field.
+/// - `$offset`: The offset of the field in the header page.
+///
+/// And a fourth optional argument:
+/// - `$ifzero`: A value to return if the field is 0.
+///
+/// The macro will generate the following functions:
+/// - `pub fn get_<field_name>(pager: &Pager) -> Result<T>`
+/// - `pub fn set_<field_name>(pager: &Pager, value: T) -> Result<()>`
+///
+macro_rules! impl_header_field_accessor {
+    ($field_name:ident, $type:ty, $offset:expr $(, $ifzero:expr)?) => {
+        paste::paste! {
+            #[allow(dead_code)]
+            pub fn [<get_ $field_name>](pager: &Pager) -> Result<$type> {
+                if pager.is_empty.load(Ordering::SeqCst) {
+                    return Err(LimboError::InternalError(format!("Database is empty, header does not exist - page 1 should've been allocated before this")));
+                }
+                let page = get_header_page(pager)?;
+                let page_inner = page.get();
+                let page_content = page_inner.contents.as_ref().unwrap();
+                let buf = page_content.buffer.borrow();
+                let buf_slice = buf.as_slice();
+                let mut bytes = [0; std::mem::size_of::<$type>()];
+                bytes.copy_from_slice(&buf_slice[$offset..$offset + std::mem::size_of::<$type>()]);
+                let value = <$type>::from_be_bytes(bytes);
+                $(
+                    if value == 0 {
+                        return Ok($ifzero);
+                    }
+                )?
+                Ok(value)
+            }
+
+            #[allow(dead_code)]
+            pub fn [<set_ $field_name>](pager: &Pager, value: $type) -> Result<()> {
+                let page = get_header_page_for_write(pager)?;
+                let page_inner = page.get();
+                let page_content = page_inner.contents.as_ref().unwrap();
+                let mut buf = page_content.buffer.borrow_mut();
+                let buf_slice = buf.as_mut_slice();
+                buf_slice[$offset..$offset + std::mem::size_of::<$type>()].copy_from_slice(&value.to_be_bytes());
+                page.set_dirty();
+                pager.add_dirty(1);
+                Ok(())
+            }
+        }
+    };
+}
+
+// impl_header_field_accessor!(magic, [u8; 16], HEADER_OFFSET_MAGIC);
+impl_header_field_accessor!(page_size, u16, HEADER_OFFSET_PAGE_SIZE);
+impl_header_field_accessor!(write_version, u8, HEADER_OFFSET_WRITE_VERSION);
+impl_header_field_accessor!(read_version, u8, HEADER_OFFSET_READ_VERSION);
+impl_header_field_accessor!(reserved_space, u8, HEADER_OFFSET_RESERVED_SPACE);
+impl_header_field_accessor!(max_embed_frac, u8, HEADER_OFFSET_MAX_EMBED_FRAC);
+impl_header_field_accessor!(min_embed_frac, u8, HEADER_OFFSET_MIN_EMBED_FRAC);
+impl_header_field_accessor!(min_leaf_frac, u8, HEADER_OFFSET_MIN_LEAF_FRAC);
+impl_header_field_accessor!(change_counter, u32, HEADER_OFFSET_CHANGE_COUNTER);
+impl_header_field_accessor!(database_size, u32, HEADER_OFFSET_DATABASE_SIZE);
+impl_header_field_accessor!(freelist_trunk_page, u32, HEADER_OFFSET_FREELIST_TRUNK_PAGE);
+impl_header_field_accessor!(freelist_pages, u32, HEADER_OFFSET_FREELIST_PAGES);
+impl_header_field_accessor!(schema_cookie, u32, HEADER_OFFSET_SCHEMA_COOKIE);
+impl_header_field_accessor!(schema_format, u32, HEADER_OFFSET_SCHEMA_FORMAT);
+impl_header_field_accessor!(
+    default_page_cache_size,
+    i32,
+    HEADER_OFFSET_DEFAULT_PAGE_CACHE_SIZE,
+    storage::sqlite3_ondisk::DEFAULT_CACHE_SIZE as i32
+);
+impl_header_field_accessor!(
+    vacuum_mode_largest_root_page,
+    u32,
+    HEADER_OFFSET_VACUUM_MODE_LARGEST_ROOT_PAGE
+);
+impl_header_field_accessor!(text_encoding, u32, HEADER_OFFSET_TEXT_ENCODING);
+impl_header_field_accessor!(user_version, i32, HEADER_OFFSET_USER_VERSION);
+impl_header_field_accessor!(
+    incremental_vacuum_enabled,
+    u32,
+    HEADER_OFFSET_INCREMENTAL_VACUUM_ENABLED
+);
+impl_header_field_accessor!(application_id, u32, HEADER_OFFSET_APPLICATION_ID);
+//impl_header_field_accessor!(reserved_for_expansion, [u8; 20], HEADER_OFFSET_RESERVED_FOR_EXPANSION);
+impl_header_field_accessor!(version_valid_for, u32, HEADER_OFFSET_VERSION_VALID_FOR);
+impl_header_field_accessor!(version_number, u32, HEADER_OFFSET_VERSION_NUMBER);

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -13,6 +13,7 @@
 pub(crate) mod btree;
 pub(crate) mod buffer_pool;
 pub(crate) mod database;
+pub(crate) mod header_accessor;
 pub(crate) mod page_cache;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -102,7 +102,8 @@ impl DumbLruPageCache {
             if let Some(existing_page_ref) = self.get(&key) {
                 assert!(
                     Arc::ptr_eq(&value, &existing_page_ref),
-                    "Attempted to insert different page with same key"
+                    "Attempted to insert different page with same key: {:?}",
+                    key
                 );
                 return Err(CacheError::KeyExists);
             }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -602,12 +602,16 @@ impl Pager {
 
     #[inline(always)]
     pub fn begin_read_tx(&self) -> Result<LimboResult> {
+        // We allocate the first page lazily in the first transaction
+        if self.is_empty.load(Ordering::SeqCst) {
+            self.allocate_page1()?;
+        }
         self.wal.borrow_mut().begin_read_tx()
     }
 
     #[inline(always)]
     pub fn begin_write_tx(&self) -> Result<LimboResult> {
-        // We allocate the first page lazily in the *first* write transaction
+        // We allocate the first page lazily in the first transaction
         if self.is_empty.load(Ordering::SeqCst) {
             self.allocate_page1()?;
         }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -971,7 +971,7 @@ impl Pager {
     #[allow(clippy::readonly_write_lock)]
     pub fn allocate_page(&self) -> Result<PageRef> {
         let old_db_size = header_accessor::get_database_size(self)?;
-        #[allow(clippy::unused_mut)]
+        #[allow(unused_mut)]
         let mut new_db_size = old_db_size + 1;
         self.is_empty.store(false, Ordering::SeqCst);
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -237,12 +237,6 @@ pub enum PagerCacheflushResult {
 }
 
 impl Pager {
-    /// Begins opening a database by reading the database header.
-    pub fn begin_open(db_file: Arc<dyn DatabaseStorage>) -> Result<Arc<SpinLock<DatabaseHeader>>> {
-        assert!(db_file.size()? > 0);
-        sqlite3_ondisk::begin_read_database_header(db_file)
-    }
-
     pub fn new(
         db_file: Arc<dyn DatabaseStorage>,
         wal: Rc<RefCell<dyn Wal>>,

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -607,6 +607,10 @@ impl Pager {
 
     #[inline(always)]
     pub fn begin_write_tx(&self) -> Result<LimboResult> {
+        // We allocate the first page lazily in the *first* write transaction
+        if self.is_empty.load(Ordering::SeqCst) {
+            self.allocate_page1()?;
+        }
         self.wal.borrow_mut().begin_write_tx()
     }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -939,7 +939,8 @@ impl Pager {
     }
 
     pub fn allocate_page1(&self) -> Result<PageRef> {
-        let default_header = DatabaseHeader::default();
+        let mut default_header = DatabaseHeader::default();
+        default_header.database_size += 1;
         self.is_empty.store(false, Ordering::SeqCst);
         let page = allocate_page(1, &self.buffer_pool, 0);
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -564,6 +564,8 @@ impl Pager {
 
     #[inline(always)]
     pub fn begin_write_tx(&self) -> Result<LimboResult> {
+        // TODO(Diego): The only possibly allocate page1 here is because OpenEphemeral needs a write transaction
+        // we should have a unique API to begin transactions, something like sqlite3BtreeBeginTrans
         while self.is_empty.load(Ordering::SeqCst) {
             let _lock = self.init_lock.lock().unwrap();
             self.allocate_page1()?;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -971,6 +971,7 @@ impl Pager {
     #[allow(clippy::readonly_write_lock)]
     pub fn allocate_page(&self) -> Result<PageRef> {
         let old_db_size = header_accessor::get_database_size(self)?;
+        #[allow(clippy::unused_mut)]
         let mut new_db_size = old_db_size + 1;
         self.is_empty.store(false, Ordering::SeqCst);
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1,4 +1,3 @@
-use crate::fast_lock::SpinLock;
 use crate::result::LimboResult;
 use crate::storage::btree::BTreePageInner;
 use crate::storage::buffer_pool::BufferPool;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -275,6 +275,8 @@ impl Pager {
 
         // read page 1
         let page = self.read_page(1)?;
+        // TODO: let's not create a new DatabaseHeader struct every time we read the header
+        // instead let's have accessor methods for reading and writing the header fields directly
         let mut header = DatabaseHeader::default();
         while !page.is_loaded() || page.is_locked() {
             // FIXME: LETS STOP DOING THESE SYNCHRONOUS IO HACKS

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -70,7 +70,7 @@ use super::wal::LimboRwLock;
 pub const DATABASE_HEADER_SIZE: usize = 100;
 // DEFAULT_CACHE_SIZE negative values mean that we store the amount of pages a XKiB of memory can hold.
 // We can calculate "real" cache size by diving by page size.
-const DEFAULT_CACHE_SIZE: i32 = -2000;
+pub const DEFAULT_CACHE_SIZE: i32 = -2000;
 
 // Minimum number of pages that cache can hold.
 pub const MIN_PAGE_CACHE_SIZE: usize = 10;
@@ -93,17 +93,17 @@ pub const DATABASE_HEADER_PAGE_ID: usize = 1;
 #[derive(Debug, Clone)]
 pub struct DatabaseHeader {
     /// The header string: "SQLite format 3\0"
-    magic: [u8; 16],
+    pub magic: [u8; 16],
 
     /// The database page size in bytes. Must be a power of two between 512 and 32768 inclusive,
     /// or the value 1 representing a page size of 65536.
-    page_size: u16,
+    pub page_size: u16,
 
     /// File format write version. 1 for legacy; 2 for WAL.
-    write_version: u8,
+    pub write_version: u8,
 
     /// File format read version. 1 for legacy; 2 for WAL.
-    read_version: u8,
+    pub read_version: u8,
 
     /// Bytes of unused "reserved" space at the end of each page. Usually 0.
     /// SQLite has the ability to set aside a small number of extra bytes at the end of every page for use by extensions.
@@ -112,16 +112,16 @@ pub struct DatabaseHeader {
     pub reserved_space: u8,
 
     /// Maximum embedded payload fraction. Must be 64.
-    max_embed_frac: u8,
+    pub max_embed_frac: u8,
 
     /// Minimum embedded payload fraction. Must be 32.
-    min_embed_frac: u8,
+    pub min_embed_frac: u8,
 
     /// Leaf payload fraction. Must be 32.
-    min_leaf_frac: u8,
+    pub min_leaf_frac: u8,
 
     /// File change counter, incremented when database is modified.
-    change_counter: u32,
+    pub change_counter: u32,
 
     /// Size of the database file in pages. The "in-header database size".
     pub database_size: u32,
@@ -136,7 +136,7 @@ pub struct DatabaseHeader {
     pub schema_cookie: u32,
 
     /// The schema format number. Supported formats are 1, 2, 3, and 4.
-    schema_format: u32,
+    pub schema_format: u32,
 
     /// Default page cache size.
     pub default_page_cache_size: i32,
@@ -146,7 +146,7 @@ pub struct DatabaseHeader {
     pub vacuum_mode_largest_root_page: u32,
 
     /// The database text encoding. 1=UTF-8, 2=UTF-16le, 3=UTF-16be.
-    text_encoding: u32,
+    pub text_encoding: u32,
 
     /// The "user version" as read and set by the user_version pragma.
     pub user_version: i32,
@@ -155,13 +155,13 @@ pub struct DatabaseHeader {
     pub incremental_vacuum_enabled: u32,
 
     /// The "Application ID" set by PRAGMA application_id.
-    application_id: u32,
+    pub application_id: u32,
 
     /// Reserved for expansion. Must be zero.
-    reserved_for_expansion: [u8; 20],
+    pub reserved_for_expansion: [u8; 20],
 
     /// The version-valid-for number.
-    version_valid_for: u32,
+    pub version_valid_for: u32,
 
     /// SQLITE_VERSION_NUMBER
     pub version_number: u32,
@@ -285,60 +285,6 @@ impl DatabaseHeader {
             self.page_size as u32
         }
     }
-}
-
-pub fn begin_read_database_header(
-    db_file: Arc<dyn DatabaseStorage>,
-) -> Result<Arc<SpinLock<DatabaseHeader>>> {
-    let drop_fn = Rc::new(|_buf| {});
-    #[allow(clippy::arc_with_non_send_sync)]
-    let buf = Arc::new(RefCell::new(Buffer::allocate(512, drop_fn)));
-    let result = Arc::new(SpinLock::new(DatabaseHeader::default()));
-    let header = result.clone();
-    let complete = Box::new(move |buf: Arc<RefCell<Buffer>>| {
-        let header = header.clone();
-        finish_read_database_header(buf, header).unwrap();
-    });
-    let c = Completion::Read(ReadCompletion::new(buf, complete));
-    #[allow(clippy::arc_with_non_send_sync)]
-    db_file.read_page(DATABASE_HEADER_PAGE_ID, Arc::new(c))?;
-    Ok(result)
-}
-
-fn finish_read_database_header(
-    buf: Arc<RefCell<Buffer>>,
-    header: Arc<SpinLock<DatabaseHeader>>,
-) -> Result<()> {
-    let buf = buf.borrow();
-    let buf = buf.as_slice();
-    let mut header = header.lock();
-    header.magic.copy_from_slice(&buf[0..16]);
-    header.page_size = u16::from_be_bytes([buf[16], buf[17]]);
-    header.write_version = buf[18];
-    header.read_version = buf[19];
-    header.reserved_space = buf[20];
-    header.max_embed_frac = buf[21];
-    header.min_embed_frac = buf[22];
-    header.min_leaf_frac = buf[23];
-    header.change_counter = u32::from_be_bytes([buf[24], buf[25], buf[26], buf[27]]);
-    header.database_size = u32::from_be_bytes([buf[28], buf[29], buf[30], buf[31]]);
-    header.freelist_trunk_page = u32::from_be_bytes([buf[32], buf[33], buf[34], buf[35]]);
-    header.freelist_pages = u32::from_be_bytes([buf[36], buf[37], buf[38], buf[39]]);
-    header.schema_cookie = u32::from_be_bytes([buf[40], buf[41], buf[42], buf[43]]);
-    header.schema_format = u32::from_be_bytes([buf[44], buf[45], buf[46], buf[47]]);
-    header.default_page_cache_size = i32::from_be_bytes([buf[48], buf[49], buf[50], buf[51]]);
-    if header.default_page_cache_size == 0 {
-        header.default_page_cache_size = DEFAULT_CACHE_SIZE;
-    }
-    header.vacuum_mode_largest_root_page = u32::from_be_bytes([buf[52], buf[53], buf[54], buf[55]]);
-    header.text_encoding = u32::from_be_bytes([buf[56], buf[57], buf[58], buf[59]]);
-    header.user_version = i32::from_be_bytes([buf[60], buf[61], buf[62], buf[63]]);
-    header.incremental_vacuum_enabled = u32::from_be_bytes([buf[64], buf[65], buf[66], buf[67]]);
-    header.application_id = u32::from_be_bytes([buf[68], buf[69], buf[70], buf[71]]);
-    header.reserved_for_expansion.copy_from_slice(&buf[72..92]);
-    header.version_valid_for = u32::from_be_bytes([buf[92], buf[93], buf[94], buf[95]]);
-    header.version_number = u32::from_be_bytes([buf[96], buf[97], buf[98], buf[99]]);
-    Ok(())
 }
 
 pub fn write_header_to_buf(buf: &mut [u8], header: &DatabaseHeader) {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -247,7 +247,7 @@ impl Default for DatabaseHeader {
             min_embed_frac: 32,
             min_leaf_frac: 32,
             change_counter: 1,
-            database_size: 1,
+            database_size: 0,
             freelist_trunk_page: 0,
             freelist_pages: 0,
             schema_cookie: 0,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -247,7 +247,7 @@ impl Default for DatabaseHeader {
             min_embed_frac: 32,
             min_leaf_frac: 32,
             change_counter: 1,
-            database_size: 0,
+            database_size: 1,
             freelist_trunk_page: 0,
             freelist_pages: 0,
             schema_cookie: 0,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -82,7 +82,7 @@ pub const MIN_PAGE_SIZE: u32 = 512;
 const MAX_PAGE_SIZE: u32 = 65536;
 
 /// The default page size in bytes.
-const DEFAULT_PAGE_SIZE: u16 = 4096;
+pub const DEFAULT_PAGE_SIZE: u16 = 4096;
 
 pub const DATABASE_HEADER_PAGE_ID: usize = 1;
 

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -287,60 +287,6 @@ impl DatabaseHeader {
     }
 }
 
-pub fn begin_read_database_header(
-    db_file: Arc<dyn DatabaseStorage>,
-) -> Result<Arc<SpinLock<DatabaseHeader>>> {
-    let drop_fn = Rc::new(|_buf| {});
-    #[allow(clippy::arc_with_non_send_sync)]
-    let buf = Arc::new(RefCell::new(Buffer::allocate(512, drop_fn)));
-    let result = Arc::new(SpinLock::new(DatabaseHeader::default()));
-    let header = result.clone();
-    let complete = Box::new(move |buf: Arc<RefCell<Buffer>>| {
-        let header = header.clone();
-        finish_read_database_header(buf, header).unwrap();
-    });
-    let c = Completion::Read(ReadCompletion::new(buf, complete));
-    #[allow(clippy::arc_with_non_send_sync)]
-    db_file.read_page(DATABASE_HEADER_PAGE_ID, Arc::new(c))?;
-    Ok(result)
-}
-
-fn finish_read_database_header(
-    buf: Arc<RefCell<Buffer>>,
-    header: Arc<SpinLock<DatabaseHeader>>,
-) -> Result<()> {
-    let buf = buf.borrow();
-    let buf = buf.as_slice();
-    let mut header = header.lock();
-    header.magic.copy_from_slice(&buf[0..16]);
-    header.page_size = u16::from_be_bytes([buf[16], buf[17]]);
-    header.write_version = buf[18];
-    header.read_version = buf[19];
-    header.reserved_space = buf[20];
-    header.max_embed_frac = buf[21];
-    header.min_embed_frac = buf[22];
-    header.min_leaf_frac = buf[23];
-    header.change_counter = u32::from_be_bytes([buf[24], buf[25], buf[26], buf[27]]);
-    header.database_size = u32::from_be_bytes([buf[28], buf[29], buf[30], buf[31]]);
-    header.freelist_trunk_page = u32::from_be_bytes([buf[32], buf[33], buf[34], buf[35]]);
-    header.freelist_pages = u32::from_be_bytes([buf[36], buf[37], buf[38], buf[39]]);
-    header.schema_cookie = u32::from_be_bytes([buf[40], buf[41], buf[42], buf[43]]);
-    header.schema_format = u32::from_be_bytes([buf[44], buf[45], buf[46], buf[47]]);
-    header.default_page_cache_size = i32::from_be_bytes([buf[48], buf[49], buf[50], buf[51]]);
-    if header.default_page_cache_size == 0 {
-        header.default_page_cache_size = DEFAULT_CACHE_SIZE;
-    }
-    header.vacuum_mode_largest_root_page = u32::from_be_bytes([buf[52], buf[53], buf[54], buf[55]]);
-    header.text_encoding = u32::from_be_bytes([buf[56], buf[57], buf[58], buf[59]]);
-    header.user_version = i32::from_be_bytes([buf[60], buf[61], buf[62], buf[63]]);
-    header.incremental_vacuum_enabled = u32::from_be_bytes([buf[64], buf[65], buf[66], buf[67]]);
-    header.application_id = u32::from_be_bytes([buf[68], buf[69], buf[70], buf[71]]);
-    header.reserved_for_expansion.copy_from_slice(&buf[72..92]);
-    header.version_valid_for = u32::from_be_bytes([buf[92], buf[93], buf[94], buf[95]]);
-    header.version_number = u32::from_be_bytes([buf[96], buf[97], buf[98], buf[99]]);
-    Ok(())
-}
-
 pub fn write_header_to_buf(buf: &mut [u8], header: &DatabaseHeader) {
     buf[0..16].copy_from_slice(&header.magic);
     buf[16..18].copy_from_slice(&header.page_size.to_be_bytes());

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -4,11 +4,9 @@ use limbo_sqlite3_parser::ast::{self, TableInternalId};
 use tracing::{instrument, Level};
 
 use crate::{
-    fast_lock::SpinLock,
     numeric::Numeric,
     parameters::Parameters,
     schema::{BTreeTable, Index, PseudoTable, Table},
-    storage::sqlite3_ondisk::DatabaseHeader,
     translate::{
         collate::CollationSeq,
         emitter::TransactionMode,
@@ -849,12 +847,7 @@ impl ProgramBuilder {
         });
     }
 
-    pub fn build(
-        mut self,
-        database_header: Arc<SpinLock<DatabaseHeader>>,
-        connection: Arc<Connection>,
-        change_cnt_on: bool,
-    ) -> Program {
+    pub fn build(mut self, connection: Arc<Connection>, change_cnt_on: bool) -> Program {
         self.resolve_labels();
 
         self.parameters.list.dedup();
@@ -866,7 +859,6 @@ impl ProgramBuilder {
                 .map(|(insn, function, _)| (insn, function))
                 .collect(),
             cursor_ref: self.cursor_ref,
-            database_header,
             comments: self.comments,
             connection,
             parameters: self.parameters,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -51,8 +51,7 @@ use crate::{
 };
 
 use crate::{
-    info, maybe_init_database_file, BufferPool, MvCursor, OpenFlags, RefValue, Row, StepResult,
-    TransactionState, IO,
+    info, BufferPool, MvCursor, OpenFlags, RefValue, Row, StepResult, TransactionState, IO,
 };
 
 use super::{
@@ -5211,7 +5210,6 @@ pub fn op_open_ephemeral(
     let io = conn.pager.io.get_memory_io();
 
     let file = io.open_file("", OpenFlags::Create, true)?;
-    maybe_init_database_file(&file, &(io.clone() as Arc<dyn IO>))?;
     let db_file = Arc::new(FileMemoryStorage::new(file));
 
     let buffer_pool = Rc::new(BufferPool::new(None));

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1680,10 +1680,8 @@ pub fn op_transaction(
         unreachable!("unexpected Insn {:?}", insn)
     };
     let conn = program.connection.clone();
-    if *write {
-        if conn._db.open_flags.contains(OpenFlags::ReadOnly) {
-            return Err(LimboError::ReadOnly);
-        }
+    if *write && !conn._db.open_flags.contains(OpenFlags::ReadOnly) {
+        return Err(LimboError::ReadOnly);
     }
 
     // We allocate the first page lazily in the first transaction
@@ -3698,7 +3696,7 @@ pub fn op_function(
                 }
             }
             ScalarFunc::SqliteVersion => {
-                let version_integer: i64 = header_accessor::get_version_number(&pager)? as i64;
+                let version_integer: i64 = header_accessor::get_version_number(pager)? as i64;
                 let version = execute_sqlite_version(version_integer);
                 state.registers[*dest] = Register::Value(Value::build_text(version));
             }
@@ -5013,7 +5011,7 @@ pub fn op_set_cookie(
     }
     match cookie {
         Cookie::UserVersion => {
-            header_accessor::set_user_version(pager, *value as i32)?;
+            header_accessor::set_user_version(pager, *value)?;
         }
         Cookie::LargestRootPageNumber => {
             header_accessor::set_vacuum_mode_largest_root_page(pager, *value as u32)?;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1683,11 +1683,11 @@ pub fn op_transaction(
         if conn._db.open_flags.contains(OpenFlags::ReadOnly) {
             return Err(LimboError::ReadOnly);
         }
+    }
 
-        // We allocate the first page lazily in the *first* write transaction
-        if conn.pager.is_empty.load(Ordering::SeqCst) {
-            conn.pager.allocate_page1()?;
-        }
+    // We allocate the first page lazily in the first transaction
+    if conn.pager.is_empty.load(Ordering::SeqCst) {
+        conn.pager.allocate_page1()?;
     }
 
     if let Some(mv_store) = &mv_store {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1685,7 +1685,7 @@ pub fn op_transaction(
         }
 
         // We allocate the first page lazily in the *first* write transaction
-        if conn.pager.npages.load(Ordering::SeqCst) == 0 {
+        if conn.pager.is_empty.load(Ordering::SeqCst) {
             conn.pager.allocate_page1()?;
         }
     }
@@ -5221,6 +5221,7 @@ pub fn op_open_ephemeral(
         io,
         page_cache,
         buffer_pool.clone(),
+        true,
     )?);
 
     let header = pager.db_header()?;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1680,7 +1680,7 @@ pub fn op_transaction(
         unreachable!("unexpected Insn {:?}", insn)
     };
     let conn = program.connection.clone();
-    if *write && !conn._db.open_flags.contains(OpenFlags::ReadOnly) {
+    if *write && conn._db.open_flags.contains(OpenFlags::ReadOnly) {
         return Err(LimboError::ReadOnly);
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1689,6 +1689,7 @@ pub fn op_transaction(
             conn.pager.allocate_page1()?;
         }
     }
+
     if let Some(mv_store) = &mv_store {
         if state.mv_tx_id.is_none() {
             let tx_id = mv_store.begin_tx();
@@ -5232,6 +5233,8 @@ pub fn op_open_ephemeral(
     } else {
         &CreateBTreeFlags::new_index()
     };
+
+    pager.begin_write_tx()?;
 
     // FIXME: handle page cache is full
     let root_page = return_if_io!(pager.btree_create(flag));

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -26,14 +26,13 @@ pub mod sorter;
 
 use crate::{
     error::LimboError,
-    fast_lock::SpinLock,
     function::{AggFunc, FuncCtx},
     storage::{pager::PagerCacheflushStatus, sqlite3_ondisk::SmallVec},
     translate::plan::TableReferences,
 };
 
 use crate::{
-    storage::{btree::BTreeCursor, pager::Pager, sqlite3_ondisk::DatabaseHeader},
+    storage::{btree::BTreeCursor, pager::Pager},
     translate::plan::ResultSetColumn,
     types::{AggContext, Cursor, CursorResult, ImmutableRecord, Value},
     vdbe::{builder::CursorType, insn::Insn},
@@ -354,7 +353,6 @@ pub struct Program {
     pub max_registers: usize,
     pub insns: Vec<(Insn, InsnFunction)>,
     pub cursor_ref: Vec<(Option<CursorKey>, CursorType)>,
-    pub database_header: Arc<SpinLock<DatabaseHeader>>,
     pub comments: Option<Vec<(InsnReference, &'static str)>>,
     pub parameters: crate::parameters::Parameters,
     pub connection: Arc<Connection>,

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -82,6 +82,8 @@ pub struct SimulatorCLI {
         default_value_t = false
     )]
     pub disable_select_optimizer: bool,
+    #[clap(long, help = "disable Reopen-Database fault", default_value_t = false)]
+    pub disable_reopen_database: bool,
 }
 
 #[derive(Parser, Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -20,6 +20,7 @@ pub(crate) struct SimulatorEnv {
     pub(crate) io: Arc<SimulatorIO>,
     pub(crate) db: Arc<Database>,
     pub(crate) rng: ChaCha8Rng,
+    pub(crate) db_path: String,
 }
 
 impl SimulatorEnv {
@@ -33,6 +34,7 @@ impl SimulatorEnv {
             io: self.io.clone(),
             db: self.db.clone(),
             rng: self.rng.clone(),
+            db_path: self.db_path.clone(),
         }
     }
 }
@@ -118,6 +120,7 @@ impl SimulatorEnv {
             page_size: 4096, // TODO: randomize this too
             max_interactions: rng.gen_range(cli_opts.minimum_tests..=cli_opts.maximum_tests),
             max_time_simulation: cli_opts.maximum_time,
+            disable_reopen_database: cli_opts.disable_reopen_database,
         };
 
         let io = Arc::new(SimulatorIO::new(seed, opts.page_size).unwrap());
@@ -150,6 +153,7 @@ impl SimulatorEnv {
             rng,
             io,
             db,
+            db_path: db_path.to_str().unwrap().to_string(),
         }
     }
 }
@@ -227,6 +231,7 @@ pub(crate) struct SimulatorOpts {
     pub(crate) disable_select_limit: bool,
     pub(crate) disable_delete_select: bool,
     pub(crate) disable_drop_select: bool,
+    pub(crate) disable_reopen_database: bool,
 
     pub(crate) max_interactions: usize,
     pub(crate) page_size: usize,


### PR DESCRIPTION
This PR makes limbo read the database header and schema via the regular pager `read_page()` route, instead of always reading it from the database file. This is very important for correctness as modifications to page 1 (containing header and schema) may exist in WAL frames, not just the main database file. Without this, practically any real use of the database would very quickly corrupt the DB as limbo would read the incorrect page count from the stale page 1 copy in the database file, and e.g. allocate the same rootpage for multiple tables and so on.

This issue has been so far hidden due to lack of tests and the fact that `Connection::close()` checkpoints the DB by default, which has delayed discovering this incredibly basic issue since most manual testing has happened via CLI, and if everything is always checkpointed, reopening the DB doesn't cause any problems.

This closes #1725

See also: #1762 (commit from this PR is bundled into this branch as well)

EDIT: Also closes #1818 