### PR TITLE
Copy instrumented image and symbols in Dockerfile.antithesis

### DIFF
--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -88,7 +88,8 @@ RUN pip install antithesis
 WORKDIR /app
 EXPOSE 8080
 COPY --from=builder /usr/lib/libvoidstar.so* /usr/lib/
-COPY --from=builder /app/target/release/limbo_stress /bin/limbo_stress
+COPY --from=builder /app/target/antithesis/limbo_stress /bin/limbo_stress
+COPY --from=builder /app/target/antithesis/limbo_stress /symbols
 COPY stress/docker-entrypoint.sh /bin
 RUN chmod +x /bin/docker-entrypoint.sh
 


### PR DESCRIPTION
Copies the binary from the antithesis build instead of release
Copies symbol files from the binary to the `/symbols` directory

Resolves the `Symbols were uploaded` and `Software was instrumented` properties in the Antithesis triage reports