### PR TITLE
bindings/rust: Implement Debug for Connection

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -148,6 +148,12 @@ impl Connection {
     }
 }
 
+impl Debug for Connection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Connection").finish()
+    }
+}
+
 pub struct Statement {
     inner: Arc<Mutex<limbo_core::Statement>>,
 }


### PR DESCRIPTION
A simple change to implement the `Debug` trait for the `Connection`, similar to how it is implemented for `Database`.  This should help users in their application code with wrapping the connection.