### PR TITLE
fix: use uv run instead of uvx for Pytest

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,11 +22,7 @@ jobs:
     steps:
       - id: gen-matrix
         run: |
-          if [ ${{ github.event_name }} == "pull_request" ]; then
-            echo "python-versions=[\"3.13\"]" >> $GITHUB_OUTPUT
-          else
-            echo "python-versions=[\"3.9\",\"3.10\",\"3.11\",\"3.12\",\"3.13\"]" >> $GITHUB_OUTPUT
-          fi
+          echo "python-versions=[\"3.9\",\"3.10\",\"3.11\",\"3.12\",\"3.13\"]" >> $GITHUB_OUTPUT
 
   test:
     needs: configure-strategy
@@ -64,7 +60,7 @@ jobs:
         run: uv sync --all-extras --dev --all-packages
 
       - name: Run Pytest
-        run: uvx pytest tests
+        run: uv run pytest tests
 
   lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
From UV docs: https://docs.astral.sh/uv/guides/tools/#running-tools 
> If you are running a tool in a [project](https://docs.astral.sh/uv/concepts/projects/) and the tool requires that your project is installed, e.g., when using pytest or mypy, you'll want to use [uv run](https://docs.astral.sh/uv/guides/projects/#running-commands) instead of uvx. Otherwise, the tool will be run in a virtual environment that is isolated from your project.

We were not seeing this problem in branch pull_requests, as there was a conditional that only tested on Python 3.13.
