### PR TITLE
Simulator: add latency to File IO

### DIFF
--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -583,7 +583,7 @@ impl DatabaseFile {
 }
 
 impl limbo_core::DatabaseStorage for DatabaseFile {
-    fn read_page(&self, page_idx: usize, c: Arc<limbo_core::Completion>) -> limbo_core::Result<()> {
+    fn read_page(&self, page_idx: usize, c: limbo_core::Completion) -> limbo_core::Result<()> {
         let r = match c.completion_type {
             limbo_core::CompletionType::Read(ref r) => r,
             _ => unreachable!(),
@@ -602,7 +602,7 @@ impl limbo_core::DatabaseStorage for DatabaseFile {
         &self,
         page_idx: usize,
         buffer: Arc<std::cell::RefCell<limbo_core::Buffer>>,
-        c: Arc<limbo_core::Completion>,
+        c: limbo_core::Completion,
     ) -> limbo_core::Result<()> {
         let size = buffer.borrow().len();
         let pos = (page_idx - 1) * size;
@@ -610,8 +610,9 @@ impl limbo_core::DatabaseStorage for DatabaseFile {
         Ok(())
     }
 
-    fn sync(&self, c: Arc<limbo_core::Completion>) -> limbo_core::Result<()> {
-        self.file.sync(c)
+    fn sync(&self, c: limbo_core::Completion) -> limbo_core::Result<()> {
+        let _ = self.file.sync(c)?;
+        Ok(())
     }
 
     fn size(&self) -> limbo_core::Result<u64> {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -584,8 +584,8 @@ impl DatabaseFile {
 
 impl limbo_core::DatabaseStorage for DatabaseFile {
     fn read_page(&self, page_idx: usize, c: Arc<limbo_core::Completion>) -> limbo_core::Result<()> {
-        let r = match *c {
-            limbo_core::Completion::Read(ref r) => r,
+        let r = match c.completion_type {
+            limbo_core::CompletionType::Read(ref r) => r,
             _ => unreachable!(),
         };
         let size = r.buf().len();

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -212,8 +212,8 @@ impl limbo_core::File for File {
     }
 
     fn pread(&self, pos: usize, c: Arc<limbo_core::Completion>) -> Result<()> {
-        let r = match *c {
-            limbo_core::Completion::Read(ref r) => r,
+        let r = match c.completion_type {
+            limbo_core::CompletionType::Read(ref r) => r,
             _ => unreachable!(),
         };
         {
@@ -232,8 +232,8 @@ impl limbo_core::File for File {
         buffer: Arc<std::cell::RefCell<limbo_core::Buffer>>,
         c: Arc<limbo_core::Completion>,
     ) -> Result<()> {
-        let w = match *c {
-            limbo_core::Completion::Write(ref w) => w,
+        let w = match c.completion_type {
+            limbo_core::CompletionType::Write(ref w) => w,
             _ => unreachable!(),
         };
         let buf = buffer.borrow();
@@ -337,8 +337,8 @@ impl DatabaseFile {
 
 impl limbo_core::DatabaseStorage for DatabaseFile {
     fn read_page(&self, page_idx: usize, c: Arc<limbo_core::Completion>) -> Result<()> {
-        let r = match *c {
-            limbo_core::Completion::Read(ref r) => r,
+        let r = match c.completion_type {
+            limbo_core::CompletionType::Read(ref r) => r,
             _ => unreachable!(),
         };
         let size = r.buf().len();

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -223,6 +223,7 @@ impl limbo_core::File for File {
             assert!(nr >= 0);
         }
         r.complete();
+        #[allow(clippy::arc_with_non_send_sync)]
         Ok(Arc::new(c))
     }
 
@@ -240,12 +241,14 @@ impl limbo_core::File for File {
         let buf: &[u8] = buf.as_slice();
         self.vfs.pwrite(self.fd, buf, pos);
         w.complete(buf.len() as i32);
+        #[allow(clippy::arc_with_non_send_sync)]
         Ok(Arc::new(c))
     }
 
     fn sync(&self, c: limbo_core::Completion) -> Result<Arc<limbo_core::Completion>> {
         self.vfs.sync(self.fd);
         c.complete(0);
+        #[allow(clippy::arc_with_non_send_sync)]
         Ok(Arc::new(c))
     }
 
@@ -363,7 +366,7 @@ impl limbo_core::DatabaseStorage for DatabaseFile {
         Ok(())
     }
 
-    fn sync(&self, c: limbo_core::Completion) -> Result<Arc<limbo_core::Completion>> {
+    fn sync(&self, c: limbo_core::Completion) -> Result<()> {
         let _ = self.file.sync(c)?;
         Ok(())
     }

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -1,5 +1,5 @@
 use super::MemoryIO;
-use crate::{Clock, Completion, File, Instant, LimboError, OpenFlags, Result, IO};
+use crate::{Clock, Completion, CompletionType, File, Instant, LimboError, OpenFlags, Result, IO};
 use std::cell::RefCell;
 use std::io::{Read, Seek, Write};
 use std::sync::Arc;
@@ -90,8 +90,8 @@ impl File for GenericFile {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         {
-            let r = match *c {
-                Completion::Read(ref r) => r,
+            let r = match c.completion_type {
+                CompletionType::Read(ref r) => r,
                 _ => unreachable!(),
             };
             let mut buf = r.buf_mut();
@@ -102,7 +102,12 @@ impl File for GenericFile {
         Ok(())
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<crate::Buffer>>, c: Arc<Completion>) -> Result<()> {
+    fn pwrite(
+        &self,
+        pos: usize,
+        buffer: Arc<RefCell<crate::Buffer>>,
+        c: Arc<Completion>,
+    ) -> Result<()> {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         let buf = buffer.borrow();

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -86,7 +86,7 @@ impl File for GenericFile {
         Ok(())
     }
 
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<()> {
+    fn pread(&self, pos: usize, c: Completion) -> Result<Arc<Completion>> {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         {
@@ -99,29 +99,29 @@ impl File for GenericFile {
             file.read_exact(buf)?;
         }
         c.complete(0);
-        Ok(())
+        Ok(Arc::new(c))
     }
 
     fn pwrite(
         &self,
         pos: usize,
         buffer: Arc<RefCell<crate::Buffer>>,
-        c: Arc<Completion>,
-    ) -> Result<()> {
+        c: Completion,
+    ) -> Result<Arc<Completion>> {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         let buf = buffer.borrow();
         let buf = buf.as_slice();
         file.write_all(buf)?;
         c.complete(buf.len() as i32);
-        Ok(())
+        Ok(Arc::new(c))
     }
 
-    fn sync(&self, c: Arc<Completion>) -> Result<()> {
+    fn sync(&self, c: Completion) -> Result<Arc<Completion>> {
         let mut file = self.file.borrow_mut();
         file.sync_all().map_err(|err| LimboError::IOError(err))?;
         c.complete(0);
-        Ok(())
+        Ok(Arc::new(c))
     }
 
     fn size(&self) -> Result<u64> {

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -311,11 +311,12 @@ impl File for UringFile {
                 .user_data(io.ring.get_key())
         };
         let c = Arc::new(c);
+        let c_uring = c.clone();
         io.ring.submit_entry(
             &write,
             Arc::new(Completion::new(CompletionType::Write(
                 WriteCompletion::new(Box::new(move |result| {
-                    c.complete(result);
+                    c_uring.complete(result);
                     // NOTE: Explicitly reference buffer to ensure it lives until here
                     let _ = buffer.borrow();
                 })),

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -2,6 +2,7 @@
 
 use super::{common, Completion, File, OpenFlags, WriteCompletion, IO};
 use crate::io::clock::{Clock, Instant};
+use crate::io::CompletionType;
 use crate::{LimboError, MemoryIO, Result};
 use rustix::fs::{self, FlockOperation, OFlags};
 use rustix::io_uring::iovec;
@@ -291,7 +292,12 @@ impl File for UringFile {
         Ok(())
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<crate::Buffer>>, c: Arc<Completion>) -> Result<()> {
+    fn pwrite(
+        &self,
+        pos: usize,
+        buffer: Arc<RefCell<crate::Buffer>>,
+        c: Arc<Completion>,
+    ) -> Result<()> {
         let mut io = self.io.borrow_mut();
         let fd = io_uring::types::Fd(self.file.as_raw_fd());
         let write = {
@@ -305,11 +311,13 @@ impl File for UringFile {
         };
         io.ring.submit_entry(
             &write,
-            Arc::new(Completion::Write(WriteCompletion::new(Box::new(move |result| {
-                c.complete(result);
-                // NOTE: Explicitly reference buffer to ensure it lives until here
-                let _ = buffer.borrow();
-            })))),
+            Arc::new(Completion::new(CompletionType::Write(
+                WriteCompletion::new(Box::new(move |result| {
+                    c.complete(result);
+                    // NOTE: Explicitly reference buffer to ensure it lives until here
+                    let _ = buffer.borrow();
+                })),
+            ))),
         );
         Ok(())
     }

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -273,7 +273,7 @@ impl File for UringFile {
         Ok(())
     }
 
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<()> {
+    fn pread(&self, pos: usize, c: Completion) -> Result<Arc<Completion>> {
         let r = c.as_read();
         trace!("pread(pos = {}, length = {})", pos, r.buf().len());
         let fd = io_uring::types::Fd(self.file.as_raw_fd());
@@ -288,16 +288,17 @@ impl File for UringFile {
                 .build()
                 .user_data(io.ring.get_key())
         };
-        io.ring.submit_entry(&read_e, c);
-        Ok(())
+        let c = Arc::new(c);
+        io.ring.submit_entry(&read_e, c.clone());
+        Ok(c)
     }
 
     fn pwrite(
         &self,
         pos: usize,
         buffer: Arc<RefCell<crate::Buffer>>,
-        c: Arc<Completion>,
-    ) -> Result<()> {
+        c: Completion,
+    ) -> Result<Arc<Completion>> {
         let mut io = self.io.borrow_mut();
         let fd = io_uring::types::Fd(self.file.as_raw_fd());
         let write = {
@@ -309,6 +310,7 @@ impl File for UringFile {
                 .build()
                 .user_data(io.ring.get_key())
         };
+        let c = Arc::new(c);
         io.ring.submit_entry(
             &write,
             Arc::new(Completion::new(CompletionType::Write(
@@ -319,18 +321,19 @@ impl File for UringFile {
                 })),
             ))),
         );
-        Ok(())
+        Ok(c)
     }
 
-    fn sync(&self, c: Arc<Completion>) -> Result<()> {
+    fn sync(&self, c: Completion) -> Result<Arc<Completion>> {
         let fd = io_uring::types::Fd(self.file.as_raw_fd());
         let mut io = self.io.borrow_mut();
         trace!("sync()");
         let sync = io_uring::opcode::Fsync::new(fd)
             .build()
             .user_data(io.ring.get_key());
-        io.ring.submit_entry(&sync, c);
-        Ok(())
+        let c = Arc::new(c);
+        io.ring.submit_entry(&sync, c.clone());
+        Ok(c)
     }
 
     fn size(&self) -> Result<u64> {

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -125,7 +125,12 @@ impl File for MemoryFile {
         Ok(c)
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion) -> Result<Arc<Completion>> {
+    fn pwrite(
+        &self,
+        pos: usize,
+        buffer: Arc<RefCell<Buffer>>,
+        c: Completion,
+    ) -> Result<Arc<Completion>> {
         let c = Arc::new(c);
         let buf = buffer.borrow();
         let buf_len = buf.len();

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -83,18 +83,19 @@ impl File for MemoryFile {
         Ok(())
     }
 
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<()> {
+    fn pread(&self, pos: usize, c: Completion) -> Result<Arc<Completion>> {
+        let c = Arc::new(c);
         let r = c.as_read();
         let buf_len = r.buf().len();
         if buf_len == 0 {
             c.complete(0);
-            return Ok(());
+            return Ok(c);
         }
 
         let file_size = self.size.get();
         if pos >= file_size {
             c.complete(0);
-            return Ok(());
+            return Ok(c);
         }
 
         let read_len = buf_len.min(file_size - pos);
@@ -121,15 +122,16 @@ impl File for MemoryFile {
             }
         }
         c.complete(read_len as i32);
-        Ok(())
+        Ok(c)
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Arc<Completion>) -> Result<()> {
+    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion) -> Result<Arc<Completion>> {
+        let c = Arc::new(c);
         let buf = buffer.borrow();
         let buf_len = buf.len();
         if buf_len == 0 {
             c.complete(0);
-            return Ok(());
+            return Ok(c);
         }
 
         let mut offset = pos;
@@ -157,13 +159,13 @@ impl File for MemoryFile {
             .set(core::cmp::max(pos + buf_len, self.size.get()));
 
         c.complete(buf_len as i32);
-        Ok(())
+        Ok(c)
     }
 
-    fn sync(&self, c: Arc<Completion>) -> Result<()> {
+    fn sync(&self, c: Completion) -> Result<Arc<Completion>> {
         // no-op
         c.complete(0);
-        Ok(())
+        Ok(Arc::new(c))
     }
 
     fn size(&self) -> Result<u64> {

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -14,9 +14,9 @@ use std::{
 pub trait File: Send + Sync {
     fn lock_file(&self, exclusive: bool) -> Result<()>;
     fn unlock_file(&self) -> Result<()>;
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<()>;
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Arc<Completion>) -> Result<()>;
-    fn sync(&self, c: Arc<Completion>) -> Result<()>;
+    fn pread(&self, pos: usize, c: Completion) -> Result<Arc<Completion>>;
+    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion) -> Result<Arc<Completion>>;
+    fn sync(&self, c: Completion) -> Result<Arc<Completion>>;
     fn size(&self) -> Result<u64>;
 }
 

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -15,7 +15,12 @@ pub trait File: Send + Sync {
     fn lock_file(&self, exclusive: bool) -> Result<()>;
     fn unlock_file(&self) -> Result<()>;
     fn pread(&self, pos: usize, c: Completion) -> Result<Arc<Completion>>;
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion) -> Result<Arc<Completion>>;
+    fn pwrite(
+        &self,
+        pos: usize,
+        buffer: Arc<RefCell<Buffer>>,
+        c: Completion,
+    ) -> Result<Arc<Completion>>;
     fn sync(&self, c: Completion) -> Result<Arc<Completion>>;
     fn size(&self) -> Result<u64>;
 }

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -53,7 +53,12 @@ pub type Complete = dyn Fn(Arc<RefCell<Buffer>>);
 pub type WriteComplete = dyn Fn(i32);
 pub type SyncComplete = dyn Fn(i32);
 
-pub enum Completion {
+pub struct Completion {
+    pub completion_type: CompletionType,
+    is_completed: Cell<bool>,
+}
+
+pub enum CompletionType {
     Read(ReadCompletion),
     Write(WriteCompletion),
     Sync(SyncCompletion),
@@ -62,31 +67,34 @@ pub enum Completion {
 pub struct ReadCompletion {
     pub buf: Arc<RefCell<Buffer>>,
     pub complete: Box<Complete>,
-    pub is_completed: Cell<bool>,
 }
 
 impl Completion {
-    pub fn is_completed(&self) -> bool {
-        match self {
-            Self::Read(r) => r.is_completed.get(),
-            Self::Write(w) => w.is_completed.get(),
-            Self::Sync(s) => s.is_completed.get(),
+    pub fn new(completion_type: CompletionType) -> Self {
+        Self {
+            completion_type,
+            is_completed: Cell::new(false),
         }
     }
 
+    pub fn is_completed(&self) -> bool {
+        self.is_completed.get()
+    }
+
     pub fn complete(&self, result: i32) {
-        match self {
-            Self::Read(r) => r.complete(),
-            Self::Write(w) => w.complete(result),
-            Self::Sync(s) => s.complete(result), // fix
-        }
+        match &self.completion_type {
+            CompletionType::Read(r) => r.complete(),
+            CompletionType::Write(w) => w.complete(result),
+            CompletionType::Sync(s) => s.complete(result), // fix
+        };
+        self.is_completed.set(true);
     }
 
     /// only call this method if you are sure that the completion is
     /// a ReadCompletion, panics otherwise
     pub fn as_read(&self) -> &ReadCompletion {
-        match self {
-            Self::Read(ref r) => r,
+        match self.completion_type {
+            CompletionType::Read(ref r) => r,
             _ => unreachable!(),
         }
     }
@@ -94,21 +102,15 @@ impl Completion {
 
 pub struct WriteCompletion {
     pub complete: Box<WriteComplete>,
-    pub is_completed: Cell<bool>,
 }
 
 pub struct SyncCompletion {
     pub complete: Box<SyncComplete>,
-    pub is_completed: Cell<bool>,
 }
 
 impl ReadCompletion {
     pub fn new(buf: Arc<RefCell<Buffer>>, complete: Box<Complete>) -> Self {
-        Self {
-            buf,
-            complete,
-            is_completed: Cell::new(false),
-        }
+        Self { buf, complete }
     }
 
     pub fn buf(&self) -> Ref<'_, Buffer> {
@@ -121,35 +123,26 @@ impl ReadCompletion {
 
     pub fn complete(&self) {
         (self.complete)(self.buf.clone());
-        self.is_completed.set(true);
     }
 }
 
 impl WriteCompletion {
     pub fn new(complete: Box<WriteComplete>) -> Self {
-        Self {
-            complete,
-            is_completed: Cell::new(false),
-        }
+        Self { complete }
     }
 
     pub fn complete(&self, bytes_written: i32) {
         (self.complete)(bytes_written);
-        self.is_completed.set(true);
     }
 }
 
 impl SyncCompletion {
     pub fn new(complete: Box<SyncComplete>) -> Self {
-        Self {
-            complete,
-            is_completed: Cell::new(false),
-        }
+        Self { complete }
     }
 
     pub fn complete(&self, res: i32) {
         (self.complete)(res);
-        self.is_completed.set(true);
     }
 }
 

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -98,7 +98,7 @@ impl File for VfsFileImpl {
         Ok(())
     }
 
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<()> {
+    fn pread(&self, pos: usize, c: Completion) -> Result<Arc<Completion>> {
         let r = match c.completion_type {
             CompletionType::Read(ref r) => r,
             _ => unreachable!(),
@@ -113,11 +113,16 @@ impl File for VfsFileImpl {
             Err(LimboError::ExtensionError("pread failed".to_string()))
         } else {
             c.complete(result);
-            Ok(())
+            Ok(Arc::new(c))
         }
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Arc<Completion>) -> Result<()> {
+    fn pwrite(
+        &self,
+        pos: usize,
+        buffer: Arc<RefCell<Buffer>>,
+        c: Completion,
+    ) -> Result<Arc<Completion>> {
         let buf = buffer.borrow();
         let count = buf.as_slice().len();
         if self.vfs.is_null() {
@@ -137,18 +142,18 @@ impl File for VfsFileImpl {
             Err(LimboError::ExtensionError("pwrite failed".to_string()))
         } else {
             c.complete(result);
-            Ok(())
+            Ok(Arc::new(c))
         }
     }
 
-    fn sync(&self, c: Arc<Completion>) -> Result<()> {
+    fn sync(&self, c: Completion) -> Result<Arc<Completion>> {
         let vfs = unsafe { &*self.vfs };
         let result = unsafe { (vfs.sync)(self.file) };
         if result < 0 {
             Err(LimboError::ExtensionError("sync failed".to_string()))
         } else {
             c.complete(0);
-            Ok(())
+            Ok(Arc::new(c))
         }
     }
 

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -1,6 +1,7 @@
 use super::{Buffer, Completion, File, MemoryIO, OpenFlags, IO};
 use crate::ext::VfsMod;
 use crate::io::clock::{Clock, Instant};
+use crate::io::CompletionType;
 use crate::{LimboError, Result};
 use limbo_ext::{VfsFileImpl, VfsImpl};
 use std::cell::RefCell;
@@ -98,8 +99,8 @@ impl File for VfsFileImpl {
     }
 
     fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<()> {
-        let r = match &*c {
-            Completion::Read(ref r) => r,
+        let r = match c.completion_type {
+            CompletionType::Read(ref r) => r,
             _ => unreachable!(),
         };
         let result = {

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -81,7 +81,7 @@ impl File for WindowsFile {
         unimplemented!()
     }
 
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<()> {
+    fn pread(&self, pos: usize, c: Completion) -> Result<Arc<Completion>> {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         {
@@ -91,24 +91,29 @@ impl File for WindowsFile {
             file.read_exact(buf)?;
         }
         c.complete(0);
-        Ok(())
+        Ok(Arc::new(c))
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<crate::Buffer>>, c: Arc<Completion>) -> Result<()> {
+    fn pwrite(
+        &self,
+        pos: usize,
+        buffer: Arc<RefCell<crate::Buffer>>,
+        c: Completion,
+    ) -> Result<Arc<Completion>> {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         let buf = buffer.borrow();
         let buf = buf.as_slice();
         file.write_all(buf)?;
         c.complete(buffer.borrow().len() as i32);
-        Ok(())
+        Ok(Arc::new(c))
     }
 
-    fn sync(&self, c: Arc<Completion>) -> Result<()> {
+    fn sync(&self, c: Completion) -> Result<Arc<Completion>> {
         let file = self.file.borrow_mut();
         file.sync_all().map_err(LimboError::IOError)?;
         c.complete(0);
-        Ok(())
+        Ok(Arc::new(c))
     }
 
     fn size(&self) -> Result<u64> {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -46,7 +46,8 @@ pub use io::UnixIO;
 #[cfg(all(feature = "fs", target_os = "linux", feature = "io_uring"))]
 pub use io::UringIO;
 pub use io::{
-    Buffer, Completion, File, MemoryIO, OpenFlags, PlatformIO, SyscallIO, WriteCompletion, IO,
+    Buffer, Completion, CompletionType, File, MemoryIO, OpenFlags, PlatformIO, SyscallIO,
+    WriteCompletion, IO,
 };
 use limbo_sqlite3_parser::{ast, ast::Cmd, lexer::sql::Parser};
 use parking_lot::RwLock;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6518,7 +6518,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        io::{Buffer, Completion, MemoryIO, OpenFlags, IO},
+        io::{Buffer, Completion, CompletionType, MemoryIO, OpenFlags, IO},
         storage::{database::DatabaseFile, page_cache::DumbLruPageCache},
         types::Text,
         vdbe::Register,
@@ -7445,7 +7445,7 @@ mod tests {
                 drop_fn,
             )));
             let write_complete = Box::new(|_| {});
-            let c = Completion::Write(WriteCompletion::new(write_complete));
+            let c = Completion::new(CompletionType::Write(WriteCompletion::new(write_complete)));
             #[allow(clippy::arc_with_non_send_sync)]
             pager
                 .db_file

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7449,7 +7449,7 @@ mod tests {
             #[allow(clippy::arc_with_non_send_sync)]
             pager
                 .db_file
-                .write_page(current_page as usize, buf.clone(), Arc::new(c))?;
+                .write_page(current_page as usize, buf.clone(), c)?;
             pager.io.run_once()?;
 
             let page = cursor.read_page(current_page as usize)?;

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -1,4 +1,5 @@
 use crate::error::LimboError;
+use crate::io::CompletionType;
 use crate::{io::Completion, Buffer, Result};
 use std::{cell::RefCell, sync::Arc};
 
@@ -84,8 +85,8 @@ unsafe impl Sync for FileMemoryStorage {}
 
 impl DatabaseStorage for FileMemoryStorage {
     fn read_page(&self, page_idx: usize, c: Arc<Completion>) -> Result<()> {
-        let r = match *c {
-            Completion::Read(ref r) => r,
+        let r = match c.completion_type {
+            CompletionType::Read(ref r) => r,
             _ => unreachable!(),
         };
         let size = r.buf().len();

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -68,10 +68,6 @@ impl DatabaseStorage for DatabaseFile {
     fn size(&self) -> Result<u64> {
         self.file.size()
     }
-
-    fn size(&self) -> Result<u64> {
-        self.file.size()
-    }
 }
 
 #[cfg(feature = "fs")]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 use crate::fast_lock::SpinLock;
-use crate::io::{File, SyncCompletion, IO};
+use crate::io::{CompletionType, File, SyncCompletion, IO};
 use crate::result::LimboResult;
 use crate::storage::sqlite3_ondisk::{
     begin_read_wal_frame, begin_write_wal_frame, finish_read_page, WAL_FRAME_HEADER_SIZE,
@@ -872,13 +872,12 @@ impl Wal for WalFile {
                 tracing::debug!("wal_sync");
                 let syncing = self.syncing.clone();
                 self.syncing.set(true);
-                let completion = Completion::Sync(SyncCompletion {
+                let completion = Completion::new(CompletionType::Sync(SyncCompletion {
                     complete: Box::new(move |_| {
                         tracing::debug!("wal_sync finish");
                         syncing.set(false);
                     }),
-                    is_completed: Cell::new(false),
-                });
+                }));
                 let shared = self.get_shared();
                 shared.file.sync(Arc::new(completion))?;
                 self.sync_state.set(SyncState::Syncing);

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -879,7 +879,7 @@ impl Wal for WalFile {
                     }),
                 }));
                 let shared = self.get_shared();
-                shared.file.sync(Arc::new(completion))?;
+                shared.file.sync(completion)?;
                 self.sync_state.set(SyncState::Syncing);
                 Ok(WalFsyncStatus::IO)
             }

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -84,6 +84,12 @@ pub struct SimulatorCLI {
     pub disable_select_optimizer: bool,
     #[clap(long, help = "disable Reopen-Database fault", default_value_t = false)]
     pub disable_reopen_database: bool,
+    #[clap(
+        long = "latency_prob",
+        help = "added IO latency probability",
+        default_value_t = 0
+    )]
+    pub latency_probability: usize,
 }
 
 #[derive(Parser, Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]
@@ -139,6 +145,13 @@ impl SimulatorCLI {
 
         if self.seed.is_some() && self.load.is_some() {
             anyhow::bail!("Cannot set seed and load plan at the same time");
+        }
+
+        if self.latency_probability > 100 {
+            anyhow::bail!(
+                "latency probability must be a number between 0 and 100. Got `{}`",
+                self.latency_probability
+            );
         }
 
         Ok(())

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -123,7 +123,8 @@ impl SimulatorEnv {
             disable_reopen_database: cli_opts.disable_reopen_database,
         };
 
-        let io = Arc::new(SimulatorIO::new(seed, opts.page_size).unwrap());
+        let io =
+            Arc::new(SimulatorIO::new(seed, opts.page_size, cli_opts.latency_probability).unwrap());
 
         // Remove existing database file if it exists
         if db_path.exists() {

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -17,13 +17,14 @@ pub(crate) struct SimulatorIO {
     pub(crate) nr_run_once_faults: Cell<usize>,
     pub(crate) page_size: usize,
     seed: u64,
+    latency_probability: usize,
 }
 
 unsafe impl Send for SimulatorIO {}
 unsafe impl Sync for SimulatorIO {}
 
 impl SimulatorIO {
-    pub(crate) fn new(seed: u64, page_size: usize) -> Result<Self> {
+    pub(crate) fn new(seed: u64, page_size: usize, latency_probability: usize) -> Result<Self> {
         let inner = Box::new(PlatformIO::new()?);
         let fault = Cell::new(false);
         let files = RefCell::new(Vec::new());
@@ -37,6 +38,7 @@ impl SimulatorIO {
             nr_run_once_faults,
             page_size,
             seed,
+            latency_probability,
         })
     }
 
@@ -82,6 +84,7 @@ impl IO for SimulatorIO {
             nr_sync_calls: Cell::new(0),
             page_size: self.page_size,
             rng: RefCell::new(ChaCha8Rng::seed_from_u64(self.seed)),
+            latency_probability: self.latency_probability,
         });
         self.files.borrow_mut().push(file.clone());
         Ok(file)

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -1,4 +1,7 @@
-use std::{cell::RefCell, sync::Arc};
+use std::{
+    cell::{Cell, RefCell},
+    sync::Arc,
+};
 
 use limbo_core::{Clock, Instant, OpenFlags, PlatformIO, Result, IO};
 use rand::{RngCore, SeedableRng};
@@ -8,10 +11,10 @@ use crate::runner::file::SimulatorFile;
 
 pub(crate) struct SimulatorIO {
     pub(crate) inner: Box<dyn IO>,
-    pub(crate) fault: RefCell<bool>,
+    pub(crate) fault: Cell<bool>,
     pub(crate) files: RefCell<Vec<Arc<SimulatorFile>>>,
     pub(crate) rng: RefCell<ChaCha8Rng>,
-    pub(crate) nr_run_once_faults: RefCell<usize>,
+    pub(crate) nr_run_once_faults: Cell<usize>,
     pub(crate) page_size: usize,
 }
 
@@ -21,10 +24,10 @@ unsafe impl Sync for SimulatorIO {}
 impl SimulatorIO {
     pub(crate) fn new(seed: u64, page_size: usize) -> Result<Self> {
         let inner = Box::new(PlatformIO::new()?);
-        let fault = RefCell::new(false);
+        let fault = Cell::new(false);
         let files = RefCell::new(Vec::new());
         let rng = RefCell::new(ChaCha8Rng::seed_from_u64(seed));
-        let nr_run_once_faults = RefCell::new(0);
+        let nr_run_once_faults = Cell::new(0);
         Ok(Self {
             inner,
             fault,
@@ -43,7 +46,7 @@ impl SimulatorIO {
     }
 
     pub(crate) fn print_stats(&self) {
-        tracing::info!("run_once faults: {}", self.nr_run_once_faults.borrow());
+        tracing::info!("run_once faults: {}", self.nr_run_once_faults.get());
         for file in self.files.borrow().iter() {
             tracing::info!("\n===========================\n{}", file.stats_table());
         }
@@ -69,12 +72,12 @@ impl IO for SimulatorIO {
         let inner = self.inner.open_file(path, flags, false)?;
         let file = Arc::new(SimulatorFile {
             inner,
-            fault: RefCell::new(false),
-            nr_pread_faults: RefCell::new(0),
-            nr_pwrite_faults: RefCell::new(0),
-            nr_pread_calls: RefCell::new(0),
-            nr_pwrite_calls: RefCell::new(0),
-            nr_sync_calls: RefCell::new(0),
+            fault: Cell::new(false),
+            nr_pread_faults: Cell::new(0),
+            nr_pwrite_faults: Cell::new(0),
+            nr_pread_calls: Cell::new(0),
+            nr_pwrite_calls: Cell::new(0),
+            nr_sync_calls: Cell::new(0),
             page_size: self.page_size,
         });
         self.files.borrow_mut().push(file.clone());
@@ -89,8 +92,9 @@ impl IO for SimulatorIO {
     }
 
     fn run_once(&self) -> Result<()> {
-        if *self.fault.borrow() {
-            *self.nr_run_once_faults.borrow_mut() += 1;
+        if self.fault.get() {
+            self.nr_run_once_faults
+                .replace(self.nr_run_once_faults.get() + 1);
             return Err(limbo_core::LimboError::InternalError(
                 "Injected fault".into(),
             ));

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -16,6 +16,7 @@ pub(crate) struct SimulatorIO {
     pub(crate) rng: RefCell<ChaCha8Rng>,
     pub(crate) nr_run_once_faults: Cell<usize>,
     pub(crate) page_size: usize,
+    seed: u64,
 }
 
 unsafe impl Send for SimulatorIO {}
@@ -35,6 +36,7 @@ impl SimulatorIO {
             rng,
             nr_run_once_faults,
             page_size,
+            seed,
         })
     }
 
@@ -79,6 +81,7 @@ impl IO for SimulatorIO {
             nr_pwrite_calls: Cell::new(0),
             nr_sync_calls: Cell::new(0),
             page_size: self.page_size,
+            rng: RefCell::new(ChaCha8Rng::seed_from_u64(self.seed)),
         });
         self.files.borrow_mut().push(file.clone());
         Ok(file)


### PR DESCRIPTION
This PR introduces the ability to introduce latency (e.g thread::sleep) in every File IO operation. There is a new cli option that configures the probability of introducing latency. Currently, this probability defaults to 0, as this change has already detected an infinite loop in `checkpoint`. To see this bug in action run the following command: `cargo run -p limbo_sim -- --seed 3961479079923545111 --latency_prob 5`

<img width="918" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/dbf38760-b478-45c2-ac8b-a0ddcf98fd23" />

EDIT: Investigating the bug further, I see that it is returning to the simulator after the disconnect checkpoint, but I have not yet seen this test end. Maybe it is just taking too long? Something to look further at 