### PR TITLE
core/storage: Make `Pager` object thread-safe

### DIFF
--- a/core/ext/vtab_xconnect.rs
+++ b/core/ext/vtab_xconnect.rs
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn execute(
                         return ResultCode::OK;
                     }
                     Ok(StepResult::IO) => {
-                        let _ = conn.pager.io.run_once();
+                        let _ = conn.pager.io_run_once();
                         continue;
                     }
                     Ok(StepResult::Interrupt) => return ResultCode::Interrupt,
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn stmt_step(stmt: *mut Stmt) -> ResultCode {
             StepResult::Done => return ResultCode::EOF,
             StepResult::IO => {
                 // always handle IO step result internally.
-                let _ = conn.pager.io.run_once();
+                let _ = conn.pager.io_run_once();
                 continue;
             }
             StepResult::Interrupt => return ResultCode::Interrupt,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -50,7 +50,7 @@ use crate::fast_lock::SpinLock;
 use crate::io::{Buffer, Complete, Completion, ReadCompletion, SyncCompletion, WriteCompletion};
 use crate::storage::buffer_pool::BufferPool;
 use crate::storage::database::DatabaseStorage;
-use crate::storage::pager::Pager;
+use crate::storage::pager::PagerInner;
 use crate::types::{
     ImmutableRecord, RawSlice, RefValue, SerialType, SerialTypeKind, TextRef, TextSubtype,
 };
@@ -772,7 +772,7 @@ pub fn finish_read_page(
 }
 
 pub fn begin_write_btree_page(
-    pager: &Pager,
+    pager: &PagerInner,
     page: &PageRef,
     write_counter: Rc<RefCell<usize>>,
 ) -> Result<()> {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -29,7 +29,7 @@ use crate::{Completion, Page};
 use self::sqlite3_ondisk::{checksum_wal, PageContent, WAL_MAGIC_BE, WAL_MAGIC_LE};
 
 use super::buffer_pool::BufferPool;
-use super::pager::{PageRef, Pager};
+use super::pager::{PageRef, PagerInner};
 use super::sqlite3_ondisk::{self, begin_write_btree_page, WalHeader};
 
 pub const READMARK_NOT_USED: u32 = 0xffffffff;
@@ -237,7 +237,7 @@ pub trait Wal {
     fn should_checkpoint(&self) -> bool;
     fn checkpoint(
         &mut self,
-        pager: &Pager,
+        pager: &PagerInner,
         write_counter: Rc<RefCell<usize>>,
         mode: CheckpointMode,
     ) -> Result<CheckpointStatus>;
@@ -309,7 +309,7 @@ impl Wal for DummyWAL {
 
     fn checkpoint(
         &mut self,
-        _pager: &Pager,
+        _pager: &PagerInner,
         _write_counter: Rc<RefCell<usize>>,
         _mode: crate::CheckpointMode,
     ) -> Result<crate::CheckpointStatus> {
@@ -704,7 +704,7 @@ impl Wal for WalFile {
     #[instrument(skip_all, level = Level::TRACE)]
     fn checkpoint(
         &mut self,
-        pager: &Pager,
+        pager: &PagerInner,
         write_counter: Rc<RefCell<usize>>,
         mode: CheckpointMode,
     ) -> Result<CheckpointStatus> {


### PR DESCRIPTION
Multiple VDBE programs share the same `Pager` object so let's make it thread-safe.