### PR TITLE
cli: Remove extra binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ check-wasm-target:
 
 limbo:
 	cargo build
-	cargo build --features index_experimental --bin limbo_index_experimental
 .PHONY: limbo
 
 limbo-c:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,12 +17,6 @@ dist = true
 name = "limbo"
 path = "main.rs"
 
-[[bin]]
-name = "limbo_index_experimental"
-path = "main.rs"
-required-features = ["index_experimental"]
-dist = false
-
 [dependencies]
 anyhow.workspace = true
 cfg-if = "1.0.0"


### PR DESCRIPTION
The `cargo-dist` tool attempts to find it but because we never build it, packaging fails. Remove the extra binary. Probably better to work towards making experimental indexes a runtime flag instead.