### PR TITLE
Cache `reserved_space` and `page_size` values at Pager init to prevent doing redundant IO

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -9,11 +9,11 @@ use crate::types::CursorResult;
 use crate::{Buffer, LimboError, Result};
 use crate::{Completion, WalFile};
 use parking_lot::RwLock;
-use std::cell::{RefCell, UnsafeCell};
+use std::cell::{OnceCell, RefCell, UnsafeCell};
 use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use tracing::{trace, Level};
 
 use super::btree::{btree_init_page, BTreePage};
@@ -225,8 +225,8 @@ pub struct Pager {
     /// Cache page_size and reserved_space at Pager init and reuse for subsequent
     /// `usable_space` calls. TODO: Invalidate reserved_space when we add the functionality
     /// to change it.
-    page_size: OnceLock<u16>,
-    reserved_space: OnceLock<u8>,
+    page_size: OnceCell<u16>,
+    reserved_space: OnceCell<u8>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -291,8 +291,8 @@ impl Pager {
             is_empty,
             init_lock,
             allocate_page1_state,
-            page_size: OnceLock::new(),
-            reserved_space: OnceLock::new(),
+            page_size: OnceCell::new(),
+            reserved_space: OnceCell::new(),
         })
     }
 


### PR DESCRIPTION
### Problem
Profiling revealed that `usable_space()` calls were consuming 60% of total execution time for simple SELECT queries, making Limbo approximately `6x` slower than SQLite for SELECT operations.
The bottleneck was caused by `usable_space()` performing expensive I/O operations on every call to read `page_size` and `reserved_space` from the database header, despite `page_size` values being effectively immutable after database initialization. Only `reserved_space` is allowed to increase in SQLite.

Evidence: https://share.firefox.dev/44tCUIy

### Solution
Implemented OnceCell-based caching for both page_size and reserved_space values in the Pager struct:

`page_size: OnceCell<u16>` - Page size is immutable after database initialization per SQLite specification
`reserved_space: OnceCell<u8>` - Reserved space rarely changes and only grows, safe to cache

### Performance Impact 

Benchmark results: Simple SELECT query time reduced from ~2.89ms to ~1.29ms (~55% improvement)


