### PR TITLE
Fix: Arc with non-Send/Sync clippy complaints

### DIFF
--- a/bindings/go/rs_src/lib.rs
+++ b/bindings/go/rs_src/lib.rs
@@ -12,7 +12,6 @@ use std::{
 /// Safe to be called from Go with null terminated DSN string.
 /// performs null check on the path.
 #[no_mangle]
-#[allow(clippy::arc_with_non_send_sync)]
 pub unsafe extern "C" fn db_open(path: *const c_char) -> *mut c_void {
     if path.is_null() {
         println!("Path is null");

--- a/bindings/java/rs_src/limbo_db.rs
+++ b/bindings/java/rs_src/limbo_db.rs
@@ -35,7 +35,6 @@ fn to_limbo_db(ptr: jlong) -> Result<&'static mut LimboDB> {
 }
 
 #[no_mangle]
-#[allow(clippy::arc_with_non_send_sync)]
 pub extern "system" fn Java_tech_turso_core_LimboDB_openUtf8<'local>(
     mut env: JNIEnv<'local>,
     obj: JObject<'local>,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -293,7 +293,6 @@ impl Drop for Connection {
     }
 }
 
-#[allow(clippy::arc_with_non_send_sync)]
 #[pyfunction]
 pub fn connect(path: &str) -> Result<Connection> {
     #[inline(always)]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -65,7 +65,7 @@ pub struct Cursor {
     smt: Option<Rc<RefCell<limbo_core::Statement>>>,
 }
 
-#[allow(unused_variables, clippy::arc_with_non_send_sync)]
+#[allow(unused_variables)]
 #[pymethods]
 impl Cursor {
     #[pyo3(signature = (sql, parameters=None))]

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -40,6 +40,7 @@ impl Builder {
         }
     }
 
