### PR TITLE
overwrite sqlite3 in install_sqlite

### DIFF
--- a/.github/shared/install_sqlite/action.yml
+++ b/.github/shared/install_sqlite/action.yml
@@ -10,6 +10,6 @@ runs:
         YEAR: 2025
       run: |
         curl -o /tmp/sqlite.zip https://sqlite.org/$YEAR/sqlite-tools-linux-x64-$SQLITE_VERSION.zip > /dev/null
-        unzip -j /tmp/sqlite.zip sqlite3 -d /usr/local/bin/
+        echo "y" | unzip -j /tmp/sqlite.zip sqlite3 -d /usr/local/bin/
         sqlite3 --version
       shell: bash


### PR DESCRIPTION
It looks like its possible to have sqlite3 persisted between runs somehow, let's make sure we overwrite it.

Context:
```
Prepare all required actions
Run ./.github/shared/install_sqlite
Run curl -o /tmp/sqlite.zip
https://sqlite.org/$YEAR/sqlite-tools-linux-x64-$SQLITE_VERSION.zip >
/dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time
Current
                                 Dload  Upload   Total   Spent    Left
Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--
0
  2 3292k    2 98304    0     0   326k      0  0:00:10 --:--:--  0:00:10
326k
100 3292k  100 3292k    0     0  6686k      0 --:--:-- --:--:-- --:--:--
6678k
replace /usr/local/bin/sqlite3? [y]es, [n]o, [A]ll, [N]one, [r]ename:
NULL
(EOF or read error, treating as "[N]one" ...)
Archive:  /tmp/sqlite.zip
Error: Process completed with exit code 1.
```