### PR TITLE
antithesis-tests: Make test drivers robust when database is locked

### DIFF
--- a/antithesis-tests/bank-test/anytime_validate.py
+++ b/antithesis-tests/bank-test/anytime_validate.py
@@ -4,7 +4,12 @@ import limbo
 from antithesis.random import get_random
 from antithesis.assertions import always
 
-con = limbo.connect("bank_test.db")
+try:
+    con = limbo.connect("bank_test.db")
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur = con.cursor()
 
 initial_state = cur.execute(f'''

--- a/antithesis-tests/bank-test/eventually_validate.py
+++ b/antithesis-tests/bank-test/eventually_validate.py
@@ -4,7 +4,12 @@ import limbo
 from antithesis.random import get_random
 from antithesis.assertions import always
 
-con = limbo.connect("bank_test.db")
+try:
+    con = limbo.connect("bank_test.db")
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur = con.cursor()
 
 initial_state = cur.execute(f'''

--- a/antithesis-tests/bank-test/finally_validate.py
+++ b/antithesis-tests/bank-test/finally_validate.py
@@ -4,7 +4,12 @@ import limbo
 from antithesis.random import get_random
 from antithesis.assertions import always
 
-con = limbo.connect("bank_test.db")
+try:
+    con = limbo.connect("bank_test.db")
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur = con.cursor()
 
 initial_state = cur.execute(f'''

--- a/antithesis-tests/bank-test/first_setup.py
+++ b/antithesis-tests/bank-test/first_setup.py
@@ -3,7 +3,12 @@
 import limbo
 from antithesis.random import get_random
 
-con = limbo.connect("bank_test.db")
+try:
+    con = limbo.connect("bank_test.db")
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur = con.cursor()
 
 # drop accounts table if it exists and create a new table

--- a/antithesis-tests/bank-test/parallel_driver_generate_transaction.py
+++ b/antithesis-tests/bank-test/parallel_driver_generate_transaction.py
@@ -13,7 +13,12 @@ logger.setLevel(logging.INFO)
 
 logger.addHandler(handler)
 
-con = limbo.connect("bank_test.db")
+try:
+    con = limbo.connect("bank_test.db")
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur = con.cursor()
 
 length = cur.execute("SELECT num_accts FROM initial_state").fetchone()[0]

--- a/antithesis-tests/stress-composer/first_setup.py
+++ b/antithesis-tests/stress-composer/first_setup.py
@@ -23,12 +23,22 @@ for f in glob.glob('*.db-wal'):
         pass
 
 # store initial states in a separate db
-con_init = limbo.connect('init_state.db')
+try:
+    con_init = limbo.connect('init_state.db')
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur_init = con_init.cursor()
 cur_init.execute('CREATE TABLE schemas (schema TEXT, tbl INT PRIMARY KEY)')
 cur_init.execute('CREATE TABLE tables (count INT)')
 
-con = limbo.connect('stress_composer.db')
+try:
+    con = limbo.connect('stress_composer.db')
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur = con.cursor()
 
 tbl_count = max(1, get_random() % 10)

--- a/antithesis-tests/stress-composer/parallel_driver_delete.py
+++ b/antithesis-tests/stress-composer/parallel_driver_delete.py
@@ -6,7 +6,12 @@ from utils import generate_random_value
 from antithesis.random import get_random
 
 # Get initial state
-con_init = limbo.connect('init_state.db')
+try:
+    con_init = limbo.connect('init_state.db')
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur_init = con_init.cursor()
 
 tbl_len = cur_init.execute('SELECT count FROM tables').fetchone()[0]
@@ -18,7 +23,11 @@ pk = tbl_schema['pk']
 # get non-pk columns
 cols = [f'col_{col}' for col in range(tbl_schema['colCount']) if col != pk]
 
-con = limbo.connect('stress_composer.db')
+try:
+    con = limbo.connect('stress_composer.db')
+except limbo.OperationalError as e:
+    print(f'Failed to open stress_composer.db. Exiting... {e}')
+    exit(0)
 cur = con.cursor()
 
 deletions = get_random() % 100

--- a/antithesis-tests/stress-composer/parallel_driver_insert.py
+++ b/antithesis-tests/stress-composer/parallel_driver_insert.py
@@ -7,7 +7,12 @@ from antithesis.random import get_random
 
 
 # Get initial state
-con_init = limbo.connect('init_state.db')
+try:
+    con_init = limbo.connect('init_state.db')
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur_init = con_init.cursor()
 
 tbl_len = cur_init.execute('SELECT count FROM tables').fetchone()[0]
@@ -15,7 +20,12 @@ selected_tbl = get_random() % tbl_len
 tbl_schema = json.loads(cur_init.execute(f'SELECT schema FROM schemas WHERE tbl = {selected_tbl}').fetchone()[0])
 cols = ', '.join([f'col_{col}' for col in range(tbl_schema['colCount'])])
 
-con = limbo.connect('stress_composer.db')
+try:
+    con = limbo.connect('stress_composer.db')
+except limbo.OperationalError as e:
+    print(f'Failed to open stress_composer.db. Exiting... {e}')
+    exit(0)
+
 cur = con.cursor()
 
 # insert up to 100 rows in the selected table

--- a/antithesis-tests/stress-composer/parallel_driver_update.py
+++ b/antithesis-tests/stress-composer/parallel_driver_update.py
@@ -6,7 +6,12 @@ from utils import generate_random_value
 from antithesis.random import get_random
 
 # Get initial state
-con_init = limbo.connect('init_state.db')
+try:
+    con_init = limbo.connect('init_state.db')
+except Exception as e:
+    print(f"Error connecting to database: {e}")
+    exit(0)
+
 cur_init = con_init.cursor()
 
 tbl_len = cur_init.execute('SELECT count FROM tables').fetchone()[0]
@@ -18,7 +23,11 @@ pk = tbl_schema['pk']
 # get non-pk columns
 cols = [f'col_{col}' for col in range(tbl_schema['colCount']) if col != pk]
 # print(cols)
-con = limbo.connect('stress_composer.db')
+try:
+    con = limbo.connect('stress_composer.db')
+except limbo.OperationalError as e:
+    print(f'Failed to open stress_composer.db. Exiting... {e}')
+    exit(0)
 cur = con.cursor()
 
 # insert up to 100 rows in the selected table


### PR DESCRIPTION
If multiple processes access the same database file concurrently, Limbo fails with:

```
LockingError("Failed locking file. File is locked by another process
```

Make test driver robust against that.