+    #[allow(unused_variables)]
     pub async fn build(self) -> Result<Database> {
         match self.path.as_str() {
             ":memory:" => {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -40,7 +40,6 @@ impl Builder {
         }
     }
 
-    #[allow(unused_variables, clippy::arc_with_non_send_sync)]
     pub async fn build(self) -> Result<Database> {
         match self.path.as_str() {
             ":memory:" => {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -175,7 +175,6 @@ impl Statement {
             }
             params::Params::Named(_items) => todo!(),
         }
-        #[allow(clippy::arc_with_non_send_sync)]
         let rows = Rows {
             inner: Arc::clone(&self.inner),
         };

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -10,7 +10,6 @@ pub struct Database {
     conn: Arc<limbo_core::Connection>,
 }
 
-#[allow(clippy::arc_with_non_send_sync)]
 #[wasm_bindgen]
 impl Database {
     #[wasm_bindgen(constructor)]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::arc_with_non_send_sync)]
 mod app;
 mod commands;
 mod config;

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -16,7 +16,6 @@ fn bench_prepare_query(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 
-    #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
     let limbo_conn = db.connect().unwrap();
@@ -63,7 +62,6 @@ fn bench_execute_select_rows(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 
-    #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
     let limbo_conn = db.connect().unwrap();
@@ -132,7 +130,6 @@ fn bench_execute_select_1(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 
-    #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
     let limbo_conn = db.connect().unwrap();
@@ -185,7 +182,6 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 
-    #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
     let limbo_conn = db.connect().unwrap();

--- a/core/benches/json_benchmark.rs
+++ b/core/benches/json_benchmark.rs
@@ -20,7 +20,6 @@ fn bench(criterion: &mut Criterion) {
     // Flag to disable rusqlite benchmarks if needed
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 
-    #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
     let limbo_conn = db.connect().unwrap();
@@ -489,7 +488,6 @@ fn bench_sequential_jsonb(criterion: &mut Criterion) {
     // Flag to disable rusqlite benchmarks if needed
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 
-    #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
     let limbo_conn = db.connect().unwrap();
@@ -646,7 +644,6 @@ fn bench_sequential_jsonb(criterion: &mut Criterion) {
 fn bench_json_patch(criterion: &mut Criterion) {
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 
-    #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
     let limbo_conn = db.connect().unwrap();

--- a/core/benches/tpc_h_benchmark.rs
+++ b/core/benches/tpc_h_benchmark.rs
@@ -28,7 +28,6 @@ fn bench_tpc_h_queries(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
 
-    #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), TPC_H_PATH, false).unwrap();
     let limbo_conn = db.connect().unwrap();

--- a/core/ext/dynamic.rs
+++ b/core/ext/dynamic.rs
@@ -68,7 +68,6 @@ impl Connection {
     }
 }
 
-#[allow(clippy::arc_with_non_send_sync)]
 pub(crate) unsafe extern "C" fn register_vfs(
     name: *const c_char,
     vfs: *const VfsImpl,
@@ -89,7 +88,6 @@ pub(crate) unsafe extern "C" fn register_vfs(
 /// any other types that are defined in the same extension will not be registered
 /// until the database file is opened and `register_builtins` is called.
 #[cfg(feature = "fs")]
-#[allow(clippy::arc_with_non_send_sync)]
 pub fn add_builtin_vfs_extensions(
     api: Option<ExtensionApi>,
 ) -> crate::Result<Vec<(String, Arc<VfsMod>)>> {

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -85,7 +85,7 @@ pub(crate) unsafe extern "C" fn register_vtab_module(
 
 impl Database {
     #[cfg(feature = "fs")]
-    #[allow(clippy::arc_with_non_send_sync, dead_code)]
+    #[allow(dead_code)]
     pub fn open_with_vfs(
         &self,
         path: &str,

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -17,7 +17,6 @@ const PAGE_SIZE: usize = 4096;
 type MemPage = Box<[u8; PAGE_SIZE]>;
 
 impl MemoryIO {
-    #[allow(clippy::arc_with_non_send_sync)]
     pub fn new() -> Self {
         debug!("Using IO backend 'memory'");
         Self {}

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -207,7 +207,6 @@ impl IO for UnixIO {
 
         let file = file.open(path)?;
 
-        #[allow(clippy::arc_with_non_send_sync)]
         let unix_file = Arc::new(UnixFile {
             file: Arc::new(RefCell::new(file)),
             poller: BorrowedPollHandler(self.poller.as_mut().into()),
@@ -285,7 +284,6 @@ enum CompletionCallback {
 }
 
 pub struct UnixFile<'io> {
-    #[allow(clippy::arc_with_non_send_sync)]
     file: Arc<RefCell<std::fs::File>>,
     poller: BorrowedPollHandler<'io>,
     callbacks: BorrowedCallbacks<'io>,
@@ -365,7 +363,12 @@ impl File for UnixFile<'_> {
         }
     }
 
-    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<crate::Buffer>>, c: Arc<Completion>) -> Result<()> {
+    fn pwrite(
+        &self,
+        pos: usize,
+        buffer: Arc<RefCell<crate::Buffer>>,
+        c: Arc<Completion>,
+    ) -> Result<()> {
         let file = self.file.borrow();
         let result = {
             let buf = buffer.borrow();

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -136,7 +136,6 @@ impl Database {
         Self::open_with_flags(io, path, db_file, flags, enable_mvcc)
     }
 
-    #[allow(clippy::arc_with_non_send_sync)]
     pub fn open(
         io: Arc<dyn IO>,
         path: &str,
@@ -146,7 +145,6 @@ impl Database {
         Self::open_with_flags(io, path, db_file, OpenFlags::default(), enable_mvcc)
     }
 
-    #[allow(clippy::arc_with_non_send_sync)]
     pub fn open_with_flags(
         io: Arc<dyn IO>,
         path: &str,
@@ -251,7 +249,6 @@ impl Database {
     /// Open a new database file with a specified VFS without an existing database
     /// connection and symbol table to register extensions.
     #[cfg(feature = "fs")]
-    #[allow(clippy::arc_with_non_send_sync)]
     pub fn open_new(path: &str, vfs: &str) -> Result<(Arc<dyn IO>, Arc<Database>)> {
         let vfsmods = ext::add_builtin_vfs_extensions(None)?;
         let io: Arc<dyn IO> = match vfsmods.iter().find(|v| v.0 == vfs).map(|v| v.1.clone()) {
@@ -308,7 +305,6 @@ pub fn maybe_init_database_file(file: &Arc<dyn File>, io: &Arc<dyn IO>) -> Resul
                 let completion = Completion::Write(WriteCompletion::new(Box::new(move |_| {
                     *flag_complete.borrow_mut() = true;
                 })));
-                #[allow(clippy::arc_with_non_send_sync)]
                 file.pwrite(0, contents.buffer.clone(), Arc::new(completion))?;
             }
             let mut limit = 100;

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -35,7 +35,7 @@ impl Schema {
         #[cfg(not(feature = "index_experimental"))]
         let has_indexes = std::collections::HashSet::new();
         let indexes: HashMap<String, Vec<Arc<Index>>> = HashMap::new();
-        #[allow(clippy::arc_with_non_send_sync)]
+
         tables.insert(
             SCHEMA_TABLE_NAME.to_string(),
             Arc::new(Table::BTree(sqlite_schema_table().into())),

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6532,7 +6532,6 @@ mod tests {
 
     use super::{btree_init_page, defragment_page, drop_cell, insert_into_cell};
 
-    #[allow(clippy::arc_with_non_send_sync)]
     fn get_page(id: usize) -> BTreePage {
         let page = Arc::new(Page::new(id));
 
@@ -6553,7 +6552,6 @@ mod tests {
         page
     }
 
-    #[allow(clippy::arc_with_non_send_sync)]
     fn get_database() -> Arc<Database> {
         let mut path = TempDir::new().unwrap().keep();
         path.push("test.db");
@@ -6845,7 +6843,6 @@ mod tests {
         let db_header = DatabaseHeader::default();
         let page_size = db_header.get_page_size();
 
-        #[allow(clippy::arc_with_non_send_sync)]
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
         let io_file = io.open_file("test.db", OpenFlags::Create, false).unwrap();
         let db_file = Arc::new(DatabaseFile::new(io_file));
@@ -7348,7 +7345,6 @@ mod tests {
         btree_insert_fuzz_run(2, 5_000, |rng| (rng.next_u32() % 32 * 1024) as usize);
     }
 
-    #[allow(clippy::arc_with_non_send_sync)]
     fn setup_test_env(database_size: u32) -> (Rc<Pager>, Arc<SpinLock<DatabaseHeader>>) {
         let page_size = 512;
         let mut db_header = DatabaseHeader::default();
@@ -7422,14 +7418,14 @@ mod tests {
         let mut current_page = 2u32;
         while current_page <= 4 {
             let drop_fn = Rc::new(|_buf| {});
-            #[allow(clippy::arc_with_non_send_sync)]
+
             let buf = Arc::new(RefCell::new(Buffer::allocate(
                 db_header.lock().get_page_size() as usize,
                 drop_fn,
             )));
             let write_complete = Box::new(|_| {});
             let c = Completion::Write(WriteCompletion::new(write_complete));
-            #[allow(clippy::arc_with_non_send_sync)]
+
             pager
                 .db_file
                 .write_page(current_page as usize, buf.clone(), Arc::new(c))?;

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -14,10 +14,8 @@ pub(crate) mod btree;
 pub(crate) mod buffer_pool;
 pub(crate) mod database;
 pub(crate) mod page_cache;
-#[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;
 pub(crate) mod sqlite3_ondisk;
-#[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod wal;
 
 #[macro_export]

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -599,7 +599,6 @@ mod tests {
         PageCacheKey::new(id)
     }
 
-    #[allow(clippy::arc_with_non_send_sync)]
     pub fn page_with_content(page_id: usize) -> PageRef {
         let page = Arc::new(Page::new(page_id));
         {
@@ -994,7 +993,6 @@ mod tests {
                     // add
                     let id_page = rng.next_u64() % max_pages;
                     let key = PageCacheKey::new(id_page as usize);
-                    #[allow(clippy::arc_with_non_send_sync)]
                     let page = Arc::new(Page::new(id_page as usize));
                     if let Some(_) = cache.peek(&key, false) {
                         continue; // skip duplicate page ids

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::arc_with_non_send_sync)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 use std::array;

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use generation::plan::{Interaction, InteractionPlan, InteractionPlanState};

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::arc_with_non_send_sync, dead_code)]
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use generation::plan::{Interaction, InteractionPlan, InteractionPlanState};
@@ -13,9 +12,11 @@ use runner::execution::{execute_plans, Execution, ExecutionHistory, ExecutionRes
 use runner::{differential, watch};
 use std::any::Any;
 use std::backtrace::Backtrace;
+use std::cell::RefCell;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::sync::{mpsc, Arc, Mutex};
 use tracing_subscriber::field::MakeExt;
 use tracing_subscriber::fmt::format;
@@ -220,7 +221,7 @@ fn watch_mode(
                                     i.shadow(&mut env);
                                 });
                             });
-                            let env = Arc::new(Mutex::new(env.clone_without_connections()));
+                            let env = Rc::new(RefCell::new(env.clone_without_connections()));
                             watch::run_simulation(env, &mut [plan], last_execution.clone())
                         }),
                         last_execution.clone(),

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -269,7 +269,7 @@ fn run_simulator(
         let bt = Backtrace::force_capture();
         tracing::error!("captured backtrace:\n{}", bt);
     }));
-
+    #[allow(clippy::arc_with_non_send_sync)]
     let env = Arc::new(Mutex::new(env));
     let result = SandboxedResult::from(
         std::panic::catch_unwind(|| {
@@ -340,6 +340,7 @@ fn run_simulator(
                 let last_execution = Arc::new(Mutex::new(*last_execution));
                 let env = SimulatorEnv::new(seed, cli_opts, &paths.shrunk_db);
 
+                #[allow(clippy::arc_with_non_send_sync)]
                 let env = Arc::new(Mutex::new(env));
                 let shrunk = SandboxedResult::from(
                     std::panic::catch_unwind(|| {
@@ -425,6 +426,8 @@ fn doublecheck(
     result: SandboxedResult,
 ) -> anyhow::Result<()> {
     let env = SimulatorEnv::new(seed, cli_opts, &paths.doublecheck_db);
+
+    #[allow(clippy::arc_with_non_send_sync)]
     let env = Arc::new(Mutex::new(env));
 
     // Run the simulation again
@@ -489,6 +492,7 @@ fn doublecheck(
     }
 }
 
+#[allow(clippy::arc_with_non_send_sync)]
 fn differential_testing(
     seed: u64,
     bugbase: Option<&mut BugBase>,

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -97,7 +97,6 @@ pub unsafe extern "C" fn sqlite3_shutdown() -> ffi::c_int {
 }
 
 #[no_mangle]
-#[allow(clippy::arc_with_non_send_sync)]
 pub unsafe extern "C" fn sqlite3_open(
     filename: *const ffi::c_char,
     db_out: *mut *mut sqlite3,

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use tracing::trace;
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc};
 
 macro_rules! stub {
     () => {

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -2,7 +2,11 @@
 #![allow(non_camel_case_types)]
 
 use limbo_core::Value;
-use std::{cell::RefCell, ffi::{self, CStr, CString}, rc::Rc};
+use std::{
+    cell::RefCell,
+    ffi::{self, CStr, CString},
+    rc::Rc,
+};
 use tracing::trace;
 
 use std::sync::{Arc, Mutex};

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use tracing::trace;
 
-use std::sync::{Arc};
+use std::sync::Arc;
 
 macro_rules! stub {
     () => {

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -15,7 +15,7 @@ pub struct TempDatabase {
 }
 unsafe impl Send for TempDatabase {}
 
-#[allow(dead_code, clippy::arc_with_non_send_sync)]
+#[allow(dead_code)]
 impl TempDatabase {
     pub fn new_empty() -> Self {
         Self::new(&format!("test-{}.db", rng().next_u32()))

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -5,7 +5,6 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-#[allow(clippy::arc_with_non_send_sync)]
 #[test]
 fn test_wal_checkpoint_result() -> Result<()> {
     maybe_setup_tracing();


### PR DESCRIPTION
This PR is meant target this issue [1750](https://github.com/tursodatabase/limbo/issues/1750)

### Summary of changes

Most of the attributes were being used without a need to do so, so I just removed them.

Some other attributes were right, so I converted the **Arc/Mutex** to an **Rc/RefCell** (I looked up all the places that used the code and it seemed that  they were not being used in any thread)

### Notes

There are 7 places where I thought it would be best not to touch, since they were database connections or things that are used quite often in the code. I left a print of which ones I am talking about, if you believe it is safe to convert or do further work, I'd be really happy to help.

![image](https://github.com/user-attachments/assets/70a1a376-bf27-4b3a-aae5-4deaaac30066)