### PR TITLE
`Rollback` simple support

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -840,10 +840,6 @@ impl Limbo {
                 anyhow::bail!("We have to throw here, even if we printed error");
             }
         }
-        // for now let's cache flush always
-        while let PagerCacheflushStatus::IO = self.conn.cacheflush()? {
-            self.io.run_once()?;
-        }
         Ok(())
     }
 

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -11,7 +11,7 @@ use crate::{
     HISTORY_FILE,
 };
 use comfy_table::{Attribute, Cell, CellAlignment, ContentArrangement, Row, Table};
-use limbo_core::{Database, LimboError, Statement, StepResult, Value};
+use limbo_core::{Database, LimboError, PagerCacheflushStatus, Statement, StepResult, Value};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
@@ -841,7 +841,9 @@ impl Limbo {
             }
         }
         // for now let's cache flush always
-        self.conn.cacheflush()?;
+        while let PagerCacheflushStatus::IO = self.conn.cacheflush()? {
+            self.io.run_once()?;
+        }
         Ok(())
     }
 

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -11,7 +11,7 @@ use crate::{
     HISTORY_FILE,
 };
 use comfy_table::{Attribute, Cell, CellAlignment, ContentArrangement, Row, Table};
-use limbo_core::{Database, LimboError, PagerCacheflushStatus, Statement, StepResult, Value};
+use limbo_core::{Database, LimboError, Statement, StepResult, Value};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -84,7 +84,7 @@ use vdbe::builder::TableRefIdCounter;
 
 pub type Result<T, E = LimboError> = std::result::Result<T, E>;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum TransactionState {
     Write,
     Read,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -328,6 +328,7 @@ pub struct Connection {
     _db: Arc<Database>,
     pager: Rc<Pager>,
     schema: Arc<RwLock<Schema>>,
+    /// Whether to automatically commit transaction
     auto_commit: Cell<bool>,
     mv_transactions: RefCell<Vec<crate::mvcc::database::TxID>>,
     transaction_state: Cell<TransactionState>,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7045,7 +7045,7 @@ mod tests {
                 )
                 .unwrap();
                 loop {
-                    match pager.end_tx().unwrap() {
+                    match pager.end_tx(false).unwrap() {
                         crate::PagerCacheflushStatus::Done(_) => break,
                         crate::PagerCacheflushStatus::IO => {
                             pager.io.run_once().unwrap();

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7172,7 +7172,7 @@ mod tests {
                 .unwrap();
                 cursor.move_to_root();
                 loop {
-                    match pager.end_tx().unwrap() {
+                    match pager.end_tx(false).unwrap() {
                         crate::PagerCacheflushStatus::Done(_) => break,
                         crate::PagerCacheflushStatus::IO => {
                             pager.io.run_once().unwrap();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -657,6 +657,14 @@ impl Pager {
         Ok(page)
     }
 
+    // Get a page from the cache, if it exists.
+    pub fn cache_get(&self, page_idx: usize) -> Option<PageRef> {
+        tracing::trace!("read_page(page_idx = {})", page_idx);
+        let mut page_cache = self.page_cache.write();
+        let page_key = PageCacheKey::new(page_idx);
+        page_cache.get(&page_key)
+    }
+
     /// Changes the size of the page cache.
     pub fn change_page_cache_size(&self, capacity: usize) -> Result<CacheResizeResult> {
         let mut page_cache = self.page_cache.write();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1078,6 +1078,7 @@ impl Pager {
     }
 
     pub fn rollback(&self) -> Result<(), LimboError> {
+        self.dirty_pages.borrow_mut().clear();
         let mut cache = self.page_cache.write();
         cache.unset_dirty_all_pages();
         cache.clear().expect("failed to clear page cache");

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -986,7 +986,7 @@ impl WalFile {
             max_frame_read_lock_index: 0,
             last_checksum: (0, 0),
             start_pages_in_frames: 0,
-            header,
+            header: *header,
         }
     }
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -930,6 +930,11 @@ impl Wal for WalFile {
         println!("finish_append_frames_commit");
         let shared = self.get_shared();
         shared.max_frame.store(self.max_frame, Ordering::SeqCst);
+        tracing::trace!(
+            "finish_append_frames_commit(max_frame={}, last_checksum={:?})",
+            self.max_frame,
+            self.last_checksum
+        );
         shared.last_checksum = self.last_checksum;
         Ok(())
     }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -909,6 +909,7 @@ impl Wal for WalFile {
             // TODO(pere): implement proper hashmap, this sucks :).
             let shared = self.get_shared();
             let max_frame = shared.max_frame.load(Ordering::SeqCst);
+            tracing::trace!("rollback(to_max_frame={})", max_frame);
             let mut frame_cache = shared.frame_cache.lock();
             for (_, frames) in frame_cache.iter_mut() {
                 let mut last_valid_frame = frames.len();
@@ -927,7 +928,6 @@ impl Wal for WalFile {
     }
 
     fn finish_append_frames_commit(&mut self) -> Result<()> {
-        println!("finish_append_frames_commit");
         let shared = self.get_shared();
         shared.max_frame.store(self.max_frame, Ordering::SeqCst);
         tracing::trace!(

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -965,7 +965,7 @@ impl WalFile {
             ));
         }
 
-        let header = unsafe { shared.get().as_mut().unwrap().wal_header.lock().clone() };
+        let header = unsafe { shared.get().as_mut().unwrap().wal_header.lock() };
         Self {
             io,
             // default to max frame in WAL, so that when we read schema we can read from WAL too if it's there.

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -64,6 +64,7 @@ pub fn translate(
     query_mode: QueryMode,
     _input: &str, // TODO: going to be used for CREATE VIEW
 ) -> Result<Program> {
+    tracing::trace!("querying {}", _input);
     let change_cnt_on = matches!(
         stmt,
         ast::Stmt::CreateIndex { .. }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod plan;
 pub(crate) mod planner;
 pub(crate) mod pragma;
 pub(crate) mod result_row;
+pub(crate) mod rollback;
 pub(crate) mod schema;
 pub(crate) mod select;
 pub(crate) mod subquery;
@@ -43,6 +44,7 @@ use alter::translate_alter_table;
 use index::{translate_create_index, translate_drop_index};
 use insert::translate_insert;
 use limbo_sqlite3_parser::ast::{self, Delete, Insert};
+use rollback::translate_rollback;
 use schema::{translate_create_table, translate_create_virtual_table, translate_drop_table};
 use select::translate_select;
 use std::rc::Rc;
@@ -183,7 +185,10 @@ pub fn translate_inner(
         }
         ast::Stmt::Reindex { .. } => bail_parse_error!("REINDEX not supported yet"),
         ast::Stmt::Release(_) => bail_parse_error!("RELEASE not supported yet"),
-        ast::Stmt::Rollback { .. } => bail_parse_error!("ROLLBACK not supported yet"),
+        ast::Stmt::Rollback {
+            tx_name,
+            savepoint_name,
+        } => translate_rollback(query_mode, schema, syms, program, tx_name, savepoint_name)?,
         ast::Stmt::Savepoint(_) => bail_parse_error!("SAVEPOINT not supported yet"),
         ast::Stmt::Select(select) => {
             translate_select(

--- a/core/translate/rollback.rs
+++ b/core/translate/rollback.rs
@@ -1,0 +1,31 @@
+use limbo_sqlite3_parser::ast::Name;
+
+use crate::{
+    schema::Schema,
+    translate::emitter::TransactionMode,
+    vdbe::{
+        builder::{ProgramBuilder, QueryMode},
+        insn::Insn,
+    },
+    Result, SymbolTable,
+};
+
+pub fn translate_rollback(
+    _query_mode: QueryMode,
+    _schema: &Schema,
+    _syms: &SymbolTable,
+    mut program: ProgramBuilder,
+    txn_name: Option<Name>,
+    savepoint_name: Option<Name>,
+) -> Result<ProgramBuilder> {
+    assert!(
+        txn_name.is_none() && savepoint_name.is_none(),
+        "txn_name and savepoint not supported yet"
+    );
+    program.emit_insn(Insn::AutoCommit {
+        auto_commit: true,
+        rollback: true,
+    });
+    program.epilogue_maybe_rollback(TransactionMode::None, true);
+    Ok(program)
+}

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1754,7 +1754,9 @@ pub fn op_auto_commit(
 
     if *auto_commit != conn.auto_commit.get() {
         if *rollback {
-            todo!("Rollback is not implemented");
+            // TODO(pere): add rollback I/O logic once we implement rollback journal
+            pager.rollback()?;
+            conn.auto_commit.replace(true);
         } else {
             conn.auto_commit.replace(*auto_commit);
         }

--- a/testing/all.test
+++ b/testing/all.test
@@ -37,3 +37,4 @@ source $testdir/create_table.test
 source $testdir/collate.test
 source $testdir/values.test
 source $testdir/integrity_check.test
+source $testdir/rollback.test

--- a/testing/rollback.test
+++ b/testing/rollback.test
@@ -54,3 +54,19 @@ do_execsql_test_on_specific_db {:memory:} rollback-mixed-operations {
     rollback;
     select * from t order by x;
 } {1 2}
+
+# The point of this test was to test we drop dirty pages after rollback by inserting into another table so that 
+# pages used are different.
+do_execsql_test_on_specific_db {:memory:} insert-after-rollback {
+    create table t (x);
+    create table t2 (x);
+    insert into t values (1);
+    insert into t values (2);
+    begin;
+    insert into t values (3);
+    update t set x = x + 10 where x = 1;
+    delete from t where x = 2;
+    rollback;
+    insert into t2 values (1);
+    select * from t2 order by x;
+} {1}

--- a/testing/rollback.test
+++ b/testing/rollback.test
@@ -1,0 +1,56 @@
+#!/usr/bin/env tclsh
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+
+do_execsql_test_on_specific_db {:memory:} simple-rollback {
+    create table t (x);
+    insert into t values (1);
+    begin;
+    insert into t values (2);
+    rollback;
+    select * from t;
+} {1}
+
+do_execsql_test_on_specific_db {:memory:} simple-rollback-2 {
+    create table t (x);
+    begin;
+    insert into t values (1);
+    insert into t values (2);
+    rollback;
+    select * from t;
+} {}
+
+
+do_execsql_test_on_specific_db {:memory:} rollback-after-update {
+    create table t (x);
+    insert into t values (1);
+    insert into t values (2);
+    begin;
+    update t set x = x + 10;
+    rollback;
+    select * from t;
+} {1 2}
+
+do_execsql_test_on_specific_db {:memory:} rollback-after-delete {
+    create table t (x);
+    insert into t values (1);
+    insert into t values (2);
+    insert into t values (3);
+    begin;
+    delete from t where x = 2;
+    rollback;
+    select * from t order by x;
+} {1 2 3}
+
+do_execsql_test_on_specific_db {:memory:} rollback-mixed-operations {
+    create table t (x);
+    insert into t values (1);
+    insert into t values (2);
+    begin;
+    insert into t values (3);
+    update t set x = x + 10 where x = 1;
+    delete from t where x = 2;
+    rollback;
+    select * from t order by x;
+} {1 2}


### PR DESCRIPTION
Support for simple interactive rollback like:

```sql
    create table t (x);
    insert into t values (1);
    begin;
    insert into t values (2);
    rollback;
    select * from t;
```

This PR also fixes some other issues I found while debugging:
* Checkpoint would never `clear_dirty` on pages in page cache.
* Auto commit for interactive transactions was not respected so any `insert` after `begin` would flush frames regardless of `auto_commit` state.
* `max_frame` on wal shared state was being updated after every `append_frame` which was incorrect, as another transaction would be able to use that new `max_frame` even tho the transaction could've rolled back. Instead we update the private copy of `max_frame` and only update it at the end.

Follow up for later are savepoints which require implementing a subjournal to track savepoints and their modified pages.